### PR TITLE
.npmrc sets npm cache to data/npm/cache

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+cache = data/npm/cache


### PR DESCRIPTION
#### Fix for #78

Sets npm cache inside data/npm/cache
