### PR TITLE
wait: timeout and retry defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  * [Cli] Fixing timeout errors to show default values on retry and timeout #288
+
 ## v0.10.0
 
 * Bug

--- a/src/system/run.js
+++ b/src/system/run.js
@@ -207,8 +207,8 @@ var Run = {
             Q(t('errors.run_timeout_error', {
               system: system.name,
               port: port_data && port_data.port,
-              retry: system.__options.wait && system.__options.wait.retry,
-              timeout: system.__options.wait && system.__options.wait.timeout,
+              retry: retry,
+              timeout: timeout,
               hostname: system.url.underline,
             }))
           );


### PR DESCRIPTION
#### Shows defaults values when `retry` or `timeout` are not informed.
![image](https://cloud.githubusercontent.com/assets/155953/6332625/6ca6d380-bb65-11e4-8ba6-c873b114072a.png)

this PR closes #288 
