### PR TITLE
[fix_dockerfile_build] Fixing Dockerfile not use relative to manifest dir. #250

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  - [Parse] Fixing running azk command in subfolder using dockfile, issue #250.
+
 * Enhancements
   * [code] Adding support to "integration testing"
 

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -163,7 +163,8 @@ module.exports = {
   manifest: {
     balancer_deprecated   : "The `balancer` option used in the `%(system)s` is deprecated, use `http` and `scalable` instead",
     cannot_extends_itself : "The system `%(system)s` cannot extend itself",
-    cannot_find_dockerfile: "Can't find `%(dockerfile)s` file to build an image for `%(system)s` system",
+    cannot_find_dockerfile: "Can't find Dockerfile in `%(dockerfile)s` path to build an image for `%(system)s` system",
+    cannot_find_dockerfile_path: "Can't find `%(dockerfile)s` path to build an image for `%(system)s` system",
     circular_dependency   : "Circular dependency between %(system1)s and %(system2)s",
     depends_not_declared  : "The `%(system)s` system depends on the `%(depend)s` system, which was not declared.",
     extends_system_invalid: "The system `%(system_source)s` for extending system `%(system_to_extend)s` cannot be found",
@@ -177,6 +178,7 @@ module.exports = {
     not_found             : "No such '%s' in current project",
     provider_invalid      : "The provider was not found: `%(wrongProvider)s`.",
     system_name_invalid   : "The system name `%(system)s` is not valid.",
+    required_path         : "Manifest class require a project path",
     validate: {
       deprecated : "The `%(option)s` used in `%(system)s` is deprecated, check the documentation for `%(new_option)s`",
       no_system_set: "No system has been set yet, check the documentation",

--- a/src/manifest/index.js
+++ b/src/manifest/index.js
@@ -67,7 +67,7 @@ export class Manifest {
     }
 
     if (required && !cwd) {
-      throw new Error("Manifest class require a project path");
+      throw new Error(t("manifest.required_path"));
     }
 
     this.images   = {};


### PR DESCRIPTION
This pull request:
 - closes #250 issue.
 - closes #302 issue.

![image](https://cloud.githubusercontent.com/assets/2034678/6569695/ce02ce40-c6cd-11e4-8597-1fd934e07972.png)


Test instructions:

- Download [azkfile-init-examples](https://github.com/azukiapp/azkfile-init-examples):

```sh
git clone https://github.com/azukiapp/azkfile-init-examples
```

- Create and go to subfolder in `dockerfile-example`:

```sh
mkdir -p azkfile-init-examples/dockerfile-example/teste
cd azkfile-init-examples/dockerfile-example/teste
```

- run azk start

```sh
azk start
```