### PR TITLE
Add argument pid at the command in rails suggestion

### DIFF
--- a/src/generator/suggestions/rails41.js
+++ b/src/generator/suggestions/rails41.js
@@ -23,7 +23,7 @@ export class Suggestion extends UIProxy {
       ],
       http    : true,
       scalable: { default: 2 },
-      command : 'bundle exec rackup config.ru --port $HTTP_PORT',
+      command : 'bundle exec rackup config.ru --pid /tmp/rails.pid --port $HTTP_PORT',
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'path', value: '.'},
         '/azk/bundler'        : {type: 'persistent', value: 'bundler'},


### PR DESCRIPTION
By default the rails stores the `pid` file of service within the `tmp` folder of the project, when working with multiple instances it creates conflict.
