### PR TITLE
[offline_start_agent] Correcting dns_servers when you can not read `/etc/resolv.conf`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  * [Agent] Fixing agent does not start when not connected to internet. #312
+
 * Enhancements
   * [code] Adding support to "integration testing"
   * [Cli] New output when pulling images: show total count and size of layers to downloaded. Shows only a single progress bar with total download status. Integrate docker-registry-downloader with azk. #234 #119

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Bug
   * [Agent] Fixing agent does not start when not connected to internet. #312
+  * [Cli] Checking namservers every time you start a container.
 
 * Enhancements
   * [code] Adding support to "integration testing"

--- a/spec/fixtures/etc/resolv.conf
+++ b/spec/fixtures/etc/resolv.conf
@@ -1,0 +1,2 @@
+nameserver 189.38.95.95
+nameserver 189.38.95.96

--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -392,6 +392,8 @@ export class Configure extends UIProxy {
 
   _readResolverFile() {
     var file = "/etc/resolv.conf";
-    return qfs.read(file).then(this._parseNameserver);
+    return qfs.read(file)
+      .then(this._parseNameserver)
+      .fail(() => { return []; });
   }
 }

--- a/src/config.js
+++ b/src/config.js
@@ -25,11 +25,6 @@ var paths = {
   vm  : path.join(data_path, 'vm'),
 };
 
-var dns_nameservers = function(key, defaultValue) {
-  var value = envs(key);
-  return _.isEmpty(value) ? defaultValue : _.invoke(value.split(','), 'trim');
-};
-
 class Dynamic {
   constructor(key) { this.key = key; }
 }
@@ -93,8 +88,9 @@ var options = mergeConfig({
       dns: {
         ip  : new Dynamic("agent:dns:ip"),
         port: envs('AZK_DNS_PORT', '53'),
-        nameservers  : dns_nameservers('AZK_DNS_SERVERS', []),
-        defaultserver: dns_nameservers('AZK_DNS_SERVERS_DEFAULTS', ['8.8.8.8', '8.8.4.4']),
+        global: [],
+        nameservers  : [],
+        defaultserver: ['8.8.8.8', '8.8.4.4'],
       },
       vm: {
         wait_ready : 180000,

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -18,7 +18,9 @@ var Utils = {
   get docker() {  return require('azk/utils/docker').default; },
 
   envs(key, defaultValue = null) {
-    return process.env[key] || (_.isFunction(defaultValue) ? defaultValue() : defaultValue);
+    var value = process.env[key];
+    if (value === 'undefined') { value = undefined; }
+    return value || (_.isFunction(defaultValue) ? defaultValue() : defaultValue);
   },
 
   mergeConfig(options) {
@@ -168,10 +170,15 @@ var Utils = {
     return _.template(template_string, data, options);
   },
 
-  isBlank (obj) {
+  isBlank(obj) {
     return _.isNull(obj) ||
            _.isUndefined(obj) ||
            obj === false;
+  },
+
+  envDefaultArray(key, defaultValue) {
+    var value = Utils.envs(key);
+    return (!value || _.isEmpty(value)) ? defaultValue : _.invoke(value.split(','), 'trim');
   }
 };
 

--- a/src/utils/net.js
+++ b/src/utils/net.js
@@ -83,8 +83,12 @@ var net = {
   _readResolverFile(file = "/etc/resolv.conf") {
     var data;
     if (file) {
-      data = fs.readFileSync(file).toString();
-      data = this.parseNameserver(data);
+      try {
+        data = fs.readFileSync(file).toString();
+        data = this.parseNameserver(data);
+      } catch (err) {
+        data = null;
+      }
     }
     return data ? data : [];
   },


### PR DESCRIPTION
This pull request closes #312 and closes #319 issue.

This feature, besides correcting the start problem of the agent of `azk` when not connected to the internet, brings improvements in the way the nameservers of the containers are resolved. If you change your network, you no longer have to restart the agent, just restart the containers.