### PR TITLE
[invalid vm action] Removing azk vm install command reference

### DIFF
--- a/docs/content/en/command-line/vm.md
+++ b/docs/content/en/command-line/vm.md
@@ -14,7 +14,7 @@ Checks if the virtual machine is installed.
 #### Example:
 
     $ azk vm installed
-    azk: virtual machine is not installed, try `azk vm install`.
+    azk: Virtual machine is not installed.
 
 _______________
 ### azk vm start

--- a/docs/content/pt-BR/command-line/vm.md
+++ b/docs/content/pt-BR/command-line/vm.md
@@ -14,7 +14,7 @@ Verifica se a máquina virtual está instalada.
 #### Exemplo:
 
     $ azk vm installed
-    azk: virtual machine is not installed, try `azk vm install`.
+    azk: Virtual machine is not installed.
 
 _______________
 ### azk vm start

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -441,7 +441,7 @@ module.exports = {
     vm: {
       description  : "Controls a virtual machine.",
       already_installed  : "Virtual machine already installed.",
-      not_installed: "Virtual machine is not installed, try `azk vm install`.",
+      not_installed: "Virtual machine is not installed.",
       running      : "Virtual machine running.",
       already_running : "Virtual machine already running.",
       not_running  : "Virtual machine is not running, try `azk vm start`.",


### PR DESCRIPTION
This closes #260.

There were only references to azk vm install in the documentation, and in the command line output.