### PR TITLE
Several improvements related to virtual machine and the agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,24 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  * [agent] Adding support to swap in order to stand heavy load memory cases;
+  * [agent] Changing dhcp-client configs (adding timeout) in order to avoid network-dependent services tree to fail;
+  * [agent] Making VirtualBox data disk deattach/remove process more reliable;
+  * [agent] Now `azk agent stop` waits for agent real stop;
+
 * Enhancements
   * [code] Adding support to "integration testing"
   * [Cli] New output when pulling images: show total layers count to download. Shows only a single progress bar with total download status. Integrate docker-registry-downloader with azk. #234 #119 #317
   * [Package] Adding update npm after install node
   * [Package] Fixing of usage npm-sheringwrap in package
+  * [code] Adding support to "integration testing";
+  * [Cli] New output when pulling images: show total count and size of layers to downloaded. Shows only a single progress bar with total download status. Integrate docker-registry-downloader with azk. #234 #119;
+  * [Package] Adding update npm after install node;
+  * [Package] Fixing of usage npm-sheringwrap in package;
+  * [agent] Using VM static ip (set via guestproperty) instead of VirtualBox DHCP servers;
+  * [agent] Adding verification of ip conflicts with existent networks interfaces;
+  * [agent] Suggesting an altertive ip in case of a conflict;
 
 ## v0.10.2 - (2015-24-02)
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -261,93 +261,94 @@
     "docker-registry-downloader": {
       "version": "0.1.33",
       "from": "docker-registry-downloader@0.1.33",
+      "resolved": "https://registry.npmjs.org/docker-registry-downloader/-/docker-registry-downloader-0.1.33.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.0",
-          "from": "async@>=0.9.0 <0.10.0",
+          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
           "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
         },
         "cli-color": {
           "version": "0.3.2",
-          "from": "cli-color@>=0.3.2 <0.4.0",
+          "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.2.tgz",
           "dependencies": {
             "d": {
               "version": "0.1.1",
-              "from": "d@>=0.1.1 <0.2.0",
+              "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
             },
             "es5-ext": {
               "version": "0.10.6",
-              "from": "es5-ext@>=0.10.2 <0.11.0",
+              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
               "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
               "dependencies": {
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "es6-iterator@>=0.1.3 <0.2.0",
+                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                 },
                 "es6-symbol": {
                   "version": "2.0.1",
-                  "from": "es6-symbol@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                 }
               }
             },
             "memoizee": {
               "version": "0.3.8",
-              "from": "memoizee@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
               "dependencies": {
                 "es6-weak-map": {
                   "version": "0.1.2",
-                  "from": "es6-weak-map@>=0.1.2 <0.2.0",
+                  "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.2.tgz",
                   "dependencies": {
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "es6-iterator@>=0.1.3 <0.2.0",
+                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
                       "dependencies": {
                         "es6-symbol": {
                           "version": "2.0.1",
-                          "from": "es6-symbol@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                         }
                       }
                     },
                     "es6-symbol": {
                       "version": "0.1.1",
-                      "from": "es6-symbol@>=0.1.0 <0.2.0",
+                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-0.1.1.tgz"
                     }
                   }
                 },
                 "event-emitter": {
                   "version": "0.3.3",
-                  "from": "event-emitter@>=0.3.1 <0.4.0",
+                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                 },
                 "lru-queue": {
                   "version": "0.1.0",
-                  "from": "lru-queue@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                 },
                 "next-tick": {
                   "version": "0.2.2",
-                  "from": "next-tick@>=0.2.2 <0.3.0",
+                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                 }
               }
             },
             "timers-ext": {
               "version": "0.1.0",
-              "from": "timers-ext@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
               "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
               "dependencies": {
                 "next-tick": {
                   "version": "0.2.2",
-                  "from": "next-tick@>=0.2.2 <0.3.0",
+                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                 }
               }
@@ -356,54 +357,54 @@
         },
         "indent-string": {
           "version": "1.2.1",
-          "from": "indent-string@>=1.2.0 <2.0.0",
+          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
+              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "minimist": {
               "version": "1.1.0",
-              "from": "minimist@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.0.tgz"
             },
             "repeating": {
               "version": "1.1.2",
-              "from": "repeating@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
               "dependencies": {
                 "is-finite": {
                   "version": "1.0.0",
-                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
                 },
                 "meow": {
                   "version": "3.1.0",
-                  "from": "meow@>=3.0.0 <4.0.0",
+                  "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.0.2",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.0",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
                         }
                       }
                     },
                     "object-assign": {
                       "version": "2.0.0",
-                      "from": "object-assign@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                     }
                   }
@@ -412,36 +413,24 @@
             }
           }
         },
-        "pretty-bytes": {
-          "version": "1.0.3",
-          "from": "pretty-bytes@>=1.0.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.3.tgz",
-          "dependencies": {
-            "get-stdin": {
-              "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
-            }
-          }
-        },
         "progress": {
           "version": "1.1.8",
-          "from": "progress@>=1.1.8 <2.0.0",
+          "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
           "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
         },
         "requestretry": {
           "version": "1.2.2",
-          "from": "requestretry@>=1.2.2 <2.0.0",
+          "from": "https://registry.npmjs.org/requestretry/-/requestretry-1.2.2.tgz",
           "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.2.2.tgz",
           "dependencies": {
             "fg-lodash": {
               "version": "0.0.2",
-              "from": "fg-lodash@0.0.2",
+              "from": "https://registry.npmjs.org/fg-lodash/-/fg-lodash-0.0.2.tgz",
               "resolved": "https://registry.npmjs.org/fg-lodash/-/fg-lodash-0.0.2.tgz",
               "dependencies": {
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "underscore.string@>=2.3.3 <2.4.0",
+                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
                 }
               }
@@ -450,49 +439,49 @@
         },
         "rimraf": {
           "version": "2.3.0",
-          "from": "rimraf@>=2.2.8 <3.0.0",
+          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.0.tgz",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.0.tgz",
           "dependencies": {
             "glob": {
               "version": "4.4.1",
-              "from": "glob@>=4.4.1 <5.0.0",
+              "from": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.4.1.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "inflight@>=1.0.4 <2.0.0",
+                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
                   "version": "2.0.1",
-                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.1.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "brace-expansion@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "balanced-match@>=0.2.0 <0.3.0",
+                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "concat-map@0.0.1",
+                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -501,12 +490,12 @@
                 },
                 "once": {
                   "version": "1.3.1",
-                  "from": "once@>=1.3.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "wrappy@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -517,166 +506,166 @@
         },
         "tar-pack": {
           "version": "2.0.0",
-          "from": "tar-pack@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
           "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
           "dependencies": {
             "uid-number": {
               "version": "0.0.3",
-              "from": "uid-number@0.0.3",
+              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
             },
             "once": {
               "version": "1.1.1",
-              "from": "once@>=1.1.1 <1.2.0",
+              "from": "https://registry.npmjs.org/once/-/once-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
             },
             "debug": {
               "version": "0.7.4",
-              "from": "debug@>=0.7.2 <0.8.0",
+              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "rimraf@>=2.2.0 <2.3.0",
+              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "fstream": {
               "version": "0.1.31",
-              "from": "fstream@>=0.1.22 <0.2.0",
+              "from": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
               "dependencies": {
                 "graceful-fs": {
                   "version": "3.0.5",
-                  "from": "graceful-fs@>=3.0.2 <3.1.0",
+                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz",
                   "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.5.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "tar": {
               "version": "0.1.20",
-              "from": "tar@>=0.1.17 <0.2.0",
+              "from": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
               "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
               "dependencies": {
                 "block-stream": {
                   "version": "0.0.7",
-                  "from": "block-stream@*",
+                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz",
                   "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "fstream-ignore": {
               "version": "0.0.7",
-              "from": "fstream-ignore@0.0.7",
+              "from": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
               "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "minimatch@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
                       "version": "2.5.0",
-                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz",
                       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.0.tgz"
                     },
                     "sigmund": {
                       "version": "1.0.0",
-                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.0 <3.0.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "graceful-fs@>=1.2.0 <1.3.0",
+              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             }
           }
         },
         "winston": {
           "version": "0.8.3",
-          "from": "winston@>=0.8.3 <0.9.0",
+          "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "cycle": {
               "version": "1.0.3",
-              "from": "cycle@>=1.0.0 <1.1.0",
+              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "isstream": {
               "version": "0.1.1",
-              "from": "isstream@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.1.tgz"
             },
             "pkginfo": {
               "version": "0.3.0",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
+              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.0 <0.1.0",
+              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
         },
         "yargs": {
           "version": "1.3.3",
-          "from": "yargs@>=1.3.3 <2.0.0",
+          "from": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
         }
       }
@@ -1182,7 +1171,7 @@
     },
     "fscache": {
       "version": "0.0.1",
-      "from": "../../../../../var/folders/r8/2t6q8xwd35d4r9nrfsrkwk8m0000gn/T/npm-4302-b32e8b79/git-cache-ffe7b84ca9d4/a23a28d453628e081ac71a6ceca1fbf2a94d485c",
+      "from": "../../../../../var/folders/r8/2t6q8xwd35d4r9nrfsrkwk8m0000gn/T/npm-70847-142b5c2e/git-cache-b9209e6353d8/a23a28d453628e081ac71a6ceca1fbf2a94d485c",
       "resolved": "git+https://github.com/nuxlli/fscache#a23a28d453628e081ac71a6ceca1fbf2a94d485c",
       "dependencies": {
         "async": {
@@ -3110,6 +3099,11 @@
       "from": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.9.0.tgz"
     },
+    "netmask": {
+      "version": "1.0.5",
+      "from": "netmask@*",
+      "resolved": "https://registry.npmjs.org/netmask/-/netmask-1.0.5.tgz"
+    },
     "node-uuid": {
       "version": "1.4.2",
       "from": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.2.tgz",
@@ -3139,12 +3133,12 @@
     },
     "pretty-bytes": {
       "version": "1.0.3",
-      "from": "pretty-bytes@*",
+      "from": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.3.tgz",
       "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-1.0.3.tgz",
       "dependencies": {
         "get-stdin": {
           "version": "4.0.1",
-          "from": "get-stdin@>=4.0.1 <5.0.0",
+          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "memorystream": "^0.2.0",
     "mkdirp": "^0.5.0",
     "moment": "^2.8.1",
+    "netmask": "^1.0.5",
     "node-uuid": "^1.4.1",
     "open": "0.0.5",
     "parentpath": "^0.2.0",

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -14,6 +14,7 @@ module.exports = {
     connect_docker_unavailable: "Could not initialize balancer because docker was not available",
     agent_not_running: "azk agent is required but is not running (try `azk agent status`)",
     agent_start: "azk agent start error: %(error)s",
+    agent_stop:  "azk agent stop error (try `azk agent status`)",
     not_been_implemented: "This feature: `%(feature)s` has not been implemented yet",
     system_not_found: "System `%(system)s` not found in `%(manifest)s`",
     manifest_required: "Manifest is required, but was not found in `%(cwd)s`",

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -192,8 +192,6 @@ module.exports = {
     loaded: "Settings loaded successfully.",
     loading_checking: "Loading settings and checking dependencies.",
     ip_question: "Enter the vm ip",
-    ip_invalid: "`%(ip)s`".yellow + " is an invalid v4 ip, try again.",
-    ip_invalid_range: "`%(ip)s`".yellow + " is an invalid ip range, try again.",
     adding_ip: "Adding %(ip)s to %(file)s ...",
     generating_key: "Generating public/private rsa key pair to connect to vm.\n",
     vm_ip_msg: ([
@@ -209,11 +207,18 @@ module.exports = {
     check_version_error: 'Checking version: [ %(error_message)s ]!',
     clean_containers: "Clearing %(count)d lost containers",
     migrations: {
-      alert: "azk updated, checking update procedures...",
-      changing_domain: "Changing domain upgrading, (issue: #255)",
-      moving_resolver: "Moving %(origin)s to %(target)s ...",
-      renaming_vm: "Renaming VirtualBox machine %(old_name)s to %(new_name)s",
-    }
+      alert             : "azk updated, checking update procedures...",
+      changing_domain   : "Changing domain upgrading, (issue: #255)",
+      moving_resolver   : "Moving %(origin)s to %(target)s ...",
+      renaming_vm       : "Renaming VirtualBox machine %(old_name)s to %(new_name)s",
+    },
+    find_suggestions_ips: "Suggesting a new ip...",
+    errors: {
+      invalid_current_ip: 'Current ip `%(ip)s` conflict with network interface `%(inter_name)s inet %(inter_ip)s`',
+      ip_invalid : "`%(ip)s`".yellow + " is an invalid v4 ip, try again.",
+      ip_loopback: "`%(ip)s`".yellow + " conflict with loopback network",
+      ip_conflict: "`%(ip)s`".yellow + " conflict with network interface `%(inter_name)s inet %(inter_ip)s`",
+    },
   },
 
   commands: {

--- a/spec/agent/vm_spec.js
+++ b/spec/agent/vm_spec.js
@@ -1,6 +1,7 @@
 import h from 'spec/spec_helper';
 import { _, async, path, Q, config } from 'azk';
 import { VM, dhcp, hostonly } from 'azk/agent/vm';
+import { net } from 'azk/utils';
 
 var qfs  = require('q-io/fs');
 var os   = require('os');
@@ -16,6 +17,13 @@ h.describeSkipVm("Azk agent vm", function() {
     ip  : "192.168.51.4",
     boot: config("agent:vm:boot_disk"),
     data: data_test,
+  };
+
+  var net_opts = {
+    ip: opts.ip,
+    gateway: net.calculateGatewayIp(opts.ip),
+    network: net.calculateNetIp(opts.ip),
+    netmask: "255.255.255.0",
   };
 
   // Setups
@@ -44,20 +52,30 @@ h.describeSkipVm("Azk agent vm", function() {
   });
 
   describe("with have a vm", function() {
-    var install_vm = () => {
-      return async(this, function *() {
-        if (this.timeout) {
-          this.timeout(0);
-        }
-        yield remove.apply(this);
-        return h.expect(VM.init(opts)).to.eventually.fulfilled;
-      });
+    var aux_tools = {
+      install_vm(options = {}) {
+        options = _.merge({}, opts, options);
+        return async(this, function *() {
+          if (this.timeout) { this.timeout(0); }
+          yield remove.apply(this);
+          return h.expect(VM.init(options)).to.eventually.fulfilled;
+        });
+      },
+      netinfo() {
+        return Q.all([hostonly.list(), dhcp.list_servers()]);
+      },
+      filter_dhcp(list, VBoxNetworkName) {
+        return _.find(list, (server) => server.NetworkName == VBoxNetworkName);
+      },
+      filter_hostonly(list, name) {
+        return _.find(list, (net) => net.Name == name);
+      },
     };
 
     describe("and have a info about vm", function() {
       // Install vm and save state
       var info = {};
-      before(() => { return install_vm().then((i => info = i)); });
+      before(() => { return aux_tools.install_vm.apply(this).then((i => info = i)); });
 
       it("should configure cpus", function() {
         h.expect(info).has.property("ostype").and.match(/Linux.*64/);
@@ -113,38 +131,63 @@ h.describeSkipVm("Azk agent vm", function() {
     });
 
     it("should add and remove dhcp server and hostonly network", function() {
-      var _tools = {
-        netinfo() {
-          return Q.all([hostonly.list(), dhcp.list_servers()]);
-        },
-        filter_dhcp(list, VBoxNetworkName) {
-          return _.find(list, (server) => server.NetworkName == VBoxNetworkName);
-        },
-        filter_hostonly(list, name) {
-          return _.find(list, (net) => net.Name == name);
-        }
-      };
-
       return async(this, function* () {
         // Install vm and get infos
-        var info = yield install_vm.apply(this);
-        var data = yield _tools.netinfo();
+        var info = yield aux_tools.install_vm.apply(this, [{ dhcp: true }]);
+        var data = yield aux_tools.netinfo();
 
         // Check for vmbox networking
-        var net  = _tools.filter_hostonly(data[0], info.hostonlyadapter1);
+        var net  = aux_tools.filter_hostonly(data[0], info.hostonlyadapter1);
         h.expect(net).to.have.property('Name', info.hostonlyadapter1);
+        h.expect(net).to.have.property('IPAddress'  , net_opts.gateway);
+        h.expect(net).to.have.property('NetworkMask', net_opts.netmask);
 
         // Check for dhcp server
         var VBoxNetworkName = net.VBoxNetworkName;
-        var server = _tools.filter_dhcp(data[1], VBoxNetworkName);
+        var server = aux_tools.filter_dhcp(data[1], VBoxNetworkName);
         h.expect(server).to.have.property('lowerIPAddress', opts.ip);
         h.expect(server).to.have.property('upperIPAddress', opts.ip);
 
         // Removing vm, network and dhcp server
         yield remove.apply(this);
-        data = yield _tools.netinfo();
-        h.expect(_tools.filter_hostonly(data[0], info.hostonlyadapter1)).to.empty;
-        h.expect(_tools.filter_dhcp(data[1], VBoxNetworkName)).to.empty;
+        data = yield aux_tools.netinfo();
+        h.expect(aux_tools.filter_hostonly(data[0], info.hostonlyadapter1)).to.empty;
+        h.expect(aux_tools.filter_dhcp(data[1], VBoxNetworkName)).to.empty;
+      });
+    });
+
+    it("should add/remove hostonly network without dhcp server", function() {
+      return async(this, function* () {
+        // Install vm and get infos
+        var info = yield aux_tools.install_vm.apply(this);
+        var data = yield aux_tools.netinfo();
+
+        // Check for vmbox networking
+        var net  = aux_tools.filter_hostonly(data[0], info.hostonlyadapter1);
+        h.expect(net).to.have.property('Name', info.hostonlyadapter1);
+        h.expect(net).to.have.property('IPAddress'  , net_opts.gateway);
+        h.expect(net).to.have.property('NetworkMask', net_opts.netmask);
+
+        // Networking configure guest ip
+        var result, key_base = "/VirtualBox/D2D/eth0";
+        result = yield VM.getProperty(opts.name, `${key_base}/address`);
+        h.expect(result).to.eql({ Value: net_opts.ip });
+        result = yield VM.getProperty(opts.name, `${key_base}/netmask`);
+        h.expect(result).to.eql({ Value: net_opts.netmask });
+        result = yield VM.getProperty(opts.name, `${key_base}/network`);
+        h.expect(result).to.eql({ Value: net_opts.network });
+
+        // Check if dhcp server is disabled
+        var VBoxNetworkName = net.VBoxNetworkName;
+        h.expect(aux_tools.filter_dhcp(data[1], VBoxNetworkName)).to.empty;
+
+        // Removing vm and network interface
+        var events   = [];
+        var progress = (event) => events.push(event);
+        yield remove.apply(this).progress(progress);
+        data = yield aux_tools.netinfo();
+        h.expect(aux_tools.filter_hostonly(data[0], info.hostonlyadapter1)).to.empty;
+        h.expect(events).to.length(2);
       });
     });
   });

--- a/src/agent/client.js
+++ b/src/agent/client.js
@@ -46,7 +46,13 @@ var Client = {
   },
 
   stop(opts) {
-    return Agent.stop(opts);
+    return defer((_resolve, _reject, notify) => {
+      notify({ type: "status", status: "stopping" });
+      return Agent.stop(opts).then((result) => {
+        if (result) { notify({ type: "status", status: "stopped" }); }
+        return { agent: result };
+      });
+    });
   },
 
   configs() {

--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -445,7 +445,8 @@ export class Configure extends UIProxy {
   }
 
   _getDockerIp() {
-    // 2: docker0    inet 10.0.42.1/16 scope global docker0\       valid_lft forever preferred_lft forever
+    // 2: docker0    inet 10.0.42.1/16 scope global docker0
+    //        valid_lft forever preferred_lft forever
     var regex = /docker0.*inet\s(.*?)\//;
     var cmd   = "/sbin/ip -o addr show";
 

--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -348,7 +348,7 @@ export class Configure extends UIProxy {
   _generateSuggestionIp(ip) {
     if (_.isEmpty(this._suggestion_ips)) {
       var ranges = _.range(50, 255).concat(_.range(10, 50 ), _.range(0 , 10 ));
-      this._suggestion_ips = _.map(ranges, (i) => `192.168.${i}.2`);
+      this._suggestion_ips = _.map(ranges, (i) => `192.168.${i}.4`);
     }
     this.info("configure.find_suggestions_ips");
     return _.find(this._suggestion_ips, (new_ip) => {

--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -11,12 +11,15 @@ var request    = require('request');
 var semver     = require('semver');
 var { isIPv4 } = require('net');
 
-/* global docker, Migrations, isOnline, exec */
+/* global docker, Migrations, isOnline, exec, Netmask, hostonly, VM */
 lazy_require(this, {
   docker     : ['azk/docker', 'default'],
   Migrations : ['azk/agent/migrations'],
   isOnline   : 'is-online',
   exec       : ['child_process'],
+  Netmask    : ['netmask'],
+  hostonly   : ['azk/agent/vm'],
+  VM         : ['azk/agent/vm'],
 });
 
 var ports_tabs = {
@@ -233,30 +236,21 @@ export class Configure extends UIProxy {
   _checkAndConfigureNetwork(use_vm = true) {
     return async(this, function* () {
       var file   = config('agent:balancer:file_dns');
-      var exist  = yield qfs.exists(file);
       var ip     = null;
       var result = {};
 
       // File exist? Get content
+      var exist = yield qfs.exists(file);
       if (exist) {
         var content = yield qfs.read(file);
         ip = this._parseNameserver(content)[0];
       }
 
-      // Not exist or invalid content
-      if (_.isEmpty(ip)) {
-        if (use_vm) {
-          this.warning('configure.vm_ip_msg');
-          ip = yield this._getNetworkIp();
-        } else {
-          ip = yield this._getDockerIp();
-        }
-        yield this._generateResolverFile(ip, file);
-      }
+      // Check ip or generate a new one
+      if (use_vm) { this._interfaces = yield this._getInterfacesIps(); }
+      ip = yield this._checkAndSaveIp(ip, file, use_vm);
 
-      if (use_vm) {
-        result['docker:host'] = `http://${ip}:2375`;
-      }
+      if (use_vm) { result['docker:host'] = `http://${ip}:2375`; }
 
       // Save to use in configure
       this.docker_ip = ip;
@@ -267,6 +261,30 @@ export class Configure extends UIProxy {
       obj['agent:dns:ip'] = ip;
       obj['agent:balancer:ip'] = ip;
       return _.merge(obj, result);
+    });
+  }
+
+  _checkAndSaveIp(ip, file, use_vm) {
+    return async(this, function* () {
+      // Not exist or invalid content
+      var conflict = use_vm ? this._conflictInterface(ip) : null;
+      if (_.isEmpty(ip) || !_.isEmpty(conflict)) {
+        if (use_vm) {
+          if (!_.isEmpty(conflict)) {
+            var fail_data = { ip, inter_name: conflict.name, inter_ip: conflict.ip };
+            this.fail('configure.errors.invalid_current_ip', fail_data);
+          } else {
+            this.warning('configure.vm_ip_msg');
+          }
+          var suggestion = this._generateSuggestionIp(ip);
+          ip = yield this._getNetworkIp(suggestion);
+        } else {
+          ip = yield this._getDockerIp();
+        }
+        yield this._generateResolverFile(ip, file);
+      }
+
+      return ip;
     });
   }
 
@@ -327,22 +345,94 @@ export class Configure extends UIProxy {
     }, []);
   }
 
-  // TODO: improve to get a free network ip ranges
+  _generateSuggestionIp(ip) {
+    if (_.isEmpty(this._suggestion_ips)) {
+      var ranges = _.range(50, 255).concat(_.range(10, 50 ), _.range(0 , 10 ));
+      this._suggestion_ips = _.map(ranges, (i) => `192.168.${i}.2`);
+    }
+    this.info("configure.find_suggestions_ips");
+    return _.find(this._suggestion_ips, (new_ip) => {
+      if (new_ip != ip) {
+        var conflict = this._conflictInterface(new_ip);
+        if (_.isEmpty(conflict)) { return true; }
+        var info_data = { ip: new_ip, inter_name: conflict.name, inter_ip: conflict.ip };
+        this.info("configure.errors.ip_conflict", info_data);
+      }
+    });
+  }
+
+  _conflictInterface(ip) {
+    if (_.isEmpty(ip)) { return null; }
+    var block = new Netmask(net.calculateNetIp(ip));
+    return _.find(this._interfaces, (network) => {
+      return block.contains(network.ip);
+    });
+  }
+
+  _getVMHostonlyInterface() {
+    return VM.info(config("agent:vm:name")).then((info) => {
+      if (info.installed) {
+        return info.hostonlyadapter1;
+      }
+      return null;
+    });
+  }
+
+  _getInterfacesIps() {
+    return async(this, function* () {
+      var hostonly_interface = yield this._getVMHostonlyInterface();
+      // System interfaces
+      var system_interfaces = _.reduce(os.networkInterfaces(), (acc, ips, name) => {
+        if (name != hostonly_interface) {
+          var ip = _.find(ips, (ip) => {
+            return ip.family == 'IPv4';
+          });
+          if (ip) { acc.push({ name: name, ip: ip.address }); }
+        }
+        return acc;
+      }, []);
+
+      // VirtualBox interfaces
+      var vbox_interfaces = _.reduce(yield hostonly.list(), (acc, inter) => {
+        var ip = inter.IPAddress;
+        if (inter.Name != hostonly_interface) {
+          acc.push({ name: inter.Name, ip });
+        }
+        return acc;
+      }, []);
+
+      return system_interfaces.concat(vbox_interfaces);
+    });
+  }
+
   // TODO: filter others /etc/resolver/* azk files
-  _getNetworkIp() {
+  _getNetworkIp(suggestion) {
     var question = {
       name    : 'ip',
       message : 'configure.ip_question',
-      default : config('agent:vm:ip'),
+      // default : config('agent:vm:ip'),
+      default: suggestion,
       validate: (value) => {
-        var data       = { ip: value };
-        var ip_invalid_range   = this.t('configure.ip_invalid_range', data);
-        var ip_invalid = this.t('configure.ip_invalid', data);
-        var ranges     = [ '127.0.0.1', '0.0.0.0' ];
+        var data     = { ip: value };
+        var invalids = {
+          ip      : () => this.t('configure.errors.ip_invalid', data),
+          loopback: () => this.t('configure.errors.ip_loopback', data),
+          conflict: (conflict) => {
+            var t_data = { ip: value, inter_name: conflict.name, inter_ip: conflict.ip };
+            return this.t('configure.errors.ip_conflict', t_data);
+          },
+        };
 
         // Check is valid ip
-        if (!isIPv4(value)) { return ip_invalid; }
-        if (_.contains(ranges, value)) { return ip_invalid_range; }
+        if (!isIPv4(value) || value === '0.0.0.0') { return invalids.ip(); }
+
+        // Conflict loopback
+        var lpblock = new Netmask('127.0.0.0/8');
+        if (lpblock.contains(value)) { return invalids.loopback(); }
+
+        // Conflict other interfaces
+        var conflict = this._conflictInterface(value);
+        if (!_.isEmpty(conflict)) { return invalids.conflict(conflict); }
 
         return true;
       }

--- a/src/agent/migrations.js
+++ b/src/agent/migrations.js
@@ -2,9 +2,9 @@ import { async, lazy_require } from 'azk';
 import { config } from 'azk';
 var qfs = require('q-io/fs');
 
-/* global Meta, VM */
+/* global meta, VM */
 lazy_require(this, {
-  Meta : ['azk/manifest/meta'],
+  meta : ['azk'],
   VM   : ['azk/agent/vm'],
 });
 
@@ -53,15 +53,13 @@ var Migrations = {
     return async(this, function* (notify) {
       // Meta options
       var meta_tag  = "last_migration";
-      var cache_dir = config('paths:azk_meta');
 
       // Initialize meta
-      var meta      = new Meta({ cache_dir });
       var last_run  = parseInt(meta.getOrSet(meta_tag, -1));
       var be_run    = this.migrations.slice(last_run + 1);
 
       // Azk agent was set up at least once?
-      if (yield qfs.exists(cache_dir) && be_run.length > 0) {
+      if (yield qfs.exists(meta.cache_dir) && be_run.length > 0) {
         // Warns on the run of migrations
         notify({ type: "status", keys: "configure.migrations.alert"});
 

--- a/src/config.js
+++ b/src/config.js
@@ -98,7 +98,7 @@ var options = mergeConfig({
       },
       vm: {
         wait_ready : 180000,
-        ip         : envs('AZK_AGENT_VM_IP'  , '192.168.50.4'),
+        ip         : new Dynamic("agent:vm:ip"),
         name       : envs('AZK_AGENT_VM_NAME', "azk-vm-" + namespace),
         user       : "docker",
         password   : "live",

--- a/src/index.js
+++ b/src/index.js
@@ -39,6 +39,12 @@ module.exports = {
   get config() { return config; },
   get set_config() { return set_config; },
 
+  // Global azk meta data
+  get meta() {
+    var cache_dir = this.config('paths:azk_meta');
+    return new (require('azk/manifest/meta').Meta)({ cache_dir });
+  },
+
   // Promise helpers
   get defer() { return defer; },
   get async() { return async; },

--- a/src/manifest/meta.js
+++ b/src/manifest/meta.js
@@ -24,8 +24,12 @@ export class Meta {
     this.__cache = value;
   }
 
+  get cache_dir() {
+    return this.options.cache_dir;
+  }
+
   clean() {
-    var path = this.options.cache_dir;
+    var path = this.cache_dir;
     if (fs.existsSync(path)) {
       this.__cache = null;
       return fs.removeSync(path);
@@ -34,7 +38,7 @@ export class Meta {
 
   get cache() {
     if (!this.__cache) {
-      var cache_dir = this.options.cache_dir;
+      var cache_dir = this.cache_dir;
       mkdir(cache_dir);
       this.__cache = createCache(cache_dir);
     }

--- a/src/utils/errors.js
+++ b/src/utils/errors.js
@@ -206,6 +206,12 @@ export class AgentStartError extends AzkError {
   }
 }
 
+export class AgentStopError extends AzkError {
+  constructor() {
+    super('agent_stop');
+  }
+}
+
 export class VmStartError extends AzkError {
   constructor(timeout, screen) {
     super('vm_start');


### PR DESCRIPTION
This pull request brings major changes to how the `azk` agent handles the virtual machine, resulting in many improvements mainly (but not exclusively) to `azk` users using mac.

### Closed issues in this PR:

 - Closes #116, adding swap support through this change in the image of the virtual machine: https://github.com/azukiapp/debian2docker/commit/6e1c93392629dc412d5c6b26a1363623ac863f8d
 - Closes #305, this problem had to do with a failure in VirtualBox DHCP Server. If it was unable to provide an ip, that caused the start of other services (including docker) to fail. This was solved by removing the use of the DHCP Server system and substituting the fixed IP configuration system through  `guestproperty`, as can be seen in:: https://github.com/azukiapp/debian2docker/commit/885303981fd9a382a488b84f40ec099d3751e20f 
 - Closes #252, solving a critical bug that could remove the data disk and lose all images already downloaded, and also saved data in persistent mounts. A simple change which uses a symbolic link in place of the actual disc in VirtualBox prevents accidental removal of the disc, furthermore improvements have been made in the error treatment while removing the VirtualBox virtual machine.
 - Closes #277, the `azk agent stop` command now awaits for the agent exit to complete before giving a return. This prevents the situation where the user could try to start the agent right after finishing it and `azk` outputting that the agent would still be running.
 - Closes #297, with the improvements made in the treatment of the virtual machine removal and ip configuration, initial tests no longer accuse errors in the use of the virtual machine on Linux. But we can't be sure that the bug is fixed, and we're looking into it.

### Bonus:

Besides the problem with the DHCP Server, there was always a problem that could cause ip conflicts between the virtual machine and any other network interface (both real interfaces as other VirtualBox interfaces). In this PR, it was added an ip conflict treatment in the agent startup process, and also an ip suggestion system besides the default `192.168.50.4`, which should ease the configuration in the event of a conflict.

### How to test:

This update uses a new iso to run the virtual machine, so before running this change:

 - Stop the agent with `azk agent stop`;
 - Go to the folder `lib/vm` and rename the file `azk.iso` to `azk_stable.iso` (so you can change it back in case you need to test some other branch that does use this change);
 - Download the new iso with `azk nvm grunt vm-download`;

Note: Be careful when dealing with files inside `lib/vm`, especially when packaging `azk` for Mac. This folder should only contain the files that will really be packed;

### Thanks

Special thanks to @dynaum and @jturolla by patience and several reports on these issues, were of great value to solving the problem.