### PR TITLE
[lock_dependencies_version] Lock all dependencies version with `npm shri...

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,0 +1,2188 @@
+{
+  "name": "azk",
+  "version": "0.8.3",
+  "dependencies": {
+    "child-process-promise": {
+      "version": "1.0.1",
+      "from": "child-process-promise@^1.0.0",
+      "resolved": "https://registry.npmjs.org/child-process-promise/-/child-process-promise-1.0.1.tgz",
+      "dependencies": {
+        "q": {
+          "version": "1.1.2",
+          "from": "q@^1.1.2",
+          "resolved": "https://registry.npmjs.org/q/-/q-1.1.2.tgz"
+        }
+      }
+    },
+    "cli-table": {
+      "version": "0.3.1",
+      "from": "cli-table@git+https://github.com/gullitmiranda/cli-table#master",
+      "resolved": "git+https://github.com/gullitmiranda/cli-table#f763bb5680d15de1cdb670f5908378bbd455a258",
+      "dependencies": {
+        "colors": {
+          "version": "1.0.3",
+          "from": "colors@1.0.3",
+          "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+        }
+      }
+    },
+    "colors": {
+      "version": "0.6.2",
+      "from": "colors@^0.6.2",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+    },
+    "dns-sync": {
+      "version": "0.1.1",
+      "from": "dns-sync@^0.1.0",
+      "resolved": "https://registry.npmjs.org/dns-sync/-/dns-sync-0.1.1.tgz",
+      "dependencies": {
+        "debug": {
+          "version": "2.1.1",
+          "from": "debug@^2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "shelljs": {
+          "version": "0.3.0",
+          "from": "shelljs@~0.3",
+          "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.3.0.tgz"
+        }
+      }
+    },
+    "dockerode": {
+      "version": "2.0.6",
+      "from": "dockerode@^2.0.3",
+      "resolved": "https://registry.npmjs.org/dockerode/-/dockerode-2.0.6.tgz",
+      "dependencies": {
+        "docker-modem": {
+          "version": "0.1.22",
+          "from": "docker-modem@0.1.x",
+          "resolved": "https://registry.npmjs.org/docker-modem/-/docker-modem-0.1.22.tgz",
+          "dependencies": {
+            "debug": {
+              "version": "0.7.4",
+              "from": "debug@~0.7.0",
+              "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
+            },
+            "follow-redirects": {
+              "version": "0.0.3",
+              "from": "follow-redirects@0.0.3",
+              "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-0.0.3.tgz"
+            },
+            "querystring": {
+              "version": "0.2.0",
+              "from": "querystring@0.2.0",
+              "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz"
+            },
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@~1.0.26-4",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "underscore": {
+          "version": "1.5.2",
+          "from": "underscore@1.5.x",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz"
+        }
+      }
+    },
+    "esprima": {
+      "version": "1.2.2",
+      "from": "esprima@^1.2.2",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.2.tgz"
+    },
+    "exec-sh": {
+      "version": "0.1.4",
+      "from": "exec-sh@^0.1.3",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.1.4.tgz",
+      "dependencies": {
+        "merge": {
+          "version": "1.2.0",
+          "from": "merge@^1.1.3",
+          "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz"
+        }
+      }
+    },
+    "express": {
+      "version": "4.11.0",
+      "from": "express@^4.9.7",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.11.0.tgz",
+      "dependencies": {
+        "accepts": {
+          "version": "1.2.2",
+          "from": "accepts@~1.2.2",
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.2.2.tgz",
+          "dependencies": {
+            "mime-types": {
+              "version": "2.0.7",
+              "from": "mime-types@~2.0.7",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.5.0",
+                  "from": "mime-db@~1.5.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                }
+              }
+            },
+            "negotiator": {
+              "version": "0.5.0",
+              "from": "negotiator@0.5.0",
+              "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.5.0.tgz"
+            }
+          }
+        },
+        "content-disposition": {
+          "version": "0.5.0",
+          "from": "content-disposition@0.5.0",
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.0.tgz"
+        },
+        "cookie-signature": {
+          "version": "1.0.5",
+          "from": "cookie-signature@1.0.5",
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.5.tgz"
+        },
+        "debug": {
+          "version": "2.1.1",
+          "from": "debug@~2.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.1.1.tgz",
+          "dependencies": {
+            "ms": {
+              "version": "0.6.2",
+              "from": "ms@0.6.2",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz"
+            }
+          }
+        },
+        "depd": {
+          "version": "1.0.0",
+          "from": "depd@~1.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+        },
+        "escape-html": {
+          "version": "1.0.1",
+          "from": "escape-html@1.0.1",
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.1.tgz"
+        },
+        "etag": {
+          "version": "1.5.1",
+          "from": "etag@~1.5.1",
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.5.1.tgz",
+          "dependencies": {
+            "crc": {
+              "version": "3.2.1",
+              "from": "crc@3.2.1",
+              "resolved": "https://registry.npmjs.org/crc/-/crc-3.2.1.tgz"
+            }
+          }
+        },
+        "finalhandler": {
+          "version": "0.3.3",
+          "from": "finalhandler@0.3.3",
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-0.3.3.tgz"
+        },
+        "fresh": {
+          "version": "0.2.4",
+          "from": "fresh@0.2.4",
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.2.4.tgz"
+        },
+        "media-typer": {
+          "version": "0.3.0",
+          "from": "media-typer@0.3.0",
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+        },
+        "methods": {
+          "version": "1.1.1",
+          "from": "methods@~1.1.1",
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.1.tgz"
+        },
+        "on-finished": {
+          "version": "2.2.0",
+          "from": "on-finished@~2.2.0",
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.2.0.tgz",
+          "dependencies": {
+            "ee-first": {
+              "version": "1.1.0",
+              "from": "ee-first@1.1.0",
+              "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.0.tgz"
+            }
+          }
+        },
+        "parseurl": {
+          "version": "1.3.0",
+          "from": "parseurl@~1.3.0",
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.0.tgz"
+        },
+        "path-to-regexp": {
+          "version": "0.1.3",
+          "from": "path-to-regexp@0.1.3",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.3.tgz"
+        },
+        "proxy-addr": {
+          "version": "1.0.5",
+          "from": "proxy-addr@~1.0.5",
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.0.5.tgz",
+          "dependencies": {
+            "forwarded": {
+              "version": "0.1.0",
+              "from": "forwarded@~0.1.0",
+              "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz"
+            },
+            "ipaddr.js": {
+              "version": "0.1.6",
+              "from": "ipaddr.js@0.1.6",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.6.tgz"
+            }
+          }
+        },
+        "qs": {
+          "version": "2.3.3",
+          "from": "qs@~2.3.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+        },
+        "range-parser": {
+          "version": "1.0.2",
+          "from": "range-parser@~1.0.2",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.0.2.tgz"
+        },
+        "send": {
+          "version": "0.11.0",
+          "from": "send@0.11.0",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.11.0.tgz",
+          "dependencies": {
+            "destroy": {
+              "version": "1.0.3",
+              "from": "destroy@1.0.3",
+              "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.3.tgz"
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@1.2.11",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "ms": {
+              "version": "0.7.0",
+              "from": "ms@0.7.0",
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.0.tgz"
+            }
+          }
+        },
+        "serve-static": {
+          "version": "1.8.0",
+          "from": "serve-static@~1.8.0",
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.8.0.tgz"
+        },
+        "type-is": {
+          "version": "1.5.5",
+          "from": "type-is@~1.5.5",
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.5.tgz",
+          "dependencies": {
+            "mime-types": {
+              "version": "2.0.7",
+              "from": "mime-types@~2.0.7",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.5.0",
+                  "from": "mime-db@~1.5.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "vary": {
+          "version": "1.0.0",
+          "from": "vary@~1.0.0",
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.0.0.tgz"
+        },
+        "cookie": {
+          "version": "0.1.2",
+          "from": "cookie@0.1.2",
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.1.2.tgz"
+        },
+        "merge-descriptors": {
+          "version": "0.0.2",
+          "from": "merge-descriptors@0.0.2",
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-0.0.2.tgz"
+        },
+        "utils-merge": {
+          "version": "1.0.0",
+          "from": "utils-merge@1.0.0",
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz"
+        }
+      }
+    },
+    "forever-monitor": {
+      "version": "1.5.2",
+      "from": "forever-monitor@^1.2.3",
+      "resolved": "https://registry.npmjs.org/forever-monitor/-/forever-monitor-1.5.2.tgz",
+      "dependencies": {
+        "broadway": {
+          "version": "0.3.6",
+          "from": "broadway@~0.3.6",
+          "resolved": "https://registry.npmjs.org/broadway/-/broadway-0.3.6.tgz",
+          "dependencies": {
+            "cliff": {
+              "version": "0.1.9",
+              "from": "cliff@0.1.9",
+              "resolved": "https://registry.npmjs.org/cliff/-/cliff-0.1.9.tgz",
+              "dependencies": {
+                "eyes": {
+                  "version": "0.1.8",
+                  "from": "eyes@0.1.x",
+                  "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+                }
+              }
+            },
+            "eventemitter2": {
+              "version": "0.4.14",
+              "from": "eventemitter2@0.4.14",
+              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.14.tgz"
+            },
+            "nconf": {
+              "version": "0.6.9",
+              "from": "nconf@0.6.9",
+              "resolved": "https://registry.npmjs.org/nconf/-/nconf-0.6.9.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.9",
+                  "from": "async@0.2.9",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+                },
+                "ini": {
+                  "version": "1.3.2",
+                  "from": "ini@1.x.x",
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.2.tgz"
+                },
+                "optimist": {
+                  "version": "0.6.0",
+                  "from": "optimist@0.6.0",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.0.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@~0.0.2",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    },
+                    "minimist": {
+                      "version": "0.0.10",
+                      "from": "minimist@~0.0.1",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "winston": {
+              "version": "0.8.0",
+              "from": "winston@0.8.0",
+              "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.0.tgz",
+              "dependencies": {
+                "async": {
+                  "version": "0.2.10",
+                  "from": "async@0.2.x",
+                  "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+                },
+                "cycle": {
+                  "version": "1.0.3",
+                  "from": "cycle@1.0.x",
+                  "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+                },
+                "eyes": {
+                  "version": "0.1.8",
+                  "from": "eyes@0.1.x",
+                  "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+                },
+                "pkginfo": {
+                  "version": "0.3.0",
+                  "from": "pkginfo@0.3.x",
+                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+                },
+                "stack-trace": {
+                  "version": "0.0.9",
+                  "from": "stack-trace@0.0.x",
+                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+                }
+              }
+            }
+          }
+        },
+        "minimatch": {
+          "version": "1.0.0",
+          "from": "minimatch@~1.0.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-1.0.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@~1.0.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        },
+        "ps-tree": {
+          "version": "0.0.3",
+          "from": "ps-tree@0.0.x",
+          "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-0.0.3.tgz",
+          "dependencies": {
+            "event-stream": {
+              "version": "0.5.3",
+              "from": "event-stream@~0.5",
+              "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-0.5.3.tgz",
+              "dependencies": {
+                "optimist": {
+                  "version": "0.2.8",
+                  "from": "optimist@0.2",
+                  "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.2.8.tgz",
+                  "dependencies": {
+                    "wordwrap": {
+                      "version": "0.0.2",
+                      "from": "wordwrap@>=0.0.1 <0.1.0",
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "watch": {
+          "version": "0.13.0",
+          "from": "watch@~0.13.0",
+          "resolved": "https://registry.npmjs.org/watch/-/watch-0.13.0.tgz",
+          "dependencies": {
+            "minimist": {
+              "version": "1.1.0",
+              "from": "minimist@^1.1.0",
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
+            }
+          }
+        },
+        "utile": {
+          "version": "0.2.1",
+          "from": "utile@~0.2.1",
+          "resolved": "https://registry.npmjs.org/utile/-/utile-0.2.1.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@~0.2.9",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "deep-equal": {
+              "version": "0.2.1",
+              "from": "deep-equal@*",
+              "resolved": "https://registry.npmjs.org/deep-equal/-/deep-equal-0.2.1.tgz"
+            },
+            "i": {
+              "version": "0.3.2",
+              "from": "i@0.3.x",
+              "resolved": "https://registry.npmjs.org/i/-/i-0.3.2.tgz"
+            },
+            "ncp": {
+              "version": "0.4.2",
+              "from": "ncp@0.4.x",
+              "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.4.2.tgz"
+            },
+            "rimraf": {
+              "version": "2.2.8",
+              "from": "rimraf@2.x.x",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+            }
+          }
+        }
+      }
+    },
+    "fs-extra": {
+      "version": "0.10.0",
+      "from": "fs-extra@^0.10.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.10.0.tgz",
+      "dependencies": {
+        "ncp": {
+          "version": "0.5.1",
+          "from": "ncp@^0.5.1",
+          "resolved": "https://registry.npmjs.org/ncp/-/ncp-0.5.1.tgz"
+        },
+        "jsonfile": {
+          "version": "1.2.0",
+          "from": "jsonfile@^1.2.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-1.2.0.tgz"
+        },
+        "rimraf": {
+          "version": "2.2.8",
+          "from": "rimraf@~2.2.8",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
+        }
+      }
+    },
+    "fscache": {
+      "version": "0.0.1",
+      "from": "fscache@git+https://github.com/nuxlli/fscache",
+      "resolved": "git+https://github.com/nuxlli/fscache#91a9a163a82d94cfa769ebb614dd894069ccf304",
+      "dependencies": {
+        "async": {
+          "version": "0.2.6",
+          "from": "async@0.2.6",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.6.tgz"
+        },
+        "should": {
+          "version": "1.2.2",
+          "from": "should@1.2.2",
+          "resolved": "https://registry.npmjs.org/should/-/should-1.2.2.tgz"
+        },
+        "grunt": {
+          "version": "0.4.0",
+          "from": "grunt@0.4.0",
+          "resolved": "https://registry.npmjs.org/grunt/-/grunt-0.4.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.1.22",
+              "from": "async@0.1.22",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.1.22.tgz"
+            },
+            "coffee-script": {
+              "version": "1.3.3",
+              "from": "coffee-script@1.3.3",
+              "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.3.3.tgz"
+            },
+            "colors": {
+              "version": "0.6.0-1",
+              "from": "colors@0.6.0-1",
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.0-1.tgz"
+            },
+            "dateformat": {
+              "version": "1.0.2-1.2.3",
+              "from": "dateformat@1.0.2-1.2.3",
+              "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.2-1.2.3.tgz"
+            },
+            "eventemitter2": {
+              "version": "0.4.11",
+              "from": "eventemitter2@0.4.11",
+              "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-0.4.11.tgz"
+            },
+            "findup-sync": {
+              "version": "0.1.1",
+              "from": "findup-sync@0.1.1",
+              "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.1.1.tgz"
+            },
+            "glob": {
+              "version": "3.1.21",
+              "from": "glob@3.1.21",
+              "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "1.2.0",
+                  "from": "graceful-fs@1.2.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.0.tgz"
+                },
+                "inherits": {
+                  "version": "1.0.0",
+                  "from": "inherits@1.0.0",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                }
+              }
+            },
+            "hooker": {
+              "version": "0.2.3",
+              "from": "hooker@0.2.3",
+              "resolved": "https://registry.npmjs.org/hooker/-/hooker-0.2.3.tgz"
+            },
+            "iconv-lite": {
+              "version": "0.2.7",
+              "from": "iconv-lite@0.2.7",
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.7.tgz"
+            },
+            "minimatch": {
+              "version": "0.2.11",
+              "from": "minimatch@0.2.11",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.11.tgz",
+              "dependencies": {
+                "lru-cache": {
+                  "version": "2.2.2",
+                  "from": "lru-cache@2.2.2",
+                  "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.2.tgz"
+                },
+                "sigmund": {
+                  "version": "1.0.0",
+                  "from": "sigmund@1.0.0",
+                  "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                }
+              }
+            },
+            "nopt": {
+              "version": "1.0.10",
+              "from": "nopt@1.0.10",
+              "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+              "dependencies": {
+                "abbrev": {
+                  "version": "1.0.4",
+                  "from": "abbrev@1.0.4",
+                  "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.4.tgz"
+                }
+              }
+            },
+            "rimraf": {
+              "version": "2.0.3",
+              "from": "rimraf@2.0.3",
+              "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.0.3.tgz",
+              "dependencies": {
+                "graceful-fs": {
+                  "version": "1.1.14",
+                  "from": "graceful-fs@1.1.14",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.1.14.tgz"
+                }
+              }
+            },
+            "lodash": {
+              "version": "0.9.2",
+              "from": "lodash@0.9.2",
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-0.9.2.tgz"
+            },
+            "underscore.string": {
+              "version": "2.2.0-rc",
+              "from": "underscore.string@2.2.0rc",
+              "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.0rc.tgz"
+            },
+            "which": {
+              "version": "1.0.5",
+              "from": "which@1.0.5",
+              "resolved": "https://registry.npmjs.org/which/-/which-1.0.5.tgz"
+            },
+            "js-yaml": {
+              "version": "1.0.3",
+              "from": "js-yaml@1.0.3",
+              "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-1.0.3.tgz",
+              "dependencies": {
+                "argparse": {
+                  "version": "0.1.12",
+                  "from": "argparse@0.1.12",
+                  "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.12.tgz",
+                  "dependencies": {
+                    "underscore": {
+                      "version": "1.4.4",
+                      "from": "underscore@1.4.4",
+                      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                    },
+                    "underscore.string": {
+                      "version": "2.3.1",
+                      "from": "underscore.string@2.3.1",
+                      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.1.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "grunt-mocha-test": {
+          "version": "0.2.0",
+          "from": "grunt-mocha-test@0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.2.0.tgz",
+          "dependencies": {
+            "mocha": {
+              "version": "1.8.1",
+              "from": "mocha@1.8.1",
+              "resolved": "https://registry.npmjs.org/mocha/-/mocha-1.8.1.tgz",
+              "dependencies": {
+                "commander": {
+                  "version": "0.6.1",
+                  "from": "commander@0.6.1",
+                  "resolved": "https://registry.npmjs.org/commander/-/commander-0.6.1.tgz"
+                },
+                "growl": {
+                  "version": "1.7.0",
+                  "from": "growl@1.7.0",
+                  "resolved": "https://registry.npmjs.org/growl/-/growl-1.7.0.tgz"
+                },
+                "jade": {
+                  "version": "0.26.3",
+                  "from": "jade@0.26.3",
+                  "resolved": "https://registry.npmjs.org/jade/-/jade-0.26.3.tgz",
+                  "dependencies": {
+                    "mkdirp": {
+                      "version": "0.3.0",
+                      "from": "mkdirp@0.3.0",
+                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.0.tgz"
+                    }
+                  }
+                },
+                "diff": {
+                  "version": "1.0.2",
+                  "from": "diff@1.0.2",
+                  "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.2.tgz"
+                },
+                "debug": {
+                  "version": "0.7.2",
+                  "from": "debug@0.7.2",
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.2.tgz"
+                },
+                "mkdirp": {
+                  "version": "0.3.3",
+                  "from": "mkdirp@0.3.3",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.3.tgz"
+                },
+                "ms": {
+                  "version": "0.3.0",
+                  "from": "ms@0.3.0",
+                  "resolved": "https://registry.npmjs.org/ms/-/ms-0.3.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "grunt-contrib-jshint": {
+          "version": "0.2.0",
+          "from": "grunt-contrib-jshint@0.2.0",
+          "resolved": "https://registry.npmjs.org/grunt-contrib-jshint/-/grunt-contrib-jshint-0.2.0.tgz",
+          "dependencies": {
+            "jshint": {
+              "version": "1.0.0",
+              "from": "jshint@1.0.0",
+              "resolved": "https://registry.npmjs.org/jshint/-/jshint-1.0.0.tgz",
+              "dependencies": {
+                "esprima": {
+                  "version": "2.0.0-dev",
+                  "from": "https://github.com/ariya/esprima/tarball/master",
+                  "resolved": "https://github.com/ariya/esprima/tarball/master"
+                },
+                "shelljs": {
+                  "version": "0.1.2",
+                  "from": "shelljs@0.1.2",
+                  "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.1.2.tgz"
+                },
+                "underscore": {
+                  "version": "1.4.4",
+                  "from": "underscore@1.4.4",
+                  "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz"
+                },
+                "peakle": {
+                  "version": "0.0.1",
+                  "from": "peakle@0.0.1",
+                  "resolved": "https://registry.npmjs.org/peakle/-/peakle-0.0.1.tgz"
+                },
+                "cli": {
+                  "version": "0.4.3",
+                  "from": "cli@0.4.3",
+                  "resolved": "https://registry.npmjs.org/cli/-/cli-0.4.3.tgz",
+                  "dependencies": {
+                    "glob": {
+                      "version": "3.1.21",
+                      "from": "glob@3.1.21",
+                      "resolved": "https://registry.npmjs.org/glob/-/glob-3.1.21.tgz",
+                      "dependencies": {
+                        "graceful-fs": {
+                          "version": "1.2.0",
+                          "from": "graceful-fs@1.2.0",
+                          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.0.tgz"
+                        },
+                        "inherits": {
+                          "version": "1.0.0",
+                          "from": "inherits@1.0.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-1.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "minimatch": {
+                  "version": "0.2.11",
+                  "from": "minimatch@0.2.11",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.11.tgz",
+                  "dependencies": {
+                    "lru-cache": {
+                      "version": "2.2.2",
+                      "from": "lru-cache@2.2.2",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.2.tgz"
+                    },
+                    "sigmund": {
+                      "version": "1.0.0",
+                      "from": "sigmund@1.0.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "gaia-tsort": {
+      "version": "0.1.0",
+      "from": "gaia-tsort@^0.1.0",
+      "resolved": "https://registry.npmjs.org/gaia-tsort/-/gaia-tsort-0.1.0.tgz"
+    },
+    "glob": {
+      "version": "3.2.11",
+      "from": "glob@^3.2.9",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "from": "inherits@2",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+        },
+        "minimatch": {
+          "version": "0.3.0",
+          "from": "minimatch@0.3",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
+          "dependencies": {
+            "lru-cache": {
+              "version": "2.5.0",
+              "from": "lru-cache@2",
+              "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+            },
+            "sigmund": {
+              "version": "1.0.0",
+              "from": "sigmund@~1.0.0",
+              "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "handlebars": {
+      "version": "2.0.0-alpha.4",
+      "from": "handlebars@2.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-2.0.0-alpha.4.tgz",
+      "dependencies": {
+        "optimist": {
+          "version": "0.3.7",
+          "from": "optimist@~0.3",
+          "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+          "dependencies": {
+            "wordwrap": {
+              "version": "0.0.2",
+              "from": "wordwrap@~0.0.2",
+              "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz"
+            }
+          }
+        },
+        "uglify-js": {
+          "version": "2.3.6",
+          "from": "uglify-js@~2.3",
+          "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.3.6.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.2.10",
+              "from": "async@~0.2.6",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+            },
+            "source-map": {
+              "version": "0.1.43",
+              "from": "source-map@~0.1.7",
+              "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.43.tgz",
+              "dependencies": {
+                "amdefine": {
+                  "version": "0.1.0",
+                  "from": "amdefine@>=0.0.4",
+                  "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "hipache": {
+      "version": "0.4.0",
+      "from": "hipache@git+https://github.com/hipache/hipache#c32e3d2138590cbdb70a67e696c5f8252f7143dc",
+      "resolved": "git+https://github.com/hipache/hipache#c32e3d2138590cbdb70a67e696c5f8252f7143dc",
+      "dependencies": {
+        "http-proxy": {
+          "version": "1.0.2",
+          "from": "http-proxy@1.0.2",
+          "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.0.2.tgz",
+          "dependencies": {
+            "eventemitter3": {
+              "version": "0.1.6",
+              "from": "eventemitter3@*",
+              "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-0.1.6.tgz"
+            }
+          }
+        },
+        "redis": {
+          "version": "0.10.3",
+          "from": "redis@0.10.x",
+          "resolved": "https://registry.npmjs.org/redis/-/redis-0.10.3.tgz"
+        },
+        "lru-cache": {
+          "version": "2.5.0",
+          "from": "lru-cache@2.5.x",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "inquirer": {
+      "version": "0.8.0",
+      "from": "inquirer@^0.8.0",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.8.0.tgz",
+      "dependencies": {
+        "ansi-regex": {
+          "version": "1.1.0",
+          "from": "ansi-regex@^1.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.0.tgz"
+        },
+        "chalk": {
+          "version": "0.5.1",
+          "from": "chalk@^0.5.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+          "dependencies": {
+            "ansi-styles": {
+              "version": "1.1.0",
+              "from": "ansi-styles@^1.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+            },
+            "escape-string-regexp": {
+              "version": "1.0.2",
+              "from": "escape-string-regexp@^1.0.0",
+              "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+            },
+            "has-ansi": {
+              "version": "0.1.0",
+              "from": "has-ansi@^0.1.0",
+              "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@^0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "strip-ansi": {
+              "version": "0.3.0",
+              "from": "strip-ansi@^0.3.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+              "dependencies": {
+                "ansi-regex": {
+                  "version": "0.2.1",
+                  "from": "ansi-regex@^0.2.1",
+                  "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                }
+              }
+            },
+            "supports-color": {
+              "version": "0.2.0",
+              "from": "supports-color@^0.2.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+            }
+          }
+        },
+        "cli-color": {
+          "version": "0.3.2",
+          "from": "cli-color@~0.3.2",
+          "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
+          "dependencies": {
+            "d": {
+              "version": "0.1.1",
+              "from": "d@~0.1.1",
+              "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
+            },
+            "es5-ext": {
+              "version": "0.10.4",
+              "from": "es5-ext@~0.10.2",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.4.tgz",
+              "dependencies": {
+                "es6-iterator": {
+                  "version": "0.1.2",
+                  "from": "es6-iterator@~0.1.1",
+                  "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
+                },
+                "es6-symbol": {
+                  "version": "0.1.1",
+                  "from": "es6-symbol@0.1.x",
+                  "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                }
+              }
+            },
+            "memoizee": {
+              "version": "0.3.8",
+              "from": "memoizee@0.3.x",
+              "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+              "dependencies": {
+                "es6-weak-map": {
+                  "version": "0.1.2",
+                  "from": "es6-weak-map@~0.1.2",
+                  "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
+                  "dependencies": {
+                    "es6-iterator": {
+                      "version": "0.1.2",
+                      "from": "es6-iterator@~0.1.1",
+                      "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.2.tgz"
+                    },
+                    "es6-symbol": {
+                      "version": "0.1.1",
+                      "from": "es6-symbol@0.1.x",
+                      "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
+                    }
+                  }
+                },
+                "event-emitter": {
+                  "version": "0.3.1",
+                  "from": "event-emitter@~0.3.1",
+                  "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.1.tgz"
+                },
+                "lru-queue": {
+                  "version": "0.1.0",
+                  "from": "lru-queue@0.1",
+                  "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
+                },
+                "next-tick": {
+                  "version": "0.2.2",
+                  "from": "next-tick@~0.2.2",
+                  "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                }
+              }
+            },
+            "timers-ext": {
+              "version": "0.1.0",
+              "from": "timers-ext@0.1.x",
+              "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+              "dependencies": {
+                "next-tick": {
+                  "version": "0.2.2",
+                  "from": "next-tick@~0.2.2",
+                  "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
+                }
+              }
+            }
+          }
+        },
+        "figures": {
+          "version": "1.3.5",
+          "from": "figures@^1.3.2",
+          "resolved": "https://registry.npmjs.org/figures/-/figures-1.3.5.tgz"
+        },
+        "mute-stream": {
+          "version": "0.0.4",
+          "from": "mute-stream@0.0.4",
+          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.4.tgz"
+        },
+        "readline2": {
+          "version": "0.1.0",
+          "from": "readline2@~0.1.0",
+          "resolved": "https://registry.npmjs.org/readline2/-/readline2-0.1.0.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "0.4.0",
+              "from": "chalk@~0.4.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.4.0.tgz",
+              "dependencies": {
+                "has-color": {
+                  "version": "0.1.7",
+                  "from": "has-color@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/has-color/-/has-color-0.1.7.tgz"
+                },
+                "ansi-styles": {
+                  "version": "1.0.0",
+                  "from": "ansi-styles@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.0.0.tgz"
+                },
+                "strip-ansi": {
+                  "version": "0.1.1",
+                  "from": "strip-ansi@~0.1.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.1.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "rx": {
+          "version": "2.3.22",
+          "from": "rx@^2.2.27",
+          "resolved": "https://registry.npmjs.org/rx/-/rx-2.3.22.tgz"
+        },
+        "through": {
+          "version": "2.3.6",
+          "from": "through@~2.3.4",
+          "resolved": "https://registry.npmjs.org/through/-/through-2.3.6.tgz"
+        }
+      }
+    },
+    "is-online": {
+      "version": "3.0.0",
+      "from": "is-online@^3.0.0",
+      "resolved": "https://registry.npmjs.org/is-online/-/is-online-3.0.0.tgz",
+      "dependencies": {
+        "each-async": {
+          "version": "1.1.1",
+          "from": "each-async@^1.1.0",
+          "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
+          "dependencies": {
+            "set-immediate-shim": {
+              "version": "1.0.0",
+              "from": "set-immediate-shim@^1.0.0",
+              "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.0.tgz"
+            }
+          }
+        },
+        "log-symbols": {
+          "version": "1.0.1",
+          "from": "log-symbols@^1.0.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.1.tgz",
+          "dependencies": {
+            "chalk": {
+              "version": "0.5.1",
+              "from": "chalk@^0.5.1",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
+              "dependencies": {
+                "ansi-styles": {
+                  "version": "1.1.0",
+                  "from": "ansi-styles@^1.1.0",
+                  "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
+                },
+                "escape-string-regexp": {
+                  "version": "1.0.2",
+                  "from": "escape-string-regexp@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+                },
+                "has-ansi": {
+                  "version": "0.1.0",
+                  "from": "has-ansi@^0.1.0",
+                  "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@^0.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "strip-ansi": {
+                  "version": "0.3.0",
+                  "from": "strip-ansi@^0.3.0",
+                  "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
+                  "dependencies": {
+                    "ansi-regex": {
+                      "version": "0.2.1",
+                      "from": "ansi-regex@^0.2.1",
+                      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
+                    }
+                  }
+                },
+                "supports-color": {
+                  "version": "0.2.0",
+                  "from": "supports-color@^0.2.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "native-dns": {
+          "version": "0.6.1",
+          "from": "https://github.com/silverwind/node-dns/tarball/8b75198dd8",
+          "resolved": "https://github.com/silverwind/node-dns/tarball/8b75198dd8",
+          "dependencies": {
+            "ipaddr.js": {
+              "version": "0.1.6",
+              "from": "ipaddr.js@>= 0.1.1",
+              "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-0.1.6.tgz"
+            },
+            "native-dns-cache": {
+              "version": "0.0.2",
+              "from": "native-dns-cache@>= 0.0.1",
+              "resolved": "https://registry.npmjs.org/native-dns-cache/-/native-dns-cache-0.0.2.tgz",
+              "dependencies": {
+                "binaryheap": {
+                  "version": "0.0.3",
+                  "from": "binaryheap@>= 0.0.3",
+                  "resolved": "https://registry.npmjs.org/binaryheap/-/binaryheap-0.0.3.tgz"
+                }
+              }
+            },
+            "native-dns-packet": {
+              "version": "0.1.1",
+              "from": "native-dns-packet@>= 0.0.4",
+              "resolved": "https://registry.npmjs.org/native-dns-packet/-/native-dns-packet-0.1.1.tgz",
+              "dependencies": {
+                "buffercursor": {
+                  "version": "0.0.12",
+                  "from": "buffercursor@>= 0.0.12",
+                  "resolved": "https://registry.npmjs.org/buffercursor/-/buffercursor-0.0.12.tgz",
+                  "dependencies": {
+                    "verror": {
+                      "version": "1.6.0",
+                      "from": "verror@^1.4.0",
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.6.0.tgz",
+                      "dependencies": {
+                        "extsprintf": {
+                          "version": "1.2.0",
+                          "from": "extsprintf@1.2.0",
+                          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.2.0.tgz"
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
+        "onetime": {
+          "version": "1.0.0",
+          "from": "onetime@^1.0.0",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.0.0.tgz"
+        },
+        "root-hints": {
+          "version": "0.2.0",
+          "from": "root-hints@^0.2.0",
+          "resolved": "https://registry.npmjs.org/root-hints/-/root-hints-0.2.0.tgz"
+        }
+      }
+    },
+    "lodash": {
+      "version": "2.4.1",
+      "from": "lodash@^2.4.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+    },
+    "memcached": {
+      "version": "0.2.8",
+      "from": "memcached@^0.2.8",
+      "resolved": "https://registry.npmjs.org/memcached/-/memcached-0.2.8.tgz",
+      "dependencies": {
+        "hashring": {
+          "version": "0.0.8",
+          "from": "hashring@0.0.x",
+          "resolved": "https://registry.npmjs.org/hashring/-/hashring-0.0.8.tgz",
+          "dependencies": {
+            "bisection": {
+              "version": "0.0.3",
+              "from": "bisection@",
+              "resolved": "https://registry.npmjs.org/bisection/-/bisection-0.0.3.tgz"
+            },
+            "simple-lru-cache": {
+              "version": "0.0.1",
+              "from": "simple-lru-cache@0.0.x",
+              "resolved": "https://registry.npmjs.org/simple-lru-cache/-/simple-lru-cache-0.0.1.tgz"
+            }
+          }
+        },
+        "jackpot": {
+          "version": "0.0.6",
+          "from": "jackpot@>=0.0.6",
+          "resolved": "https://registry.npmjs.org/jackpot/-/jackpot-0.0.6.tgz",
+          "dependencies": {
+            "retry": {
+              "version": "0.6.0",
+              "from": "retry@0.6.0",
+              "resolved": "https://registry.npmjs.org/retry/-/retry-0.6.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "memcachedjs": {
+      "version": "0.0.1",
+      "from": "memcachedjs@0.0.1",
+      "resolved": "https://registry.npmjs.org/memcachedjs/-/memcachedjs-0.0.1.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "memory-streams": {
+      "version": "0.0.3",
+      "from": "memory-streams@0.0.3",
+      "resolved": "https://registry.npmjs.org/memory-streams/-/memory-streams-0.0.3.tgz",
+      "dependencies": {
+        "readable-stream": {
+          "version": "1.0.33",
+          "from": "readable-stream@~1.0.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+          "dependencies": {
+            "core-util-is": {
+              "version": "1.0.1",
+              "from": "core-util-is@~1.0.0",
+              "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+            },
+            "isarray": {
+              "version": "0.0.1",
+              "from": "isarray@0.0.1",
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+            },
+            "string_decoder": {
+              "version": "0.10.31",
+              "from": "string_decoder@~0.10.x",
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@~2.0.1",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            }
+          }
+        }
+      }
+    },
+    "memorystream": {
+      "version": "0.2.0",
+      "from": "memorystream@^0.2.0",
+      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.2.0.tgz"
+    },
+    "mkdirp": {
+      "version": "0.5.0",
+      "from": "mkdirp@^0.5.0",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.0.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "moment": {
+      "version": "2.9.0",
+      "from": "moment@^2.8.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
+    },
+    "node-uuid": {
+      "version": "1.4.2",
+      "from": "node-uuid@^1.4.1",
+      "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz"
+    },
+    "open": {
+      "version": "0.0.5",
+      "from": "open@0.0.5",
+      "resolved": "https://registry.npmjs.org/open/-/open-0.0.5.tgz"
+    },
+    "parentpath": {
+      "version": "0.2.0",
+      "from": "parentpath@^0.2.0",
+      "resolved": "https://registry.npmjs.org/parentpath/-/parentpath-0.2.0.tgz"
+    },
+    "portscanner": {
+      "version": "1.0.0",
+      "from": "portscanner@^1.0.0",
+      "resolved": "https://registry.npmjs.org/portscanner/-/portscanner-1.0.0.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.1.15",
+          "from": "async@0.1.15",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.1.15.tgz"
+        }
+      }
+    },
+    "prettyjson": {
+      "version": "1.0.0",
+      "from": "prettyjson@^1.0.0",
+      "resolved": "https://registry.npmjs.org/prettyjson/-/prettyjson-1.0.0.tgz",
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "from": "minimist@0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+        }
+      }
+    },
+    "printf": {
+      "version": "0.2.0",
+      "from": "printf@^0.2.0",
+      "resolved": "https://registry.npmjs.org/printf/-/printf-0.2.0.tgz"
+    },
+    "progress": {
+      "version": "1.1.5",
+      "from": "progress@git+https://github.com/nuxlli/node-progress",
+      "resolved": "git+https://github.com/nuxlli/node-progress#f9ab9f0f663628ea236ecdd2c7317c48c84fd8d6"
+    },
+    "q": {
+      "version": "1.0.1",
+      "from": "q@~1.0.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.0.1.tgz"
+    },
+    "q-io": {
+      "version": "1.11.6",
+      "from": "q-io@^1.11.0",
+      "resolved": "https://registry.npmjs.org/q-io/-/q-io-1.11.6.tgz",
+      "dependencies": {
+        "qs": {
+          "version": "1.2.2",
+          "from": "qs@^1.2.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+        },
+        "url2": {
+          "version": "0.0.0",
+          "from": "url2@^0.0.0",
+          "resolved": "https://registry.npmjs.org/url2/-/url2-0.0.0.tgz"
+        },
+        "mime": {
+          "version": "1.2.11",
+          "from": "mime@^1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+        },
+        "mimeparse": {
+          "version": "0.1.4",
+          "from": "mimeparse@^0.1.4",
+          "resolved": "https://registry.npmjs.org/mimeparse/-/mimeparse-0.1.4.tgz"
+        },
+        "collections": {
+          "version": "0.2.2",
+          "from": "collections@^0.2.0",
+          "resolved": "https://registry.npmjs.org/collections/-/collections-0.2.2.tgz",
+          "dependencies": {
+            "weak-map": {
+              "version": "1.0.0",
+              "from": "weak-map@1.0.0",
+              "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "request": {
+      "version": "2.51.0",
+      "from": "request@^2.45.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.51.0.tgz",
+      "dependencies": {
+        "bl": {
+          "version": "0.9.3",
+          "from": "bl@~0.9.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.3.tgz",
+          "dependencies": {
+            "readable-stream": {
+              "version": "1.0.33",
+              "from": "readable-stream@~1.0.26",
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "dependencies": {
+                "core-util-is": {
+                  "version": "1.0.1",
+                  "from": "core-util-is@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                },
+                "isarray": {
+                  "version": "0.0.1",
+                  "from": "isarray@0.0.1",
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                },
+                "string_decoder": {
+                  "version": "0.10.31",
+                  "from": "string_decoder@~0.10.x",
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                },
+                "inherits": {
+                  "version": "2.0.1",
+                  "from": "inherits@~2.0.1",
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "caseless": {
+          "version": "0.8.0",
+          "from": "caseless@~0.8.0",
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.8.0.tgz"
+        },
+        "forever-agent": {
+          "version": "0.5.2",
+          "from": "forever-agent@~0.5.0",
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.5.2.tgz"
+        },
+        "form-data": {
+          "version": "0.2.0",
+          "from": "form-data@~0.2.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz",
+          "dependencies": {
+            "async": {
+              "version": "0.9.0",
+              "from": "async@~0.9.0",
+              "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+            },
+            "mime-types": {
+              "version": "2.0.7",
+              "from": "mime-types@~2.0.3",
+              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.7.tgz",
+              "dependencies": {
+                "mime-db": {
+                  "version": "1.5.0",
+                  "from": "mime-db@~1.5.0",
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.5.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "json-stringify-safe": {
+          "version": "5.0.0",
+          "from": "json-stringify-safe@~5.0.0",
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz"
+        },
+        "mime-types": {
+          "version": "1.0.2",
+          "from": "mime-types@~1.0.1",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-1.0.2.tgz"
+        },
+        "qs": {
+          "version": "2.3.3",
+          "from": "qs@~2.3.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-2.3.3.tgz"
+        },
+        "tunnel-agent": {
+          "version": "0.4.0",
+          "from": "tunnel-agent@~0.4.0",
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+        },
+        "tough-cookie": {
+          "version": "0.12.1",
+          "from": "tough-cookie@>=0.12.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-0.12.1.tgz",
+          "dependencies": {
+            "punycode": {
+              "version": "1.3.2",
+              "from": "punycode@>=0.2.0",
+              "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz"
+            }
+          }
+        },
+        "http-signature": {
+          "version": "0.10.1",
+          "from": "http-signature@~0.10.0",
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+          "dependencies": {
+            "assert-plus": {
+              "version": "0.1.5",
+              "from": "assert-plus@^0.1.5",
+              "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+            },
+            "asn1": {
+              "version": "0.1.11",
+              "from": "asn1@0.1.11",
+              "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+            },
+            "ctype": {
+              "version": "0.5.3",
+              "from": "ctype@0.5.3",
+              "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+            }
+          }
+        },
+        "oauth-sign": {
+          "version": "0.5.0",
+          "from": "oauth-sign@~0.5.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.5.0.tgz"
+        },
+        "hawk": {
+          "version": "1.1.1",
+          "from": "hawk@1.1.1",
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+          "dependencies": {
+            "hoek": {
+              "version": "0.9.1",
+              "from": "hoek@0.9.x",
+              "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz"
+            },
+            "boom": {
+              "version": "0.4.2",
+              "from": "boom@0.4.x",
+              "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz"
+            },
+            "cryptiles": {
+              "version": "0.2.2",
+              "from": "cryptiles@0.2.x",
+              "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz"
+            },
+            "sntp": {
+              "version": "0.2.4",
+              "from": "sntp@0.2.x",
+              "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz"
+            }
+          }
+        },
+        "aws-sign2": {
+          "version": "0.5.0",
+          "from": "aws-sign2@~0.5.0",
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+        },
+        "stringstream": {
+          "version": "0.0.4",
+          "from": "stringstream@~0.0.4",
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+        },
+        "combined-stream": {
+          "version": "0.0.7",
+          "from": "combined-stream@~0.0.5",
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+          "dependencies": {
+            "delayed-stream": {
+              "version": "0.0.5",
+              "from": "delayed-stream@0.0.5",
+              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+            }
+          }
+        }
+      }
+    },
+    "scp2": {
+      "version": "0.1.4",
+      "from": "scp2@^0.1.4",
+      "resolved": "https://registry.npmjs.org/scp2/-/scp2-0.1.4.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@~0.2.9",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "lodash": {
+          "version": "2.0.0",
+          "from": "lodash@~2.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.0.0.tgz"
+        }
+      }
+    },
+    "semver": {
+      "version": "4.2.0",
+      "from": "semver@^4.1.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-4.2.0.tgz"
+    },
+    "source-map-support": {
+      "version": "0.2.9",
+      "from": "source-map-support@~0.2.5",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.2.9.tgz",
+      "dependencies": {
+        "source-map": {
+          "version": "0.1.32",
+          "from": "source-map@0.1.32",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+          "dependencies": {
+            "amdefine": {
+              "version": "0.1.0",
+              "from": "amdefine@>=0.0.4",
+              "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+            }
+          }
+        }
+      }
+    },
+    "ssh2": {
+      "version": "0.2.22",
+      "from": "ssh2@0.2.22",
+      "resolved": "https://registry.npmjs.org/ssh2/-/ssh2-0.2.22.tgz",
+      "dependencies": {
+        "streamsearch": {
+          "version": "0.1.2",
+          "from": "streamsearch@0.1.2",
+          "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
+        },
+        "asn1": {
+          "version": "0.1.11",
+          "from": "asn1@0.1.11",
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+        }
+      }
+    },
+    "syntax-error": {
+      "version": "1.1.2",
+      "from": "syntax-error@^1.1.0",
+      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.1.2.tgz",
+      "dependencies": {
+        "acorn": {
+          "version": "0.9.0",
+          "from": "acorn@~0.9.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-0.9.0.tgz"
+        }
+      }
+    },
+    "touch": {
+      "version": "0.0.3",
+      "from": "touch@0.0.3",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
+      "dependencies": {
+        "nopt": {
+          "version": "1.0.10",
+          "from": "nopt@~1.0.10",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
+          "dependencies": {
+            "abbrev": {
+              "version": "1.0.5",
+              "from": "abbrev@1",
+              "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.0.5.tgz"
+            }
+          }
+        }
+      }
+    },
+    "traceur": {
+      "version": "0.0.72",
+      "from": "traceur@0.0.72",
+      "resolved": "https://registry.npmjs.org/traceur/-/traceur-0.0.72.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.6.0",
+          "from": "commander@2.x",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.6.0.tgz"
+        },
+        "glob": {
+          "version": "4.3.4",
+          "from": "glob@4.x",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.4.tgz",
+          "dependencies": {
+            "inflight": {
+              "version": "1.0.4",
+              "from": "inflight@^1.0.4",
+              "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            },
+            "inherits": {
+              "version": "2.0.1",
+              "from": "inherits@2",
+              "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+            },
+            "minimatch": {
+              "version": "2.0.1",
+              "from": "minimatch@^2.0.1",
+              "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
+              "dependencies": {
+                "brace-expansion": {
+                  "version": "1.1.0",
+                  "from": "brace-expansion@^1.0.0",
+                  "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                  "dependencies": {
+                    "balanced-match": {
+                      "version": "0.2.0",
+                      "from": "balanced-match@^0.2.0",
+                      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
+                    },
+                    "concat-map": {
+                      "version": "0.0.1",
+                      "from": "concat-map@0.0.1",
+                      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "once": {
+              "version": "1.3.1",
+              "from": "once@^1.3.0",
+              "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+              "dependencies": {
+                "wrappy": {
+                  "version": "1.0.1",
+                  "from": "wrappy@1",
+                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
+                }
+              }
+            }
+          }
+        },
+        "regexpu": {
+          "version": "0.3.0",
+          "from": "regexpu@0.3.0",
+          "resolved": "https://registry.npmjs.org/regexpu/-/regexpu-0.3.0.tgz",
+          "dependencies": {
+            "recast": {
+              "version": "0.8.8",
+              "from": "recast@^0.8.0",
+              "resolved": "https://registry.npmjs.org/recast/-/recast-0.8.8.tgz",
+              "dependencies": {
+                "esprima-fb": {
+                  "version": "7001.1.0-dev-harmony-fb",
+                  "from": "esprima-fb@~7001.1.0-dev-harmony-fb",
+                  "resolved": "https://registry.npmjs.org/esprima-fb/-/esprima-fb-7001.1.0-dev-harmony-fb.tgz"
+                },
+                "source-map": {
+                  "version": "0.1.32",
+                  "from": "source-map@0.1.32",
+                  "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.1.32.tgz",
+                  "dependencies": {
+                    "amdefine": {
+                      "version": "0.1.0",
+                      "from": "amdefine@>=0.0.4",
+                      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-0.1.0.tgz"
+                    }
+                  }
+                },
+                "private": {
+                  "version": "0.1.6",
+                  "from": "private@~0.1.5",
+                  "resolved": "https://registry.npmjs.org/private/-/private-0.1.6.tgz"
+                },
+                "cls": {
+                  "version": "0.1.5",
+                  "from": "cls@~0.1.3",
+                  "resolved": "https://registry.npmjs.org/cls/-/cls-0.1.5.tgz"
+                },
+                "depd": {
+                  "version": "1.0.0",
+                  "from": "depd@~1.0.0",
+                  "resolved": "https://registry.npmjs.org/depd/-/depd-1.0.0.tgz"
+                },
+                "ast-types": {
+                  "version": "0.5.7",
+                  "from": "ast-types@~0.5.7",
+                  "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.5.7.tgz"
+                }
+              }
+            },
+            "regenerate": {
+              "version": "1.0.1",
+              "from": "regenerate@^1.0.0",
+              "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.0.1.tgz"
+            },
+            "regjsgen": {
+              "version": "0.2.0",
+              "from": "regjsgen@^0.2.0",
+              "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz"
+            },
+            "regjsparser": {
+              "version": "0.1.3",
+              "from": "regjsparser@^0.1.2",
+              "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.3.tgz",
+              "dependencies": {
+                "jsesc": {
+                  "version": "0.5.0",
+                  "from": "jsesc@~0.5.0",
+                  "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz"
+                }
+              }
+            }
+          }
+        },
+        "rsvp": {
+          "version": "3.0.16",
+          "from": "rsvp@^3.0.13",
+          "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-3.0.16.tgz"
+        },
+        "semver": {
+          "version": "2.3.2",
+          "from": "semver@2.x",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-2.3.2.tgz"
+        }
+      }
+    },
+    "underscore": {
+      "version": "1.7.0",
+      "from": "underscore@^1.6.0",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+    },
+    "vboxmanage": {
+      "version": "0.0.16",
+      "from": "vboxmanage@git+https://github.com/nuxlli/node-vboxmanage",
+      "resolved": "git+https://github.com/nuxlli/node-vboxmanage#9244eac7498aab28db5c8e0cce60c914c4b73c4c",
+      "dependencies": {
+        "stream-buffers": {
+          "version": "0.2.5",
+          "from": "stream-buffers@0.2.5",
+          "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-0.2.5.tgz"
+        },
+        "async": {
+          "version": "0.2.9",
+          "from": "async@0.2.9",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+        },
+        "logsmith": {
+          "version": "0.0.2",
+          "from": "logsmith@0.0.2",
+          "resolved": "https://registry.npmjs.org/logsmith/-/logsmith-0.0.2.tgz",
+          "dependencies": {
+            "winston": {
+              "version": "0.7.2",
+              "from": "winston@0.7.2",
+              "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.2.tgz",
+              "dependencies": {
+                "cycle": {
+                  "version": "1.0.3",
+                  "from": "cycle@1.0.x",
+                  "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+                },
+                "eyes": {
+                  "version": "0.1.8",
+                  "from": "eyes@0.1.x",
+                  "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+                },
+                "pkginfo": {
+                  "version": "0.3.0",
+                  "from": "pkginfo@0.3.x",
+                  "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+                },
+                "request": {
+                  "version": "2.16.6",
+                  "from": "request@2.16.x",
+                  "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
+                  "dependencies": {
+                    "form-data": {
+                      "version": "0.0.10",
+                      "from": "form-data@~0.0.3",
+                      "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+                      "dependencies": {
+                        "combined-stream": {
+                          "version": "0.0.7",
+                          "from": "combined-stream@~0.0.4",
+                          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                          "dependencies": {
+                            "delayed-stream": {
+                              "version": "0.0.5",
+                              "from": "delayed-stream@0.0.5",
+                              "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    "mime": {
+                      "version": "1.2.11",
+                      "from": "mime@~1.2.7",
+                      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+                    },
+                    "hawk": {
+                      "version": "0.10.2",
+                      "from": "hawk@~0.10.2",
+                      "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+                      "dependencies": {
+                        "hoek": {
+                          "version": "0.7.6",
+                          "from": "hoek@0.7.x",
+                          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
+                        },
+                        "boom": {
+                          "version": "0.3.8",
+                          "from": "boom@0.3.x",
+                          "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
+                        },
+                        "cryptiles": {
+                          "version": "0.1.3",
+                          "from": "cryptiles@0.1.x",
+                          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
+                        },
+                        "sntp": {
+                          "version": "0.1.4",
+                          "from": "sntp@0.1.x",
+                          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
+                        }
+                      }
+                    },
+                    "cookie-jar": {
+                      "version": "0.2.0",
+                      "from": "cookie-jar@~0.2.0",
+                      "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
+                    },
+                    "aws-sign": {
+                      "version": "0.2.0",
+                      "from": "aws-sign@~0.2.0",
+                      "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
+                    },
+                    "oauth-sign": {
+                      "version": "0.2.0",
+                      "from": "oauth-sign@~0.2.0",
+                      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
+                    },
+                    "forever-agent": {
+                      "version": "0.2.0",
+                      "from": "forever-agent@~0.2.0",
+                      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
+                    },
+                    "tunnel-agent": {
+                      "version": "0.2.0",
+                      "from": "tunnel-agent@~0.2.0",
+                      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
+                    },
+                    "json-stringify-safe": {
+                      "version": "3.0.0",
+                      "from": "json-stringify-safe@~3.0.0",
+                      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
+                    },
+                    "qs": {
+                      "version": "0.5.6",
+                      "from": "qs@~0.5.4",
+                      "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+                    }
+                  }
+                },
+                "stack-trace": {
+                  "version": "0.0.9",
+                  "from": "stack-trace@0.0.x",
+                  "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "which": {
+      "version": "1.0.8",
+      "from": "which@^1.0.5",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.0.8.tgz"
+    },
+    "winston": {
+      "version": "0.7.3",
+      "from": "winston@^0.7.3",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-0.7.3.tgz",
+      "dependencies": {
+        "async": {
+          "version": "0.2.10",
+          "from": "async@0.2.x",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+        },
+        "cycle": {
+          "version": "1.0.3",
+          "from": "cycle@1.0.x",
+          "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+        },
+        "eyes": {
+          "version": "0.1.8",
+          "from": "eyes@0.1.x",
+          "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+        },
+        "pkginfo": {
+          "version": "0.3.0",
+          "from": "pkginfo@0.3.x",
+          "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
+        },
+        "request": {
+          "version": "2.16.6",
+          "from": "request@2.16.x",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.16.6.tgz",
+          "dependencies": {
+            "form-data": {
+              "version": "0.0.10",
+              "from": "form-data@~0.0.3",
+              "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.10.tgz",
+              "dependencies": {
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@~0.0.4",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                }
+              }
+            },
+            "mime": {
+              "version": "1.2.11",
+              "from": "mime@~1.2.7",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz"
+            },
+            "hawk": {
+              "version": "0.10.2",
+              "from": "hawk@~0.10.2",
+              "resolved": "https://registry.npmjs.org/hawk/-/hawk-0.10.2.tgz",
+              "dependencies": {
+                "hoek": {
+                  "version": "0.7.6",
+                  "from": "hoek@0.7.x",
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz"
+                },
+                "boom": {
+                  "version": "0.3.8",
+                  "from": "boom@0.3.x",
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-0.3.8.tgz"
+                },
+                "cryptiles": {
+                  "version": "0.1.3",
+                  "from": "cryptiles@0.1.x",
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.1.3.tgz"
+                },
+                "sntp": {
+                  "version": "0.1.4",
+                  "from": "sntp@0.1.x",
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.1.4.tgz"
+                }
+              }
+            },
+            "cookie-jar": {
+              "version": "0.2.0",
+              "from": "cookie-jar@~0.2.0",
+              "resolved": "https://registry.npmjs.org/cookie-jar/-/cookie-jar-0.2.0.tgz"
+            },
+            "aws-sign": {
+              "version": "0.2.0",
+              "from": "aws-sign@~0.2.0",
+              "resolved": "https://registry.npmjs.org/aws-sign/-/aws-sign-0.2.0.tgz"
+            },
+            "oauth-sign": {
+              "version": "0.2.0",
+              "from": "oauth-sign@~0.2.0",
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.2.0.tgz"
+            },
+            "forever-agent": {
+              "version": "0.2.0",
+              "from": "forever-agent@~0.2.0",
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.2.0.tgz"
+            },
+            "tunnel-agent": {
+              "version": "0.2.0",
+              "from": "tunnel-agent@~0.2.0",
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.2.0.tgz"
+            },
+            "json-stringify-safe": {
+              "version": "3.0.0",
+              "from": "json-stringify-safe@~3.0.0",
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-3.0.0.tgz"
+            },
+            "qs": {
+              "version": "0.5.6",
+              "from": "qs@~0.5.4",
+              "resolved": "https://registry.npmjs.org/qs/-/qs-0.5.6.tgz"
+            }
+          }
+        },
+        "stack-trace": {
+          "version": "0.0.9",
+          "from": "stack-trace@0.0.x",
+          "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+        }
+      }
+    },
+    "xregexp": {
+      "version": "2.0.0",
+      "from": "xregexp@^2.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-2.0.0.tgz"
+    }
+  }
+}


### PR DESCRIPTION
Now all the dependencies used in production are locked with their versions. So every time you run the installation (`npm install`) will be installed the particular version by shrinkwrap.

To force the installation the latest versions available in the repository there are two options:

1. Use the force option in npm-install command:
    ```
    $ azk nvm npm install --force
    ```

    http://stackoverflow.com/a/17552256

2. Remove the file that the shrinkwrap uses to lock versions.:
    ```sh
    $ rm -f npm-shrinkwrap.json
    ```

More information about `npm shrinkwrap` in https://docs.npmjs.com/cli/shrinkwrap