### PR TITLE
[azk shell logs] Showing logs when building an image

### DIFF
--- a/src/cmds/shell.js
+++ b/src/cmds/shell.js
@@ -122,8 +122,9 @@ class Cmd extends InteractiveCmds {
           pull_progress(event);
         } else if (event.type === "action") {
           var keys = ["commands", "scale"];
+          var actions = ["pull_image", "build_image"]
 
-          if (event.action == "pull_image") {
+          if (actions.indexOf(event.action) > -1) {
             var data = { image: system.image.name };
             this.ok([...keys].concat(event.action), data);
           }

--- a/src/cmds/shell.js
+++ b/src/cmds/shell.js
@@ -122,7 +122,7 @@ class Cmd extends InteractiveCmds {
           pull_progress(event);
         } else if (event.type === "action") {
           var keys = ["commands", "scale"];
-          var actions = ["pull_image", "build_image"]
+          var actions = ["pull_image", "build_image"];
 
           if (actions.indexOf(event.action) > -1) {
             var data = { image: system.image.name };


### PR DESCRIPTION
I complemented the #211 feature to show log messages when `azk` is building an image. This happens when `Azkfile.js` uses a `Dockerfile` as an image.

```shell
$ azk shell
azk: ⇲ building `azkbuild/a4746dc0a9-my_app:6651ddff6eb82c840ced7c1dddee15c6e1913dd4` image...
root@241746bb3d60:/azk/my-app#
```

Now, it shows log messages when downloading or building an image.