### PR TITLE
Fixing parse a public port in Azkfile.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  * [Systems] Fixing parse a public port in Azkfile.js
+
 ## v0.10.0
 
 * Bug

--- a/spec/spec_helpers/mock_manifest.js
+++ b/spec/spec_helpers/mock_manifest.js
@@ -114,7 +114,7 @@ export function extend(h) {
           ports: {
             test_tcp: "80/tcp",
             test_udp: "53/udp",
-            test_public: "443:443/tcp",
+            test_public: "5252:443/tcp",
           },
         },
         'ports-disable': {

--- a/spec/system/index_spec.js
+++ b/spec/system/index_spec.js
@@ -157,7 +157,7 @@ describe("Azk system class, main set", function() {
           HostIp: config('agent:dns:ip')
         }]);
         h.expect(options).to.deep.have.property("ports.443/tcp").and.eql([{
-          HostIp: config('agent:dns:ip'), HostPort: "443"
+          HostIp: config('agent:dns:ip'), HostPort: "5252"
         }]);
       });
 

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -8,7 +8,7 @@ import { Balancer } from 'azk/system/balancer';
 
 var XRegExp = require('xregexp').XRegExp;
 var regex_port = new XRegExp(
-  "(?<private>[0-9]{1,})(:(?<public>[0-9]{1,})){0,1}(/(?<protocol>tcp|udp)){0,1}", "x"
+  "(?<public>[0-9]{1,})(:(?<private>[0-9]{1,})){0,1}(/(?<protocol>tcp|udp)){0,1}", "x"
 );
 
 export class System {
@@ -424,7 +424,12 @@ export class System {
 
       // TODO: Add support a bind ip
       var conf = { HostIp: config("agent:dns:ip") };
-      if (port.public) {
+      if (_.isEmpty(port.private)) {
+        port.private = port.public;
+        port.public  = null;
+      }
+
+      if (!_.isEmpty(port.public)) {
         conf.HostPort = port.public;
       }
 


### PR DESCRIPTION
This pull request closes #287 issue.

Before this fix `azk` was not parsing the port correctly. In an example like:

```js
ports: {
  http: "8080:80/tcp"
}
```

`8080` should be a "public" port, but it was a "private" port and `80` is a public port.