### PR TITLE
Including new node.js versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 * Enhancements
   * Adding `--force` option to `azk vm remove`. It's useful when `azk vm remove` doesn't work properly due to some unknown problem.
-  * Added message logs to `azk shell` command. Now, when `azk` is 
-downloading the requested image it doesn't seem to be frozen anymore. To prevent those logs use the `--silent` option. It's useful when using the `-c` option and the output is used as input to another command using the pipe `|` operator.
+  * Added message logs to `azk shell` command. Now, when `azk` is downloading the requested image it doesn't seem to be frozen anymore. To prevent those logs use the `--silent` option. It's useful when using the `-c` option and the output is used as input to another command using the pipe `|` operator.
   * [System] Adding support to customize DNS servers to will be used in system. #273
   * [Manifest] Adding `extends` support.
   * [Cli] Updated messages in locales/en-US for easier understanding
@@ -13,6 +12,7 @@ downloading the requested image it doesn't seem to be frozen anymore. To prevent
 * Bug
   * [Cli] Showing `azk`'s timeout errors #217 #268
   * [Generators] Notifying when runtime system version was unidentified.
+  * [Generators] Including not found node.js suggestions #276
 
 ## v0.9.2 - (2015-29-01)
 

--- a/spec/generator/court_spec.js
+++ b/spec/generator/court_spec.js
@@ -105,7 +105,7 @@ describe('Azk generator tool court veredict:', function() {
              fullpath:'/tmp/azk-test-302101g49y9s/api/package.json',
              ruleType:'runtime',
              name:'node',
-             ruleName:'node010',     <----------  [0][0]
+             ruleName:'node012',     <----------  [0][0]
              version:'0.4.1'
           }
        ],
