### PR TITLE
Showing docker logs when verbose is enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,7 @@
 
 * Enhancements
   * Adding `--force` option to `azk vm remove`. It's useful when `azk vm remove` doesn't work properly due to some unknown problem.
-  * Added message logs to `azk shell` command. Now, when `azk` is 
-downloading the requested image it doesn't seem to be frozen anymore. To prevent those logs use the `--silent` option. It's useful when using the `-c` option and the output is used as input to another command using the pipe `|` operator.
+  * Added message logs to `azk shell` command. Now, when `azk` is downloading or building the requested image it doesn't seem to be frozen anymore. To prevent those logs use the `--silent` option. It's useful when using the `-c` option and the output is used as input to another command using the pipe `|` operator.
   * [System] Adding support to customize DNS servers to will be used in system. #273
   * [Manifest] Adding `extends` support.
   * [Cli] Updated messages in locales/en-US for easier understanding

--- a/src/cmds/shell.js
+++ b/src/cmds/shell.js
@@ -113,7 +113,6 @@ class Cmd extends InteractiveCmds {
     return (event) => {
       var pull_progress = Helpers.newPullProgress(this);
       var escape_progress = Helpers.escapeCapture(escape);
-      var actions = ["pull_image", "build_image"];
 
       // show verbose output
       if (verbose && event.stream) {

--- a/src/cmds/shell.js
+++ b/src/cmds/shell.js
@@ -16,7 +16,6 @@ lazy_require(this, {
 class Cmd extends InteractiveCmds {
   action(opts) {
     var progress = Helpers.newPullProgress(this);
-
     return async(this, function* () {
       var cmd = [opts.cmd, ...opts.__leftover];
       var dir = this.cwd;
@@ -79,7 +78,7 @@ class Cmd extends InteractiveCmds {
           return false;
         };
 
-        var shell_progress = this._escapeAndPullProgress(escape, system, !opts.silent);
+        var shell_progress = this._escapeAndPullProgress(escape, system, !opts.silent, opts.verbose, options.stdout);
 
         system.runShell(cmd, options).
           progress(shell_progress).
@@ -110,12 +109,18 @@ class Cmd extends InteractiveCmds {
     throw error;
   }
 
-  _escapeAndPullProgress(escape, system, show_logs) {
+  _escapeAndPullProgress(escape, system, show_logs, verbose) {
     return (event) => {
       var pull_progress = Helpers.newPullProgress(this);
       var escape_progress = Helpers.escapeCapture(escape);
+      var actions = ["pull_image", "build_image"];
 
-      if (event.type === "stdin_pipe") {
+      // show verbose output
+      if (verbose && event.stream) {
+        this.stdout().write('  ' + event.stream);
+      }
+
+      if (actions.indexOf(event.action) > -1) {
         escape_progress(event);
       } else if (show_logs) {
         if (show_logs && event.type === "pull_msg") {

--- a/src/cmds/shell.js
+++ b/src/cmds/shell.js
@@ -120,7 +120,7 @@ class Cmd extends InteractiveCmds {
         this.stdout().write('  ' + event.stream);
       }
 
-      if (actions.indexOf(event.action) > -1) {
+      if (event.type === "stdin_pipe") {
         escape_progress(event);
       } else if (show_logs) {
         if (show_logs && event.type === "pull_msg") {
@@ -128,7 +128,7 @@ class Cmd extends InteractiveCmds {
         } else if (event.type === "action") {
           var keys = ["commands", "scale"];
 
-          if (event.action == "pull_image") {
+          if (actions.indexOf(event.action) > -1) {
             var data = { image: system.image.name };
             this.ok([...keys].concat(event.action), data);
           }

--- a/src/docker/build.js
+++ b/src/docker/build.js
@@ -76,12 +76,11 @@ function parseAddManifestFiles (archive, dockerfile, content) {
   });
 }
 
-export function build(docker, opts) {
+export function build(docker, options) {
   return async(function* (notify) {
-    opts = _.extend({
-      verbose: true,
-      cache: true,
-    }, opts);
+    var opts = _.extend({
+      cache: true
+    }, options);
 
     // Check if "Dockerfile" exist
     var dockerfile = opts.dockerfile;
@@ -118,6 +117,9 @@ export function build(docker, opts) {
       if (!msg.error) {
         msg.type = 'build_msg';
         msg.statusParsed = parse_stream(msg.stream);
+        if (opts.verbose && opts.stdout) {
+          opts.stdout.write(msg.stream);
+        }
         if (msg.statusParsed) {
           notify(msg);
           if (msg.statusParsed.type == "building_from") {

--- a/src/docker/build.js
+++ b/src/docker/build.js
@@ -118,7 +118,7 @@ export function build(docker, options) {
         msg.type = 'build_msg';
         msg.statusParsed = parse_stream(msg.stream);
         if (opts.verbose && opts.stdout) {
-          opts.stdout.write(msg.stream);
+          opts.stdout.write('  ' + msg.stream);
         }
         if (msg.statusParsed) {
           notify(msg);

--- a/src/images/index.js
+++ b/src/images/index.js
@@ -107,7 +107,12 @@ export class Image {
       var image = yield this.check();
       if (options.build_force || isBlank(image)) {
         notify({ type: 'action', context: 'image', action: 'build_image', data: this });
-        image = yield docker.build({ dockerfile: this.path, tag: this.name });
+        image = yield docker.build({
+                                    dockerfile: this.path,
+                                    tag: this.name,
+                                    verbose: options.provision_verbose,
+                                    stdout: options.stdout
+                                  });
       }
       return image;
     });


### PR DESCRIPTION
This closes this https://github.com/azukiapp/azk/issues/253;
You can test with verbose `-v` option enabled:

```
azk start -v --rebuild
```

![image](https://cloud.githubusercontent.com/assets/155953/6257950/75b7499a-b7ab-11e4-8a10-a0ac808e9364.png)

