### PR TITLE
[system_dns] Adding support to `dns_servers` in system, #214

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## dev
+
+* Enhancements
+  * [System] Adding support to customize DNS servers to will be used in system. #273
+
 ## v0.9.2 - (2015-29-01)
 
 * Bug

--- a/docs/content/en/SUMMARY.md
+++ b/docs/content/en/SUMMARY.md
@@ -26,6 +26,7 @@
    * [Overview](azkfilejs/overview.md)
    * [image](azkfilejs/image.md)
    * [depends](azkfilejs/depends.md)
+   * [dns_servers](azkfilejs/dns_servers.md)
    * [provision](azkfilejs/provision.md)
    * [workdir](azkfilejs/workdir.md)
    * [shell](azkfilejs/shell.md)

--- a/docs/content/en/azkfilejs/dns_servers.md
+++ b/docs/content/en/azkfilejs/dns_servers.md
@@ -1,0 +1,16 @@
+## dns_servers
+
+Gives the possibility to customize the DNS servers that will be used by the system.
+
+##### Example:
+
+For the system to use the [openDNS](https://www.opendns.com/home-internet-security/opendns-ip-addresses/) servers:
+
+```javascript
+systems({
+  'web': {
+    // ...
+    dns_servers: ['208.67.222.222', '208.67.222.220']
+  },
+});
+```

--- a/docs/content/pt-BR/SUMMARY.md
+++ b/docs/content/pt-BR/SUMMARY.md
@@ -25,6 +25,7 @@
 * [Azkfile.js](azkfilejs/README.md)
    * [image](azkfilejs/image.md)
    * [depends](azkfilejs/depends.md)
+   * [dns_servers](azkfilejs/dns_servers.md)
    * [provision](azkfilejs/provision.md)
    * [workdir](azkfilejs/workdir.md)
    * [shell](azkfilejs/shell.md)

--- a/docs/content/pt-BR/azkfilejs/dns_servers.md
+++ b/docs/content/pt-BR/azkfilejs/dns_servers.md
@@ -1,0 +1,16 @@
+## dns_servers
+
+Dá a possibilidade de personalizar os servidores de **DNS** que serão utilizados pelo sistema.
+
+##### Exemplo:
+
+Para o sistema utilizar servidores do [openDNS](https://www.opendns.com/home-internet-security/opendns-ip-addresses/):
+
+```javascript
+systems({
+  'web': {
+    // ...
+    dns_servers: ['208.67.222.222', '208.67.222.220']
+  },
+});
+```

--- a/spec/spec_helpers/mock_manifest.js
+++ b/spec/spec_helpers/mock_manifest.js
@@ -143,6 +143,7 @@ export function extend(h) {
             "manifest.project_name: #{manifest.project_name}",
             "azk.version: #{azk.version}",
             "azk.default_domain: #{azk.default_domain}",
+            "azk.default_dns: #{azk.default_dns}",
             "azk.balancer_port: #{azk.balancer_port}",
             "azk.balancer_ip: #{azk.balancer_ip}",
           ],

--- a/spec/system/index_spec.js
+++ b/spec/system/index_spec.js
@@ -28,6 +28,14 @@ describe("Azk system class, main set", function() {
     h.expect(system).to.have.property("default_options").to.fail;
   });
 
+  it("should merge options with dns_servers", function() {
+    system.options = _.defaults(system.default_options, {
+      dns_servers: ['208.67.222.222', '208.67.222.220']
+    });
+
+    h.expect(system).to.have.property("dns_servers").and.eql(['208.67.222.222', '208.67.222.220']);
+  });
+
   describe("with valid manifest", function() {
     var manifest, system;
 
@@ -68,6 +76,7 @@ describe("Azk system class, main set", function() {
         h.expect(provision).to.include(`manifest.project_name: ${manifest.manifestDirName}`);
         h.expect(provision).to.include(`azk.version: ${version}`);
         h.expect(provision).to.include(`azk.default_domain: ${config('agent:balancer:host')}`);
+        h.expect(provision).to.include(`azk.default_dns: ${net.nameServers().toString()}`);
         h.expect(provision).to.include(`azk.balancer_port: ${config('agent:balancer:port').toString()}`);
         h.expect(provision).to.include(`azk.balancer_ip: ${config('agent:balancer:ip')}`);
       });
@@ -239,6 +248,17 @@ describe("Azk system class, main set", function() {
           "/azk", utils.docker.resolvePath(manifest.manifestPath)
         );
         h.expect(mounts).to.have.property("/data", folder);
+      });
+
+      it("should support custom dns_servers", function() {
+        // Customized options
+        var custom  = {
+          dns_servers: ['208.67.222.222', '208.67.222.220']
+        };
+
+        var options = system.daemonOptions(custom);
+
+        h.expect(options).to.have.property("dns").and.eql(['208.67.222.222', '208.67.222.220']);
       });
 
       it("should extract options from image_data", function() {

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -196,6 +196,10 @@ export class System {
     return ports;
   }
 
+  get dns_servers() {
+    return this.options.dns_servers;
+  }
+
   // Envs
   get envs() { return this.options.envs; }
   expandExportEnvs(data) {
@@ -276,6 +280,11 @@ export class System {
       // WorkingDir
       if (_.isEmpty(this.options.workdir) && _.isEmpty(options.workdir)) {
         options.workdir = config.WorkingDir;
+      }
+
+      // DNS Servers
+      if (_.isEmpty(this.options.dns_servers) && _.isEmpty(options.dns_servers)) {
+        options.dns_servers = config.dns_servers;
       }
 
       // ExposedPorts
@@ -359,6 +368,8 @@ export class System {
       this._mounts_to_volumes(options.mounts)
     );
 
+    var dns_servers = !_.isEmpty(options.dns_servers) ? options.dns_servers : net.nameServers();
+
     var finalOptions = {
       daemon: daemon,
       ports: ports,
@@ -367,7 +378,7 @@ export class System {
       volumes: mounts,
       working_dir: options.workdir || this.workdir,
       env: envs,
-      dns: net.nameServers(),
+      dns: dns_servers,
       docker: options.docker || this.options.docker_extra || null,
       annotations: { azk: {
         type : type,
@@ -439,6 +450,7 @@ export class System {
       azk: {
         version       : version,
         default_domain: config('agent:balancer:host'),
+        default_dns   : net.nameServers(),
         balancer_port : config('agent:balancer:port'),
         balancer_ip   : config('agent:balancer:ip'),
       }


### PR DESCRIPTION
Adding support to customize DNS servers to will be used in system.

```javascript
systems({
  'web': {
    image: "azukiapp/node",
    command: "node index.js",
    workdir: "/azk/#{manifest.dir}",
    http: {
      domains: [ "#{system.name}.#{azk.default_domain}" ],
    },
    dns_servers: ['208.67.222.222', '208.67.222.220']
  },
});
```
