### PR TITLE
[azk help alphabetically] Sorting help in outputWithLabel #223

### DIFF
--- a/src/cli/ui.js
+++ b/src/cli/ui.js
@@ -35,7 +35,7 @@ var UI = {
   },
 
   outputWithLabel(rows, ident = '') {
-    rows = _.map(rows, (row) => {
+    rows = _.map(_.sortBy(rows), (row) => {
       return _.isArray(row) ? row : row.split('\t');
     });
 


### PR DESCRIPTION
All azk help `commands` outputs are sorted by name:

![image](https://cloud.githubusercontent.com/assets/155953/5818498/2bf2c804-a09d-11e4-985d-3185ba4e95cc.png)
