### PR TITLE
[system_dns] Fixing support to dns_servers

### DIFF
--- a/spec/system/index_spec.js
+++ b/spec/system/index_spec.js
@@ -252,13 +252,11 @@ describe("Azk system class, main set", function() {
 
       it("should support custom dns_servers", function() {
         // Customized options
-        var custom  = {
-          dns_servers: ['208.67.222.222', '208.67.222.220']
-        };
+        var nameservers = ['208.67.222.222', '208.67.222.220'];
+        var custom      = { dns_servers: nameservers };
+        var options     = system.daemonOptions(custom);
 
-        var options = system.daemonOptions(custom);
-
-        h.expect(options).to.have.property("dns").and.eql(['208.67.222.222', '208.67.222.220']);
+        h.expect(options).to.have.property("dns").and.eql(net.nameServers(nameservers));
       });
 
       it("should extract options from image_data", function() {

--- a/spec/utils/net_spec.js
+++ b/spec/utils/net_spec.js
@@ -16,6 +16,17 @@ describe("Azk utils.net module", function() {
     h.expect(net_utils.calculateGatewayIp('192.168.50.4')).to.equal('192.168.50.1');
   });
 
+  it('should custom nameservers', function () {
+    var custom_nameservers        = ['208.67.222.222', '208.67.222.220'];
+    var full_custom_nameservers   = [config("agent:dns:ip")].concat(custom_nameservers);
+
+    var default_nameservers       = config('agent:dns:nameservers');
+    var full_default_nameservers  = [config("agent:dns:ip")].concat(default_nameservers);
+
+    h.expect(full_custom_nameservers).to.eql(net_utils.nameServers(custom_nameservers));
+    h.expect(full_default_nameservers).to.eql(net_utils.nameServers());
+  });
+
   describe("wait for service", function() {
     var server, port, unix;
     before(() => {

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -282,11 +282,6 @@ export class System {
         options.workdir = config.WorkingDir;
       }
 
-      // DNS Servers
-      if (_.isEmpty(this.options.dns_servers) && _.isEmpty(options.dns_servers)) {
-        options.dns_servers = config.dns_servers;
-      }
-
       // ExposedPorts
       var ports = _.reduce(options.ports, (ports, value, key) => {
         if (isBlank(value)) {
@@ -349,6 +344,7 @@ export class System {
       ports: {},
       sequencies: {},
       docker: null,
+      dns_servers: this.options.dns_servers
     });
 
     // Map ports to docker configs: ports and envs
@@ -370,8 +366,13 @@ export class System {
       this._mounts_to_volumes(options.mounts)
     );
 
-    var dns_servers = !_.isEmpty(options.dns_servers) ? options.dns_servers : net.nameServers();
+    var dns_servers = [];
 
+    if (!_.isEmpty(options.dns_servers)) {
+      dns_servers = net.nameServers(options.dns_servers);
+    } else {
+      dns_servers = net.nameServers();
+    }
     var finalOptions = {
       daemon: daemon,
       ports: ports,

--- a/src/utils/net.js
+++ b/src/utils/net.js
@@ -33,17 +33,25 @@ var net = {
     return ip.replace(/^(.*)\..*$/, "$1.1");
   },
 
-  nameServers(dns) {
-    if (dns) {
-      nameservers = dns;
+  nameServers(options) {
+    var dns_servers;
+
+    if (options) {
+      dns_servers = options;
+    } else if (isBlank(nameservers)) {
+      dns_servers = config('agent:dns:nameservers');
+    } else {
+      dns_servers = nameservers;
     }
-    if (isBlank(nameservers)) {
-      nameservers = config('agent:dns:nameservers');
+
+    if (!_.contains(dns_servers, config("agent:dns:ip"))) {
+      dns_servers.unshift(config("agent:dns:ip"));
     }
-    if (!_.contains(nameservers, config("agent:dns:ip"))) {
-      nameservers.unshift(config("agent:dns:ip"));
+
+    if (!options) {
+      nameservers = dns_servers;
     }
-    return nameservers;
+    return dns_servers;
   },
 
   waitService(uri, retry = 15, opts = {}) {

--- a/src/utils/net.js
+++ b/src/utils/net.js
@@ -33,9 +33,14 @@ var net = {
     return ip.replace(/^(.*)\..*$/, "$1.1");
   },
 
-  nameServers() {
+  nameServers(dns) {
+    if (dns) {
+      nameservers = dns;
+    }
     if (isBlank(nameservers)) {
       nameservers = config('agent:dns:nameservers');
+    }
+    if (!_.contains(nameservers, config("agent:dns:ip"))) {
       nameservers.unshift(config("agent:dns:ip"));
     }
     return nameservers;


### PR DESCRIPTION
Fixing support to dns_servers (PR #273 )

To test:

- Add custom `dns_servers` in Azkfile.js:

```js
systems({
  'web': {
    image: "azukiapp/node",
    command: "node index.js",
    workdir: "/azk/#{manifest.dir}",
    http: {
      domains: [ "#{system.name}.#{azk.default_domain}" ],
    },
    dns_servers: ['208.67.222.222', '208.67.222.220']
  },
});
```

- Run `azk shell` and check `/etc/resolv.conf` file:

```sh
$ azk shell
# cat /etc/resolv.conf
nameserver 192.168.50.4
nameserver 208.67.222.222
nameserver 208.67.222.220
```