### PR TITLE
pull progress bar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Enhancements
   * [code] Adding support to "integration testing"
-  * [Cli] New output when pulling images: show total count and size of layers to downloaded. Shows only a single progress bar with total download status. Integrate docker-registry-downloader with azk. #234 #119
+  * [Cli] New output when pulling images: show total layers count to download. Shows only a single progress bar with total download status. Integrate docker-registry-downloader with azk. #234 #119 #317
   * [Package] Adding update npm after install node
   * [Package] Fixing of usage npm-sheringwrap in package
 

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -336,7 +336,7 @@ module.exports = {
         pull_getLayersDiff : "⇲".blue    + " comparing registry layers and local layers...",
         pull_layers_left      : "⇲".blue    + " %(non_existent_locally_ids_count)s layers left to download.",
         pull_start         : "⇲".blue    + " pulling %(left_to_download_count)s/%(total_registry_layers)s layers.",
-        pull_ended         : "\n✓".blue    + " completed download of `" + "%(image)s".yellow + "`\n",
+        pull_ended         : "\n" + "✓".blue    + " completed download of `" + "%(image)s".yellow + "`\n",
         already_being      : "⇲".yellow  + " image already being pulled. Please wait...",
       }
     },

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -334,9 +334,9 @@ module.exports = {
         bar_progress       : '  :title [:bar] :percent :progress',
         bar_status         : '  :title :msg',
         pull_getLayersDiff : "⇲".blue    + " comparing registry layers and local layers...",
-        pull_getSizes      : "⇲".blue    + " %(non_existent_locally_ids_count)s layers left to download. Getting total size...",
-        pull_start         : "⇲".blue    + " pulling %(left_to_download_count)s/%(total_registry_layers)s layers. %(left_to_download_size)s left to download.",
-        pull_ended         : "✓".blue    + " completed download of `" + "%(image)s".yellow + "`\n",
+        pull_layers_left      : "⇲".blue    + " %(non_existent_locally_ids_count)s layers left to download.",
+        pull_start         : "⇲".blue    + " pulling %(left_to_download_count)s/%(total_registry_layers)s layers.",
+        pull_ended         : "\n✓".blue    + " completed download of `" + "%(image)s".yellow + "`\n",
         already_being      : "⇲".yellow  + " image already being pulled. Please wait...",
       }
     },

