### PR TITLE
Feature/211 azk shell logs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Dev
+
+* Enhancements
+  * Added message logs to `azk shell` command. Now, when `azk` is 
+downloading the requested image it doesn't seem to be freezed anymore. To prevent those logs use `--silent` option. It's useful when using `-c` option and the output is used as input to another command using pipe `|` operator.
+
 ## v0.9.2 - (2015-29-01)
 
 * Bug

--- a/docs/content/en/command-line/shell.md
+++ b/docs/content/en/command-line/shell.md
@@ -14,6 +14,7 @@ Initializes a shell with the instance context, or executes an arbitrary command.
 - `--mount="", -m, -mm`   Points to an additional mount (ex:./origin:/azk/target) - supports multiple
 - `--env="", -e, -ee`     Additional environment variable - supports multiple
 - `--verbose, -v`         Displays details about the command execution (default: false)
+- `--silent`              Prevents any log message about the command execution. It's useful when using `-c` option and the output is used as input to another command using pipe `|` operator.
 
 #### Usage:
 
@@ -35,4 +36,9 @@ $ azk shell [system_name] -c "ls -l /"
 # Start a container from the image `azukiapp/azktcl: 0.0.2` mounting
 #  and running the command /bin/bash, and forcing the allocation of pseudo-tty
 $ azk shell --image azukiapp/azktcl:0.0.2 -t -c "/bin/bash"
+
+# Executes a command inside the container and uses its output as input to 
+# another command using the pipe `|` operator. Note the `--silent` option
+# to prevent that `azk shell` shows any log message in the output.
+azk shell --silent -c "rake routes" | grep posts
 ```

--- a/docs/content/pt-BR/command-line/shell.md
+++ b/docs/content/pt-BR/command-line/shell.md
@@ -14,6 +14,7 @@ Inicializa um shell com o contexto da instância, ou executa um comando arbitrá
 - `--mount="", -m, -mm`   Aponta para uma montagem adicional (ex:./origin:/azk/target) - suporta múltiplas
 - `--env="", -e, -ee`     Variável de ambiente adicional - suporta múltiplas
 - `--verbose, -v`         Exibe detalhes sobre a execução do comando (padrão: falso)
+- `--silent`              Previne qualquer mensagem de log sobre a execução do comando. É útil quando é utilizada a opção `-c` e o output é utilizado de entrada para outro comando com o operador pipe `|`.
 
 #### Uso:
 
@@ -35,4 +36,9 @@ $ azk shell [system_name] -c "ls -l /"
 # Inicia um container a partir da imagem `azukiapp/azktcl:0.0.2` montando
 #  e executando o comando /bin/bash, e forçando a alocação do pseudo-tty
 $ azk shell --image azukiapp/azktcl:0.0.2 -t -c "/bin/bash"
+
+# Executa um commando dentro do container e utiliza o output como input
+# para outro comando usando o operador pipe `|`. Note a opção `--silent`
+# para evitar que `azk shell` exiba mensagens de log no output.
+azk shell --silent -c "rake routes" | grep posts
 ```


### PR DESCRIPTION
This pull request closes https://github.com/azukiapp/azk/issues/211 issue.

Some details:
- As you can see in the pictures below, now the `azk shell` shows the download progress like the `azk start`.
- You can use `--silent` option to prevent those logs.
- When the image is already downloaded, it doesn't show any log message like before.

### Downloading
![screen shot 2015-02-10 at 12 34 11](https://cloud.githubusercontent.com/assets/26623/6128920/477362ca-b121-11e4-94c8-1daec3d02e50.png)

### Download completed
![screen shot 2015-02-10 at 12 36 23](https://cloud.githubusercontent.com/assets/26623/6128933/75e74fc2-b121-11e4-836a-c8e399a7f9d9.png)

### Image is already downloaded
![screen shot 2015-02-10 at 12 40 46](https://cloud.githubusercontent.com/assets/26623/6129017/21c5ee70-b122-11e4-8b43-ea933c4ba666.png)

## Tests

- [ ] Test in OS X
- [ ] Test in Linux