@@ -129,7 +129,7 @@ describe('Azk generator tool court veredict:', function() {
     */
     var filteredEvidences = _.values(court.__evidences_by_folder);
 
-    h.expect(filteredEvidences[0][0]).to.have.property('ruleName', 'node010');
+    h.expect(filteredEvidences[0][0]).to.have.property('ruleName', 'node012');
     h.expect(filteredEvidences[1][0]).to.have.property('ruleName', 'postgres93');
     h.expect(filteredEvidences[1][1]).to.have.property('ruleName', 'rails41');
 
@@ -150,13 +150,13 @@ describe('Azk generator tool court veredict:', function() {
     var firstEvidence = evidence0;
     h.expect(firstEvidence).to.have.property('ruleType', 'runtime');
     h.expect(firstEvidence).to.have.property('name', 'node');
-    h.expect(firstEvidence).to.have.property('ruleName', 'node010');
+    h.expect(firstEvidence).to.have.property('ruleName', 'node012');
     h.expect(firstEvidence).to.have.property('version', '0.4.1');
 
     // first suggestion
     var firstSuggestion = evidence0.suggestionChoosen.suggestion;
     h.expect(firstSuggestion).to.have.property('name', 'api');
-    h.expect(evidence0.suggestionChoosen.ruleNamesList).to.contains('node010');
+    h.expect(evidence0.suggestionChoosen.ruleNamesList).to.contains('node012');
     h.expect(firstSuggestion).have.property('__type', 'node.js');
   });
 

--- a/spec/generator/rules/generation/node_gen_spec.js
+++ b/spec/generator/rules/generation/node_gen_spec.js
@@ -32,7 +32,7 @@ describe('Azk generator generation node rule', function() {
     var command  = new RegExp(h.escapeRegExp('npm start'));
 
     h.expect(system).to.have.deep.property('name', project_folder_name);
-    h.expect(system).to.have.deep.property('image.name', 'node:0.10');
+    h.expect(system).to.have.deep.property('image.name', 'node:0.12');
     h.expect(system).to.have.deep.property('depends').and.to.eql([]);
     h.expect(system).to.have.deep.property('command').and.to.match(command);
 

--- a/spec/generator/rules/node_spec.js
+++ b/spec/generator/rules/node_spec.js
@@ -27,7 +27,7 @@ describe('Azk generators Node.js rule', function() {
     h.expect(evidence).to.have.deep.property('fullpath', packageJsonfilePath);
     h.expect(evidence).to.have.deep.property('ruleType', 'runtime');
     h.expect(evidence).to.have.deep.property('name'    , 'node');
-    h.expect(evidence).to.have.deep.property('ruleName', 'node010');
+    h.expect(evidence).to.have.deep.property('ruleName', 'node012');
     h.expect(evidence).to.have.deep.property('version' , '0.4.1');
   });
 
@@ -41,7 +41,7 @@ describe('Azk generators Node.js rule', function() {
     ].join('\n');
 
     var evidence = rule.getEvidence(packageJsonfilePath, packageJsonContent);
-    h.expect(evidence).to.have.deep.property('ruleName', 'node010');
+    h.expect(evidence).to.have.deep.property('ruleName', 'node012');
   });
 
   it('should get latest node version when version is too low', () => {
@@ -55,7 +55,7 @@ describe('Azk generators Node.js rule', function() {
     ].join('\n');
 
     var evidence = rule.getEvidence(packageJsonfilePath, packageJsonContent);
-    h.expect(evidence).to.have.deep.property('ruleName', 'node010');
+    h.expect(evidence).to.have.deep.property('ruleName', 'node012');
   });
 
   it('should get 0.8 version when required', () => {
@@ -74,20 +74,20 @@ describe('Azk generators Node.js rule', function() {
     h.expect(evidence).to.have.deep.property('ruleName', 'node08');
   });
 
-  it('should get latest version when version is v0.10', () => {
+  it('should get latest version when version is v0.12', () => {
     var packageJsonfilePath = '/tmp/azk-test-30501680wvr4/front/package.json';
     var packageJsonContent = [
       '{',
       '  "name": "best-practices",',
       '  "engines": {',
-      '    "node": "v0.10.0"',
+      '    "node": "v0.12.0"',
       '  },',
       '  "author": "Charlie Robbins <charlie@nodejitsu.com>"',
       '}',
     ].join('\n');
 
     var evidence = rule.getEvidence(packageJsonfilePath, packageJsonContent);
-    h.expect(evidence).to.have.deep.property('ruleName', 'node010');
+    h.expect(evidence).to.have.deep.property('ruleName', 'node012');
   });
 
   it('should get 0.11 version when version is >= v0.11', () => {
@@ -96,14 +96,30 @@ describe('Azk generators Node.js rule', function() {
       '{',
       '  "name": "best-practices",',
       '  "engines": {',
-      '    "node": "v0.11.0"',
+      '    "node": "v0.12.0"',
       '  },',
       '  "author": "Charlie Robbins <charlie@nodejitsu.com>"',
       '}',
     ].join('\n');
 
     var evidence = rule.getEvidence(packageJsonfilePath, packageJsonContent);
-    h.expect(evidence).to.have.deep.property('ruleName', 'node011');
+    h.expect(evidence).to.have.deep.property('ruleName', 'node012');
+  });
+
+  it('should get latest version when version is not found', () => {
+    var packageJsonfilePath = '/tmp/azk-test-30501680wvr4/front/package.json';
+    var packageJsonContent = [
+      '{',
+      '  "name": "best-practices",',
+      '  "engines": {',
+      '    "node": "v99"',
+      '  },',
+      '  "author": "Charlie Robbins <charlie@nodejitsu.com>"',
+      '}',
+    ].join('\n');
+
+    var evidence = rule.getEvidence(packageJsonfilePath, packageJsonContent);
+    h.expect(evidence).to.have.deep.property('ruleName', 'node012');
   });
 
 });

--- a/spec/generator/rules/node_spec.js
+++ b/spec/generator/rules/node_spec.js
@@ -96,7 +96,23 @@ describe('Azk generators Node.js rule', function() {
       '{',
       '  "name": "best-practices",',
       '  "engines": {',
-      '    "node": "v0.12.0"',
+      '    "node": "v0.11.02"',
+      '  },',
+      '  "author": "Charlie Robbins <charlie@nodejitsu.com>"',
+      '}',
+    ].join('\n');
+
+    var evidence = rule.getEvidence(packageJsonfilePath, packageJsonContent);
+    h.expect(evidence).to.have.deep.property('ruleName', 'node012');
+  });
+
+  it('should get 0.12 version when version is >= v0.12', () => {
+    var packageJsonfilePath = '/tmp/azk-test-30501680wvr4/front/package.json';
+    var packageJsonContent = [
+      '{',
+      '  "name": "best-practices",',
+      '  "engines": {',
+      '    "node": "v0.13.00"',
       '  },',
       '  "author": "Charlie Robbins <charlie@nodejitsu.com>"',
       '}',

--- a/spec/generator/rules/node_spec.js
+++ b/spec/generator/rules/node_spec.js
@@ -90,7 +90,7 @@ describe('Azk generators Node.js rule', function() {
     h.expect(evidence).to.have.deep.property('ruleName', 'node012');
   });
 
-  it('should get 0.11 version when version is >= v0.11', () => {
+  it('should get 0.12 version when version is >= v0.11', () => {
     var packageJsonfilePath = '/tmp/azk-test-30501680wvr4/front/package.json';
     var packageJsonContent = [
       '{',

--- a/src/generator/rules/node.js
+++ b/src/generator/rules/node.js
@@ -41,7 +41,7 @@ export class Rule extends BaseRule {
       fullpath: path,
       ruleType: 'runtime',
       name    : 'node',
-      ruleName: 'node010'
+      ruleName: 'node012'
     };
 
     var nodeVersion = getVersion(path, content);
@@ -55,9 +55,9 @@ export class Rule extends BaseRule {
     // Suggest a docker image
     // https://registry.hub.docker.com/u/library/node/
     var versionRules = {
-      'node010': '<0.8.0 || >=0.10.0 <0.11.0',
       'node08' : '>=0.8.0 <0.10.0',
-      'node011': '>=0.11.0',
+      'node010': '>=0.10.0 <0.11.0',
+      'node012': '<0.8.0 || >=0.11.0',
     };
 
     evidence.ruleName = _.findKey(versionRules, (value) => {

--- a/src/generator/sugestion_chooser.js
+++ b/src/generator/sugestion_chooser.js
@@ -32,8 +32,10 @@ export class SugestionChooser extends UIProxy {
         return diff.length === 0;
       });
 
-      evidence.suggestionChoosen            = _.clone(suggestionChoosen);
-      evidence.suggestionChoosen.suggestion = _.cloneDeep(suggestionChoosen.suggestion);
+      if (suggestionChoosen) {
+        evidence.suggestionChoosen            = _.clone(suggestionChoosen);
+        evidence.suggestionChoosen.suggestion = _.cloneDeep(suggestionChoosen.suggestion);
+      }
       return evidence;
     });
   }

--- a/src/generator/suggestions/node012.js
+++ b/src/generator/suggestions/node012.js
@@ -1,0 +1,34 @@
+import { _ } from 'azk';
+import { UIProxy } from 'azk/cli/ui';
+import { example_system } from 'azk/generator/rules';
+
+export class Suggestion extends UIProxy {
+  constructor(...args) {
+    super(...args);
+
+    // Readable name for this suggestion
+    this.name = 'node012';
+
+    // Which rules they suggestion is valid
+    this.ruleNamesList = ['node012'];
+
+    // Initial Azkfile.js suggestion
+    this.suggestion = _.extend({}, example_system, {
+      __type: "node.js",
+      image : { docker: "node:0.12" },
+      provision: [
+        "npm install"
+      ],
+      http: true,
+      scalable: { default: 2 },
+      command : "npm start",
+      envs    : {
+        NODE_ENV: "dev"
+      }
+    });
+  }
+
+  suggest() {
+    return this.suggestion;
+  }
+}

--- a/src/generator/suggestions/node08.js
+++ b/src/generator/suggestions/node08.js
@@ -1,0 +1,34 @@
+import { _ } from 'azk';
+import { UIProxy } from 'azk/cli/ui';
+import { example_system } from 'azk/generator/rules';
+
+export class Suggestion extends UIProxy {
+  constructor(...args) {
+    super(...args);
+
+    // Readable name for this suggestion
+    this.name = 'node08';
+
+    // Which rules they suggestion is valid
+    this.ruleNamesList = ['node08'];
+
+    // Initial Azkfile.js suggestion
+    this.suggestion = _.extend({}, example_system, {
+      __type: "node.js",
+      image : { docker: "node:0.8" },
+      provision: [
+        "npm install"
+      ],
+      http: true,
+      scalable: { default: 2 },
+      command : "npm start",
+      envs    : {
+        NODE_ENV: "dev"
+      }
+    });
+  }
+
+  suggest() {
+    return this.suggestion;
+  }
+}


### PR DESCRIPTION
##### bug_suggesting_version_azk_init

This closes https://github.com/azukiapp/azk/issues/276;
We had the rule but not the suggestion.

- Including new suggestions for new docker node version: 0.12, 0.10 e 0.8
- Fixing tests that now expect stable version to be node 0.12
