### PR TITLE
[raise_dockerfile_build] Fixing does not show the error when the Dockerfile not build, issue #303

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## dev
 
 * Bug
-  - [Parse] Fixing running azk command in subfolder using dockfile, issue #250.
+  - [Parse] Fixing running azk command in subfolder using Dockerfile, issue #250.
+  - [Dockerfile] Fixing does not show the error when the Dockerfile not build, issue #303.
 
 * Enhancements
   * [code] Adding support to "integration testing"

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -45,6 +45,7 @@ module.exports = {
     ].join("\n"),
 
     docker_build_error: {
+      command_error: "  Error in building `%(dockerfile)s`:\n%(output)s\n",
       server_error: "Internal error in build `%(dockerfile)s`: %(error)",
       not_found   : "Can't find `%(from)s` image to build `%(dockerfile)s`",
       can_find_dockerfile: "Can't find `%(dockerfile)s` file",

--- a/spec/docker/build_spec.js
+++ b/spec/docker/build_spec.js
@@ -73,6 +73,23 @@ describe("Azk docker module, image build @slow", function() {
         });
     });
 
+    it("should raise error for a invalid step", function() {
+      var events = [];
+      return build('DockerfileBuildError')
+        .progress((event) => {
+          events.push(event);
+        })
+        .then(() => {
+          // test for Docker 1.2
+          h.expect(events).to.be.length(1);
+          h.expect(events[0].statusParsed).to.be.deep.equal({});
+        })
+        .catch(function(rejection) {
+          // test for Docker 1.4
+          h.expect(rejection.translation_key).to.equal('docker_build_error.command_error');
+        });
+    });
+
     it("should raise error for not found from", function() {
       return h.expect(build('DockerfileFrom404')).to.be.rejectedWith(DockerBuildError, /not_found/);
     });

--- a/spec/fixtures/build/DockerfileBuildError
+++ b/spec/fixtures/build/DockerfileBuildError
@@ -1,0 +1,3 @@
+FROM azukiapp/azktcl:0.0.2
+
+RUN exit 1000


### PR DESCRIPTION
This pull request closes #303 issue.

Now the AZK captures the error of build the Dockerfile:

![image](https://cloud.githubusercontent.com/assets/2034678/6768200/720fb85a-d03c-11e4-8aad-b62b618f30ec.png)

#### Test:

```sh
$ azk nvm grunt --grep="invalids Dockerfile's should raise error for a invalid step"'
```