--- a/spec/cli/download_part_spec.js
+++ b/spec/cli/download_part_spec.js
@@ -3,12 +3,13 @@ import { DownloadPart } from 'azk/cli/download_part';
 
 describe('DownloadPart progressbar', function() {
 
-  var download_part, fake_progress_bar;
+  var download_part, tick_callback;
+  var total_ticks = 0;
 
-  fake_progress_bar = { total_ticks: 0 };
-  fake_progress_bar.tick = function(number) {
-    this.total_ticks += number;
+  tick_callback = function(number) {
+    total_ticks += number;
   };
+  total_ticks = 0;
 
   beforeEach(function () {
     var msg = {
@@ -18,8 +19,8 @@ describe('DownloadPart progressbar', function() {
         total  : 100
       }
     };
-    fake_progress_bar.total_ticks = 0;
-    download_part = new DownloadPart(msg, 5, fake_progress_bar);
+    total_ticks = 0;
+    download_part = new DownloadPart(msg, 5, tick_callback);
   });
 
   it('should DownloadPart be instantiated', function() {
@@ -36,39 +37,39 @@ describe('DownloadPart progressbar', function() {
 
   it('should call _progress_bar tick()', function() {
     download_part.update({ id: 'abcd', progressDetail: { current: 0, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(0);
+    h.expect(total_ticks).to.be.equal(0);
 
     download_part.update({ id: 'abcd', progressDetail: { current: 10, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(0.5);
+    h.expect(total_ticks).to.be.equal(0.5);
 
     download_part.update({ id: 'abcd', progressDetail: { current: 20, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(1);
+    h.expect(total_ticks).to.be.equal(1);
 
     download_part.update({ id: 'abcd', progressDetail: { current: 30, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(1.5);
+    h.expect(total_ticks).to.be.equal(1.5);
 
     download_part.update({ id: 'abcd', progressDetail: { current: 40, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(2);
+    h.expect(total_ticks).to.be.equal(2);
 
     download_part.update({ id: 'abcd', progressDetail: { current: 50, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(2.5);
+    h.expect(total_ticks).to.be.equal(2.5);
 
     download_part.update({ id: 'abcd', progressDetail: { current: 60, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(3);
+    h.expect(total_ticks).to.be.equal(3);
 
     download_part.update({ id: 'abcd', progressDetail: { current: 100, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(5);
+    h.expect(total_ticks).to.be.equal(5);
   });
 
   it('should call all ticks when download finished', function() {
     download_part.update({ id: 'abcd', progressDetail: { current: 0, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(0);
+    h.expect(total_ticks).to.be.equal(0);
 
     download_part.update({ id: 'abcd', progressDetail: { current: 40, total  : 100 } });
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(2);
+    h.expect(total_ticks).to.be.equal(2);
 
     download_part.setComplete();
-    h.expect(fake_progress_bar.total_ticks).to.be.equal(5);
+    h.expect(total_ticks).to.be.equal(5);
   });
 
 });

--- a/spec/cli/download_part_spec.js
+++ b/spec/cli/download_part_spec.js
@@ -1,0 +1,74 @@
+import h from 'spec/spec_helper';
+import { DownloadPart } from 'azk/cli/download_part';
+
+describe('DownloadPart progressbar', function() {
+
+  var download_part, fake_progress_bar;
+
+  fake_progress_bar = { total_ticks: 0 };
+  fake_progress_bar.tick = function(number) {
+    this.total_ticks += number;
+  };
+
+  beforeEach(function () {
+    var msg = {
+      id: 'abcd',
+      progressDetail: {
+        current: 10,
+        total  : 100
+      }
+    };
+    fake_progress_bar.total_ticks = 0;
+    download_part = new DownloadPart(msg, 5, fake_progress_bar);
+  });
+
+  it('should DownloadPart be instantiated', function() {
+    h.expect(download_part).to.not.be.undefined;
+  });
+
+  it('should have bars to spend', function() {
+    h.expect(download_part._representing_bars).to.be.equal(5);
+  });
+
+  it('should split total in equal parts', function() {
+    h.expect(download_part._part_size).to.be.equal(20);
+  });
+
+  it('should call _progress_bar tick()', function() {
+    download_part.update({ id: 'abcd', progressDetail: { current: 0, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(0);
+
+    download_part.update({ id: 'abcd', progressDetail: { current: 10, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(0.5);
+
+    download_part.update({ id: 'abcd', progressDetail: { current: 20, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(1);
+
+    download_part.update({ id: 'abcd', progressDetail: { current: 30, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(1.5);
+
+    download_part.update({ id: 'abcd', progressDetail: { current: 40, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(2);
+
+    download_part.update({ id: 'abcd', progressDetail: { current: 50, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(2.5);
+
+    download_part.update({ id: 'abcd', progressDetail: { current: 60, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(3);
+
+    download_part.update({ id: 'abcd', progressDetail: { current: 100, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(5);
+  });
+
+  it('should call all ticks when download finished', function() {
+    download_part.update({ id: 'abcd', progressDetail: { current: 0, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(0);
+
+    download_part.update({ id: 'abcd', progressDetail: { current: 40, total  : 100 } });
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(2);
+
+    download_part.setComplete();
+    h.expect(fake_progress_bar.total_ticks).to.be.equal(5);
+  });
+
+});

--- a/spec/cli/smart_progress_bar_spec.js
+++ b/spec/cli/smart_progress_bar_spec.js
@@ -1,0 +1,53 @@
+import h from 'spec/spec_helper';
+import { _ } from 'azk';
+import { SmartProgressBar } from 'azk/cli/smart_progress_bar';
+
+describe('SmartProgressBar', function() {
+
+  var smartProgressBar;
+
+  beforeEach(function () {
+    smartProgressBar = new SmartProgressBar();
+  });
+
+  it('should SmartProgressBar be instantiated', function() {
+    h.expect(smartProgressBar).to.not.be.undefined;
+  });
+
+  it('should has parts', function() {
+    h.expect(_.isArray(smartProgressBar._download_parts)).to.be.true;
+  });
+
+  it('should add and get a part', function() {
+    var msg = {
+      id            : 'abcd',
+      progressDetail: {
+        current: 200,
+        total  : 2000
+      }
+    };
+
+    smartProgressBar.addPart(msg);
+
+    var part1 = smartProgressBar.getPartById('abcd');
+    h.expect(part1.id).to.be.equal('abcd');
+    h.expect(part1.current_downloaded_size).to.be.equal(200);
+    h.expect(part1.total_downloaded_size).to.be.equal(2000);
+  });
+
+  it('should calculate percetage', function() {
+    var msg = {
+      id            : 'abcd',
+      progressDetail: {
+        current: 200,
+        total  : 2000
+      }
+    };
+
+    smartProgressBar.addPart(msg);
+
+    var download_part1 = smartProgressBar.getPartById('abcd');
+    h.expect(download_part1.getTotalPercentage()).to.be.equal(0.10);
+  });
+
+});

--- a/spec/cli/smart_progress_bar_spec.js
+++ b/spec/cli/smart_progress_bar_spec.js
@@ -7,32 +7,63 @@ describe('SmartProgressBar', function() {
   var smartProgressBar;
 
   beforeEach(function () {
-    smartProgressBar = new SmartProgressBar();
+    smartProgressBar = new SmartProgressBar(50, 10);
   });
 
   it('should SmartProgressBar be instantiated', function() {
     h.expect(smartProgressBar).to.not.be.undefined;
   });
 
-  it('should has parts', function() {
+  it('should have parts', function() {
     h.expect(_.isArray(smartProgressBar._download_parts)).to.be.true;
+  });
+
+  it('should have bars count', function() {
+    h.expect(_.isNumber(smartProgressBar._bar_count)).to.be.true;
+  });
+
+  it('should have layers count', function() {
+    h.expect(_.isNumber(smartProgressBar._layers_count)).to.be.true;
+  });
+
+  it('should calculate bars per layers', function() {
+    h.expect(smartProgressBar._bars_per_layers).to.be.equal(5);
+  });
+
+  it('should calculate percentage tick', function() {
+    h.expect(smartProgressBar._percentage_tick).to.be.equal(0.2);
   });
 
   it('should add and get a part', function() {
     var msg = {
-      id            : 'abcd',
+      id: 'abcd',
       progressDetail: {
         current: 200,
         total  : 2000
       }
     };
 
-    smartProgressBar.addPart(msg);
+    smartProgressBar.receiveMessage(msg);
 
-    var part1 = smartProgressBar.getPartById('abcd');
+    var part1 = smartProgressBar.getPart(msg);
     h.expect(part1.id).to.be.equal('abcd');
     h.expect(part1.current_downloaded_size).to.be.equal(200);
     h.expect(part1.total_downloaded_size).to.be.equal(2000);
+  });
+
+  it('should calculate percetage', function() {
+    var msg = {
+      id: 'abcd',
+      progressDetail: {
+        current: 200,
+        total  : 2000
+      }
+    };
+
+    smartProgressBar.receiveMessage(msg);
+
+    var download_part1 = smartProgressBar.getPart(msg);
+    h.expect(download_part1.getTotalPercentage()).to.be.equal(0.10);
   });
 
   it('should calculate percetage', function() {
@@ -44,10 +75,32 @@ describe('SmartProgressBar', function() {
       }
     };
 
-    smartProgressBar.addPart(msg);
+    smartProgressBar.receiveMessage(msg);
 
-    var download_part1 = smartProgressBar.getPartById('abcd');
+    var download_part1 = smartProgressBar.getPart(msg);
     h.expect(download_part1.getTotalPercentage()).to.be.equal(0.10);
   });
+
+  it('should update downloaded_part when receives same message', function() {
+    var msg = { id: 'abcd', progressDetail: { current: 200, total  : 2000 } };
+    smartProgressBar.receiveMessage(msg);
+    h.expect(smartProgressBar.getPart(msg).current_downloaded_size)
+      .to.be.equal(200);
+
+    msg = { id: 'abcd', progressDetail: { current: 300, total  : 2000 } };
+    smartProgressBar.receiveMessage(msg);
+    h.expect(smartProgressBar.getPart(msg).current_downloaded_size)
+      .to.be.equal(300);
+
+  });
+
+  // it('should emit a tick when _percentage_tick is reach', function() {
+  //   var msg = { id: 'abcd', progressDetail: { current: 200, total  : 2000 } };
+
+  //   smartProgressBar.receiveMessage(msg);
+
+  //   var download_part1 = smartProgressBar.getPart(msg);
+  //   h.expect(download_part1.getTotalPercentage()).to.be.equal(0.10);
+  // });
 
 });

--- a/spec/cli/smart_progress_bar_spec.js
+++ b/spec/cli/smart_progress_bar_spec.js
@@ -2,12 +2,17 @@ import h from 'spec/spec_helper';
 import { _ } from 'azk';
 import { SmartProgressBar } from 'azk/cli/smart_progress_bar';
 
-describe('SmartProgressBar', function() {
+describe('SmartProgressBar progressbar', function() {
 
-  var smartProgressBar;
+  var smartProgressBar, fake_progress_bar;
 
   beforeEach(function () {
-    smartProgressBar = new SmartProgressBar(50, 10);
+    fake_progress_bar = { total_ticks: 0 };
+    fake_progress_bar.tick = function(number) {
+      this.total_ticks += number;
+    };
+
+    smartProgressBar = new SmartProgressBar(50, 10, fake_progress_bar);
   });
 
   it('should SmartProgressBar be instantiated', function() {
@@ -91,16 +96,6 @@ describe('SmartProgressBar', function() {
     smartProgressBar.receiveMessage(msg);
     h.expect(smartProgressBar.getPart(msg).current_downloaded_size)
       .to.be.equal(300);
-
   });
-
-  // it('should emit a tick when _percentage_tick is reach', function() {
-  //   var msg = { id: 'abcd', progressDetail: { current: 200, total  : 2000 } };
-
-  //   smartProgressBar.receiveMessage(msg);
-
-  //   var download_part1 = smartProgressBar.getPart(msg);
-  //   h.expect(download_part1.getTotalPercentage()).to.be.equal(0.10);
-  // });
 
 });

--- a/spec/cli/smart_progress_bar_spec.js
+++ b/spec/cli/smart_progress_bar_spec.js
@@ -48,7 +48,7 @@ describe('SmartProgressBar progressbar', function() {
       }
     };
 
-    smartProgressBar.receiveMessage(msg);
+    smartProgressBar.receiveMessage(msg, 'download');
 
     var part1 = smartProgressBar.getPart(msg);
     h.expect(part1.id).to.be.equal('abcd');
@@ -65,7 +65,7 @@ describe('SmartProgressBar progressbar', function() {
       }
     };
 
-    smartProgressBar.receiveMessage(msg);
+    smartProgressBar.receiveMessage(msg, 'download');
 
     var download_part1 = smartProgressBar.getPart(msg);
     h.expect(download_part1.getTotalPercentage()).to.be.equal(0.10);
@@ -80,7 +80,7 @@ describe('SmartProgressBar progressbar', function() {
       }
     };
 
-    smartProgressBar.receiveMessage(msg);
+    smartProgressBar.receiveMessage(msg, 'download');
 
     var download_part1 = smartProgressBar.getPart(msg);
     h.expect(download_part1.getTotalPercentage()).to.be.equal(0.10);
@@ -88,12 +88,12 @@ describe('SmartProgressBar progressbar', function() {
 
   it('should update downloaded_part when receives same message', function() {
     var msg = { id: 'abcd', progressDetail: { current: 200, total  : 2000 } };
-    smartProgressBar.receiveMessage(msg);
+    smartProgressBar.receiveMessage(msg, 'download');
     h.expect(smartProgressBar.getPart(msg).current_downloaded_size)
       .to.be.equal(200);
 
     msg = { id: 'abcd', progressDetail: { current: 300, total  : 2000 } };
-    smartProgressBar.receiveMessage(msg);
+    smartProgressBar.receiveMessage(msg, 'download');
     h.expect(smartProgressBar.getPart(msg).current_downloaded_size)
       .to.be.equal(300);
   });

--- a/src/cli/download_part.js
+++ b/src/cli/download_part.js
@@ -1,0 +1,45 @@
+// import { _ } from 'azk';
+
+export class DownloadPart {
+  constructor(msg, representing_bars, progress_bar) {
+    // set progress bar link
+    this._progress_bar         = progress_bar;
+
+    // get info from docker remote message
+    this.id                    = msg.id;
+    this.total_downloaded_size = msg.progressDetail.total;
+
+    // associate with progress bar
+    this._representing_bars    = representing_bars;
+    this._part_size            = this._calculate_part_size();
+    this._last_tick_current    = 0;
+
+    // get current size from message
+    this.update(msg);
+  }
+
+  getTotalPercentage() {
+    return this.current_downloaded_size / this.total_downloaded_size;
+  }
+
+  update(msg) {
+    this.current_downloaded_size = msg.progressDetail.current;
+
+    var current_after_last_tick = this.current_downloaded_size - this._last_tick_current;
+    var ticks_to_be_called = current_after_last_tick / this._part_size;
+    this._progress_bar.tick(ticks_to_be_called);
+    this._last_tick_current = this.current_downloaded_size;
+  }
+
+  setComplete() {
+    this.update({
+      progressDetail: {
+        current: this.total_downloaded_size
+      }
+    });
+  }
+
+  _calculate_part_size() {
+    return this.total_downloaded_size / this._representing_bars;
+  }
+}

--- a/src/cli/download_part.js
+++ b/src/cli/download_part.js
@@ -1,4 +1,4 @@
-// import { _ } from 'azk';
+import { log } from 'azk';
 
 export class DownloadPart {
   constructor(msg, representing_bars, progress_bar) {
@@ -16,6 +16,8 @@ export class DownloadPart {
 
     // get current size from message
     this.update(msg);
+
+    log.debug('\n>>---------\n DownloadPart:', this, '\n>>---------\n');
   }
 
   getTotalPercentage() {
@@ -23,11 +25,19 @@ export class DownloadPart {
   }
 
   update(msg) {
+    var current_after_last_tick, ticks_to_be_called;
+
+    // get current size from progressDetail docker remote message
     this.current_downloaded_size = msg.progressDetail.current;
 
-    var current_after_last_tick = this.current_downloaded_size - this._last_tick_current;
-    var ticks_to_be_called = current_after_last_tick / this._part_size;
+    // current chunk
+    current_after_last_tick = this.current_downloaded_size - this._last_tick_current;
+
+    // calculate percentual bar tick
+    ticks_to_be_called = current_after_last_tick / this._part_size;
     this._progress_bar.tick(ticks_to_be_called);
+
+    // save _last_tick_current to get chunk on next round
     this._last_tick_current = this.current_downloaded_size;
   }
 

--- a/src/cli/download_part.js
+++ b/src/cli/download_part.js
@@ -1,9 +1,9 @@
 import { log } from 'azk';
 
 export class DownloadPart {
-  constructor(msg, representing_bars, progress_bar) {
+  constructor(msg, representing_bars, tick_calback) {
     // set progress bar link
-    this._progress_bar         = progress_bar;
+    this._tick_calback         = tick_calback;
 
     // get info from docker remote message
     this.id                    = msg.id;
@@ -35,7 +35,7 @@ export class DownloadPart {
 
     // calculate percentual bar tick
     ticks_to_be_called = current_after_last_tick / this._part_size;
-    this._progress_bar.tick(ticks_to_be_called);
+    this._tick_calback(ticks_to_be_called);
 
     // save _last_tick_current to get chunk on next round
     this._last_tick_current = this.current_downloaded_size;

--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -118,8 +118,8 @@ var Helpers = {
         return false;
       }
 
-      if (!this.last_download_current) {
-        this.last_download_current = {};
+      if (!_.isNumber(this.non_existent_locally_ids_count)) {
+        this.non_existent_locally_ids_count = msg.registry_result.non_existent_locally_ids_count;
       }
 
       // parse messages by type
@@ -138,7 +138,7 @@ var Helpers = {
             });
 
             // create a new progress-bar
-            this.bar = cmd.createProgressBar('     [:bar] :percent  ', {
+            this.bar = cmd.createProgressBar('     [:bar] :percent :layers_left/:layers_total ', {
               complete: '=',
               incomplete: ' ',
               width: 50,
@@ -148,7 +148,7 @@ var Helpers = {
             // control progress-bar with SmartProgressBar
             this.smartProgressBar = new SmartProgressBar(
               50,
-              msg.registry_result.non_existent_locally_ids_count,
+              this.non_existent_locally_ids_count,
               this.bar);
           }
           this.smartProgressBar.receiveMessage(msg, status.type);

--- a/src/cli/smart_progress_bar.js
+++ b/src/cli/smart_progress_bar.js
@@ -1,35 +1,53 @@
 import { _ } from 'azk';
-
 // var ProgressBar = require('progress');
 
 class DownloadPart {
-  constructor(id, current_downloaded_size, total_downloaded_size) {
-    this.id = id;
-    this.current_downloaded_size = current_downloaded_size;
-    this.total_downloaded_size = total_downloaded_size;
+  constructor(msg) {
+    this.id = msg.id;
+    this.current_downloaded_size = msg.progressDetail.current;
+    this.total_downloaded_size = msg.progressDetail.total;
   }
 
   getTotalPercentage() {
     return this.current_downloaded_size / this.total_downloaded_size;
   }
+
+  update(msg) {
+    this.current_downloaded_size = msg.progressDetail.current;
+  }
 }
 
-// TODO: Implement tests
 export class SmartProgressBar {
 
-  constructor() {
+  constructor(bar_count, layers_count) {
     this._download_parts = [];
+    this._bar_count = bar_count;
+    this._layers_count = layers_count;
+    this._bars_per_layers = this._calculate_bars_per_layers();
+    this._percentage_tick = this._calculate_percentage_tick();
   }
 
-  addPart(msg) {
-    var downloadPart = new DownloadPart(msg.id, msg.progressDetail.current, msg.progressDetail.total);
-
-    this._download_parts.push(downloadPart);
+  _calculate_bars_per_layers() {
+    return this._bar_count / this._layers_count;
   }
 
-  getPartById(id) {
+  _calculate_percentage_tick() {
+    return 1.0 / this._bars_per_layers;
+  }
+
+  receiveMessage(msg) {
+    var current_download_part = this.getPart(msg);
+    if (!current_download_part) {
+      var downloadPart = new DownloadPart(msg);
+      this._download_parts.push(downloadPart);
+    } else {
+      current_download_part.update(msg);
+    }
+  }
+
+  getPart(msg) {
     return _.find(this._download_parts, function(part) {
-      return part.id === id;
+      return part.id === msg.id;
     });
   }
 

--- a/src/cli/smart_progress_bar.js
+++ b/src/cli/smart_progress_bar.js
@@ -1,4 +1,4 @@
-import { _ } from 'azk';
+import { _, log } from 'azk';
 import { DownloadPart } from 'azk/cli/download_part';
 // var ProgressBar = require('progress');
 
@@ -18,6 +18,8 @@ export class SmartProgressBar {
     this._layers_count = layers_count;
     this._bars_per_layers = this._calculate_bars_per_layers();
     this._percentage_tick = this._calculate_percentage_tick();
+
+    log.debug('\n>>---------\n SmartProgressBar:', this, '\n>>---------\n');
   }
 
   _calculate_bars_per_layers() {
@@ -30,6 +32,11 @@ export class SmartProgressBar {
 
   receiveMessage(msg, msg_type) {
     var current_download_part = this.getPart(msg);
+
+    if (msg_type === 'download_complete') {
+      return current_download_part.setComplete();
+    }
+
     if (!current_download_part) {
       var downloadPart = new DownloadPart(msg, this._bars_per_layers, this._progress_bar);
       this._download_parts.push(downloadPart);
@@ -37,9 +44,6 @@ export class SmartProgressBar {
       current_download_part.update(msg);
     }
 
-    if (msg_type === 'download_complete') {
-      current_download_part.setComplete();
-    }
   }
 
   getPart(msg) {

--- a/src/cli/smart_progress_bar.js
+++ b/src/cli/smart_progress_bar.js
@@ -1,0 +1,36 @@
+import { _ } from 'azk';
+
+// var ProgressBar = require('progress');
+
+class DownloadPart {
+  constructor(id, current_downloaded_size, total_downloaded_size) {
+    this.id = id;
+    this.current_downloaded_size = current_downloaded_size;
+    this.total_downloaded_size = total_downloaded_size;
+  }
+
+  getTotalPercentage() {
+    return this.current_downloaded_size / this.total_downloaded_size;
+  }
+}
+
+// TODO: Implement tests
+export class SmartProgressBar {
+
+  constructor() {
+    this._download_parts = [];
+  }
+
+  addPart(msg) {
+    var downloadPart = new DownloadPart(msg.id, msg.progressDetail.current, msg.progressDetail.total);
+
+    this._download_parts.push(downloadPart);
+  }
+
+  getPartById(id) {
+    return _.find(this._download_parts, function(part) {
+      return part.id === id;
+    });
+  }
+
+}

--- a/src/images/index.js
+++ b/src/images/index.js
@@ -137,14 +137,6 @@ export class Image {
         registry_layers_ids_count      : registry_layers_ids.length,
         non_existent_locally_ids_count : non_existent_locally_ids.length
       };
-
-      notify({  type       : "pull_msg",
-                traslation : "commands.helpers.pull.pull_getSizes",
-                data       : registry_infos });
-
-      var total_layer_size_left = yield syncronizer.getSizes(hubResult, non_existent_locally_ids);
-      registry_infos.total_layer_size_left = total_layer_size_left;
-
       return registry_infos;
     });
   }


### PR DESCRIPTION
As we do not know exactly the size to be downloaded, I've created the classes below to control the progress bar. It is based on the number of layers that will be downloaded. Each block is updated according to the progress of each layer.

#### DownloadPart

file: cli/download_part.js

Is a download block. Receives the status message docker remote and sends the tick to the progress bar.

#### SmartProgressBar

file: cli/smart_progress_bar.js

Manages a progress bar without knowing total size previously

#### output example 

```
$ azk start python34

azk: ↑ starting `python34` system, 2 new instances...
azk: ✓ checking `azukiapp/python:3.4` image...
azk: ⇲ downloading `azukiapp/python:3.4` image...
azk: ⇲ comparing registry layers and local layers...
azk: ⇲ pulling 11/29 layers.
     [============================================     ] 91% 10/11 
azk: ✓ completed download of `azukiapp/python:3.4`
```

### how to test

```sh
# run progressbar tests
$ azk nvm grunt --grep='progressbar'

# download images
$ adocker rmi -f saitodisse/10mblayers; azk shell -i saitodisse/10mblayers
$ adocker rmi -f mongo; azk shell -i mongo
```

This closes #234, closes #119 and closes #317;