### PR TITLE
Adding `Installation from package` instructions on README #92

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ $ [sudo] touch /etc/apt/sources.list.d/azuki.list
 Include this line on /etc/apt/sources.list.d/azuki.list file:
 
 ```
-deb [trusted=yes] https://repo.fury.io/azuki-precise/ /
+deb [trusted=yes] http://repo.azukiapp.com/azuki-precise/ /
 ```
 
 Update sources and install azk:
@@ -94,7 +94,7 @@ $ [sudo] touch /etc/apt/sources.list.d/azuki.list
 Include this line on /etc/apt/sources.list.d/azuki.list file:
 
 ```
-deb [trusted=yes] https://repo.fury.io/azuki-trusty/ /
+deb [trusted=yes] http://repo.azukiapp.com/azuki-trusty/ /
 ```
 
 Update sources and install azk:
@@ -117,7 +117,7 @@ Include this line on `/etc/yum.repos.d/azuki.repo` file:
 ```
 [azuki]
 name=azk
-baseurl=https://repo.fury.io/azuki-fedora20/
+baseurl=http://repo.azukiapp.com/azuki-fedora20/
 enabled=1
 gpgcheck=0
 ```


### PR DESCRIPTION
I added Ubuntu 12 and 14 separated because they have differents `/etc/apt/sources.list.d/azuki.list` contents;

What do you think about the `[sudo]` included at shell commands?

I could not solve the dependencies installation in fedora, but this command "resolves" that issue:

``` bash
$ [sudo] yum install docker-io libnss-resolver azk
```
