### PR TITLE
Configuring continuous integration with Wercker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.8.0-dev
+* Enhancements
+  * [CI] configuring Wercker service to run all tests whenever there is a commit on master branch.
+
 ## v0.7.1 - (2014-01-12)
 
 * Enhancements

--- a/spec/system/run_spec.js
+++ b/spec/system/run_spec.js
@@ -32,7 +32,7 @@ describe("Azk system class, run set", function() {
           { stdout: mocks.stdout, stderr: mocks.stderr }
         );
         h.expect(exitResult).to.have.property("code", 0);
-        h.expect(outputs).to.have.property("stdout").match(/root.*src/);
+        h.expect(outputs).to.have.property("stdout").match(/(root|1000).*src/);
       });
     });
 

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,55 @@
+box: wercker-labs/docker
+build:
+  steps:
+
+    - script:
+        name: configure Docker 1.2.0
+        code: |
+          sudo groupadd docker -f
+          sudo gpasswd -a ${USER} docker
+
+    - script:
+        name: install libnss-resolver
+        code: |
+          sudo apt-key adv --keyserver keys.gnupg.net --recv-keys 022856F6D78159DF43B487D5C82CF0628592D2C9
+          echo "deb [arch=amd64] http://repo.azukiapp.com trusty main" | sudo tee /etc/apt/sources.list.d/azuki.list
+          sudo apt-get update -y
+          sudo apt-get install libnss-resolver -y
+
+    - script:
+        name: /etc/resolver/azk.dev
+        code: |
+          sudo mkdir -p /etc/resolver
+          sudo touch /etc/resolver/azk.dev
+          echo "nameserver 172.17.42.1:53" | sudo tee -a /etc/resolver/azk.dev
+
+    - script:
+        name: make
+        code: |
+          make
+
+    - script:
+        name: versions
+        code: |
+          docker -v
+          bin/azk version
+
+    - script:
+        name: azk agent start
+        code: |
+          bin/azk agent start --no-daemon > azk-agent-start.log 2>&1 &
+
+    - script:
+        name: wait agent to start
+        code: |
+          until bin/azk status; do sleep 1; done
+
+    - script:
+        name: download azktcl
+        code: |
+          docker pull azukiapp/azktcl:0.0.2
+
+    - script:
+        name: run all slow tests
+        code: |
+          bin/azk nvm grunt slow_test


### PR DESCRIPTION
For now, just running all tests.

Several attempts were made with Travis using a MacOS machine. However, because the build and deploy process are very complex, involving docker and the azk itself, it was not possible to perform the build and the package creation at a time. 

Probably we will use a virtual machine to perform the Continuous Delivery separately.
