### PR TITLE
Feature/vm remove force

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Dev
+
+* Enhancements
+  * Adding `--force` option to `azk vm remove`. It's useful when the `azk vm remove` doesn't work properly due some unkown problem.
+
 ## v0.9.0
 
 * Bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Dev
 
 * Enhancements
-  * Adding `--force` option to `azk vm remove`. It's useful when the `azk vm remove` doesn't work properly due some unkown problem.
+  * Adding `--force` option to `azk vm remove`. It's useful when the `azk vm remove` doesn't work properly due some unknown problem.
 
 ## v0.9.0
 

--- a/docs/content/en/SUMMARY.md
+++ b/docs/content/en/SUMMARY.md
@@ -54,6 +54,7 @@
    * [status](command-line/status.md)
    * [stop](command-line/stop.md)
    * [version](command-line/version.md)
+   * [vm](command-line/vm.md)
    /** [Basic commands](azkfilejs/basic.md)*/
    /** [Shell](azkfilejs/shell.md)*/
    /** [Scaling](azkfilejs/escalando.md)*/

--- a/docs/content/en/command-line/vm.md
+++ b/docs/content/en/command-line/vm.md
@@ -1,0 +1,72 @@
+## azk vm
+
+Controls the virtual machine used on Mac OS X.
+
+#### Usage:
+
+    $ azk [options] vm [options] {action}
+
+_______________
+### azk vm installed
+
+Checks if the virtual machine is installed.
+
+#### Example:
+
+    $ azk vm installed
+    azk: virtual machine is not installed, try `azk vm install`.
+
+_______________
+### azk vm start
+
+Starts the virtual machine.
+
+#### Example:
+
+    $ azk vm start
+
+_______________
+### azk vm stop
+
+Stops the virtual machine.
+
+#### Example:
+
+    $ azk vm stop
+
+_______________
+### azk vm status
+
+Shows the current state of the virtual machine.
+
+#### Example:
+
+	$ azk vm status
+
+_______________
+### azk vm ssh
+
+Gets access to the virtual machine via SSH protocol.
+
+#### Example:
+
+    $ azk vm ssh
+
+_______________
+### azk vm remove
+
+Removes the virtual machine.
+
+#### Options:
+
+- `--force`      Tries to force virtual machine destruction. It's useful when the `remove` action doesn't work properly due some unkown problem.
+
+#### Examples:
+
+##### Tries to remove the virtual machine:
+
+    $ azk vm remove
+
+##### Forces the destruction of the virtual machine:
+
+    $ azk vm remove --force

--- a/docs/content/en/command-line/vm.md
+++ b/docs/content/en/command-line/vm.md
@@ -59,7 +59,7 @@ Removes the virtual machine.
 
 #### Options:
 
-- `--force`      Tries to force virtual machine destruction. It's useful when the `remove` action doesn't work properly due some unkown problem.
+- `--force`      Tries to force virtual machine destruction. It's useful when the `remove` action doesn't work properly due some unknown problem.
 
 #### Examples:
 

--- a/docs/content/pt-BR/SUMMARY.md
+++ b/docs/content/pt-BR/SUMMARY.md
@@ -54,6 +54,7 @@
    * [status](command-line/status.md)
    * [stop](command-line/stop.md)
    * [version](command-line/version.md)
+   * [vm](command-line/vm.md)
    /** [Operações básicas](azkfilejs/basic.md)*/
    /** [Shell](azkfilejs/shell.md)*/
    /** [Escalando](azkfilejs/escalando.md)*/

--- a/docs/content/pt-BR/command-line/vm.md
+++ b/docs/content/pt-BR/command-line/vm.md
@@ -1,0 +1,72 @@
+## azk vm
+
+Controla a máquina virtual utilizada no Mac OS X.
+
+#### Uso:
+
+    $ azk [options] vm [options] {action}
+
+_______________
+### azk vm installed
+
+Verifica se a máquina virtual está instalada.
+
+#### Exemplo:
+
+    $ azk vm installed
+    azk: virtual machine is not installed, try `azk vm install`.
+
+_______________
+### azk vm start
+
+Inicia a máquina virtual.
+
+#### Exemplo:
+
+    $ azk vm start
+
+_______________
+### azk vm stop
+
+Para a máquina virtual.
+
+#### Exemplo:
+
+    $ azk vm stop
+
+_______________
+### azk vm status
+
+Exibe a situção atual da máquina virtual.
+
+#### Exemplo:
+
+	$ azk vm status
+
+_______________	
+### azk vm ssh
+
+Acessa a máquina virtual via protocolo SSH.
+
+#### Exemplo:
+
+    $ azk vm ssh
+    
+_______________	
+### azk vm remove
+
+Remove a máquina virtual.
+
+#### Opções:
+
+- `--force`      Tenta forçar a remoção da máquina virtual. É útil quando o comando `azk vm remove` não funciona devido a algum problema desconhecido.
+
+#### Exemplos:
+
+##### Tenta remove a máquina virtual normalmente:
+
+    $ azk vm remove
+
+##### Força a remoção a máquina virtual:
+    
+    $ azk vm remove --force

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -437,6 +437,7 @@ module.exports = {
             remove: "Remove virtual machine but keep its contents",
           },
         },
+        force: "Tries to force virtual machine destruction. It's useful when the `remove` action doesn't work properly.",
       }
     }
   },

--- a/src/cmds/vm.js
+++ b/src/cmds/vm.js
@@ -67,7 +67,7 @@ class VmCmd extends InteractiveCmds {
     });
   }
 
-  action_start(vm_info) {
+  action_start(vm_info, _opts) {
     return async(this, function* () {
       if (vm_info.running) {
         this.fail("commands.vm.already_running");
@@ -78,28 +78,28 @@ class VmCmd extends InteractiveCmds {
     });
   }
 
-  action_stop(vm_info) {
+  action_stop(vm_info, opts) {
     return async(this, function* () {
       this.require_running(vm_info);
-      yield VM.stop(vm_info.name);
+      yield VM.stop(vm_info.name, opts.force);
     });
   }
 
-  action_status(vm_info) {
+  action_status(vm_info, _opts) {
     return async(this, function* () {
       this.require_running(vm_info);
       this.ok("commands.vm.running");
     });
   }
 
-  action_installed(vm_info) {
+  action_installed(vm_info, _opts) {
     return async(this, function* () {
       this.require_installed(vm_info);
       this.ok("commands.vm.already");
     });
   }
 
-  action_remove(vm_info) {
+  action_remove(vm_info, _opts) {
     return async(this, function* () {
       this.require_installed(vm_info);
       if (vm_info.running) {
@@ -112,8 +112,9 @@ class VmCmd extends InteractiveCmds {
 
 export function init(cli) {
   if (config('agent:requires_vm')) {
-    (new VmCmd('vm {*action}', cli))
-      .setOptions('action', { options: ['ssh', 'installed', 'start', 'status', 'stop', 'remove'] });
+    (new VmCmd('vm {action}', cli))
+      .setOptions('action', { options: ['ssh', 'installed', 'start', 'status', 'stop', 'remove'] })
+      .addOption(['--force'], { default: false });
   }
 }
 


### PR DESCRIPTION
Added an option `--force` to `azk vm remove` command. It's useful when the `azk vm remove` action doesn't work properly due some unknown problem.

## Tests

- [ ] Test in OS X
- [ ] Test in Linux