### PR TITLE
Locking `traceur` and `grunt-traceur` versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "grunt-mocha-test": "^0.10.0",
     "grunt-newer": "^0.7.0",
     "grunt-node-inspector": "^0.1.5",
-    "grunt-traceur": "^0.2.9",
+    "grunt-traceur": "0.2.9",
     "keypress": "~0.2.1",
     "load-grunt-tasks": "^0.6.0",
     "mocha": "^1.21.4",


### PR DESCRIPTION
Versions of traceur up version 0.0.72 are not compatible with the `node --harmony`, the is generating the following error:

``` sh
$ azk agent status                                                  v0.7.1-dev

/Users/gmmaster/.azk/lib/azk/cli/index.js:11
}
^
SyntaxError: Variable 'require' has already been declared
    at Module._compile (module.js:439:25)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at Object.<anonymous> (/Users/gmmaster/.azk/bin/azk.js:21:11)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
```

Error details can be checked in issue [#1486](https://github.com/google/traceur-compiler/issues/1486) of traceur.

This is a temporary fix locking the traceur and the grunt-traceur in versions that work with `node --harmony`.
