### PR TITLE
[azk lowercase] Showing azk in lowercase at azk version command #222

### DIFF
--- a/src/cmds/version.js
+++ b/src/cmds/version.js
@@ -3,7 +3,7 @@ import Azk from 'azk';
 
 class HelpCmd extends Command {
   action(opts) {
-    this.output("Azk %s", Azk.version);
+    this.output("azk %s", Azk.version);
     return 0;
   }
 }


### PR DESCRIPTION
`azk version` now shows the `azk` in lowercase:

![image](https://cloud.githubusercontent.com/assets/155953/5818675/8431da36-a09e-11e4-881d-e0bfe47d7f27.png)
