### PR TITLE
Fixing duplicate declaration `config` in `index.js` and `t` in `scale.js`

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -1,5 +1,4 @@
-import { _, Q, config, defer, log, path, lazy_require } from 'azk';
-import { config, set_config } from 'azk';
+import { _, Q, config, defer, log, path, lazy_require, set_config } from 'azk';
 import { Pid } from 'azk/utils/pid';
 import { AgentStartError } from 'azk/utils/errors';
 

--- a/src/cmds/scale.js
+++ b/src/cmds/scale.js
@@ -1,4 +1,4 @@
-import { log, t, _, async, config, t, lazy_require } from 'azk';
+import { log, _, async, config, t, lazy_require } from 'azk';
 import { Command, Helpers } from 'azk/cli/command';
 import { VerboseCmd } from 'azk/cli/verbose_cmd';
 import { Cmd as StatusCmd } from 'azk/cmds/status';


### PR DESCRIPTION
When there is duplication in the `import` the `traceur` returns an error.

![image](https://cloud.githubusercontent.com/assets/2034678/5220784/8943a77e-7651-11e4-869f-a29335167385.png)
