### PR TITLE
[Balancer] Fixing conflict at some port to be expected by the wait, issue #309.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Agent] Changing dhcp-client configs (adding timeout) in order to avoid network-dependent services tree to fail;
   * [Agent] Making VirtualBox data disk deattach/remove process more reliable;
   * [Agent] Now `azk agent stop` waits for agent real stop;
+  * [Balancer] Fixing conflict at the port to be expected by the wait, issue #309;
 
 * Enhancements
   * [code] Adding support to "integration testing"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Agent] Making VirtualBox data disk deattach/remove process more reliable;
   * [Agent] Now `azk agent stop` waits for agent real stop;
   * [Balancer] Fixing conflict at the port to be expected by the wait, issue #309;
+  * [Agent] Fixing bug that could cause DNS and HTTP Balancer ports configuration to be ignored;
 
 * Enhancements
   * [code] Adding support to "integration testing"
@@ -28,6 +29,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [agent] Using VM static ip (set via guestproperty) instead of VirtualBox DHCP servers;
   * [agent] Adding verification of ip conflicts with existent networks interfaces;
   * [agent] Suggesting an altertive ip in case of a conflict;
+  * [Agent] Adding tests to verify DNS port exchange between Agent instances and rewrite `/etc/resolver/dev.azk.io` file;
 
 ## v0.10.2 - (2015-24-02)
 

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -61,8 +61,9 @@ module.exports = {
         mv_resolver: "Upgrading domains error, moving files was not possible",
       },
       darwin: {
-        VBoxManage : 'VirtualBox not installed. Install before continuing.',
-        network: 'Networking error',
+        VBoxManage     : 'VirtualBox not installed. Install before continuing.',
+        network        : 'Networking error',
+        custom_dns_port: 'Sorry, but Mac OS X supports only port `53` as `AZK_DNS_PORT`',
       },
       linux: {
         port_error: [
@@ -218,7 +219,8 @@ module.exports = {
     },
     find_suggestions_ips: "Suggesting a new ip...",
     errors: {
-      invalid_current_ip: 'Current ip `%(ip)s` conflict with network interface `%(inter_name)s inet %(inter_ip)s`',
+      unmatched_dns_port: 'The current dns port `%(old)s` set in `%(file)s` differs from env var `AZK_DNS_PORT=%(new)s`',
+      invalid_current_ip: 'Current ip `%(ip)s` conflicts with network interface `%(inter_name)s inet %(inter_ip)s`',
       ip_invalid : "`%(ip)s`".yellow + " is an invalid v4 ip, try again.",
       ip_loopback: "`%(ip)s`".yellow + " conflict with loopback network",
       ip_conflict: "`%(ip)s`".yellow + " conflict with network interface `%(inter_name)s inet %(inter_ip)s`",

--- a/spec/manifest/index_spec.js
+++ b/spec/manifest/index_spec.js
@@ -67,7 +67,7 @@ describe("Azk manifest class, main set", function() {
         h.expect(systems).to.has.deep.property("[0]").to.equal(
           manifest.system("expand-test")
         );
-        h.expect(systems).to.has.deep.property("[9]").to.equal(
+        h.expect(systems).to.has.deep.property("[10]").to.equal(
           manifest.system("example")
         );
       });
@@ -96,7 +96,7 @@ describe("Azk manifest class, main set", function() {
 
     describe("with a tree of the requireds systems", function() {
       it("should return a systems in required order", function() {
-        var systems = [ "expand-test", "mount-test", "ports-disable", "ports-test",
+        var systems = [ "expand-test", "mount-test", "ports-disable", "ports-fixed", "ports-test",
                         "test-image-opts", "empty", "db", "api", "example-extends", "example"];
 
         h.expect(manifest.systemsInOrder()).to.eql(systems);

--- a/spec/spec_helpers/mock_manifest.js
+++ b/spec/spec_helpers/mock_manifest.js
@@ -117,11 +117,11 @@ export function extend(h) {
             test_public: "5252:443/tcp",
           },
         },
-        'ports-fixed': {
+        'ports-static': {
           image: { docker: default_img },
           ports: {
-            test_fixed_tcp: "81:81/tcp",
-            test_public: "5252:443/tcp",
+            81: "81:81/tcp",
+            443: "5252:443/tcp",
           },
         },
         'ports-disable': {

--- a/spec/spec_helpers/mock_manifest.js
+++ b/spec/spec_helpers/mock_manifest.js
@@ -110,10 +110,17 @@ export function extend(h) {
           image: { docker: default_img },
         },
         'ports-test': {
-          image: { docker: config("docker:image_empty") },
+          image: { docker: default_img },
           ports: {
             test_tcp: "80/tcp",
             test_udp: "53/udp",
+            test_public: "5252:443/tcp",
+          },
+        },
+        'ports-fixed': {
+          image: { docker: default_img },
+          ports: {
+            test_fixed_tcp: "81:81/tcp",
             test_public: "5252:443/tcp",
           },
         },

--- a/spec/system/index_spec.js
+++ b/spec/system/index_spec.js
@@ -162,7 +162,7 @@ describe("Azk system class, main set", function() {
       });
 
       it("should merge system ports with image ports", function() {
-        var system  = manifest.system('ports-fixed');
+        var system  = manifest.system('ports-static');
         return system.image.check().then((image) => {
           return image.inspect().then((image_data) => {
             var options = system.daemonOptions({ image_data });
@@ -184,7 +184,7 @@ describe("Azk system class, main set", function() {
       });
 
       it("should orderly and merged system ports with image ports", function() {
-        var system  = manifest.system('ports-fixed');
+        var system  = manifest.system('ports-static');
         return system.image.check().then((image) => {
           return image.inspect().then((image_data) => {
             var options = system.daemonOptions({ image_data });
@@ -197,7 +197,7 @@ describe("Azk system class, main set", function() {
       });
 
       it("should merge ports system without override", function() {
-        var system  = manifest.system('ports-fixed');
+        var system  = manifest.system('ports-static');
         return system.image.check().then((image) => {
           return image.inspect().then((image_data) => {
             var options = system.daemonOptions({ image_data });
@@ -239,7 +239,7 @@ describe("Azk system class, main set", function() {
             "6379/tcp": "6379/tcp",
           }
         };
-        var system  = manifest.system('ports-fixed');
+        var system  = manifest.system('ports-static');
         var options = system.daemonOptions(custom);
 
         h.expect(options).to.deep.have.property("ports.8080/tcp").and.eql([{

--- a/spec/system/index_spec.js
+++ b/spec/system/index_spec.js
@@ -162,25 +162,63 @@ describe("Azk system class, main set", function() {
       });
 
       it("should merge system ports with image ports", function() {
-        var system  = manifest.system('db');
+        var system  = manifest.system('ports-fixed');
         return system.image.check().then((image) => {
           return image.inspect().then((image_data) => {
             var options = system.daemonOptions({ image_data });
 
-            h.expect(options).to.deep.have.property("ports.5000/tcp").and.eql([{
-              HostIp: config('agent:dns:ip')
-            }]);
             h.expect(options).to.deep.have.property("ports.80/tcp").and.eql([{
               HostIp: config('agent:dns:ip')
             }]);
-            h.expect(options).to.deep.have.property("ports.53/tcp").and.eql([{
+            h.expect(options).to.deep.have.property("ports.81/tcp").and.eql([{
+              HostIp: config('agent:dns:ip'), HostPort: "81"
+            }]);
+            h.expect(options).to.deep.have.property("ports.53/udp").and.eql([{
               HostIp: config('agent:dns:ip')
+            }]);
+            h.expect(options).to.deep.have.property("ports.443/tcp").and.eql([{
+              HostIp: config('agent:dns:ip'), HostPort: "5252"
             }]);
           });
         });
       });
 
-      it("should disable image ports with option `disable'", function() {
+      it("should orderly and merged system ports with image ports", function() {
+        var system  = manifest.system('ports-fixed');
+        return system.image.check().then((image) => {
+          return image.inspect().then((image_data) => {
+            var options = system.daemonOptions({ image_data });
+            h.expect(options).to.deep.have.property("ports_orderly.0.name").and.eql('81/tcp');
+            h.expect(options).to.deep.have.property("ports_orderly.1.name").and.eql('443/tcp');
+            h.expect(options).to.deep.have.property("ports_orderly.2.name").and.eql('53/udp');
+            h.expect(options).to.deep.have.property("ports_orderly.3.name").and.eql('80/tcp');
+          });
+        });
+      });
+
+      it("should merge ports system without override", function() {
+        var system  = manifest.system('ports-fixed');
+        return system.image.check().then((image) => {
+          return image.inspect().then((image_data) => {
+            var options = system.daemonOptions({ image_data });
+
+            h.expect(options).to.deep.have.property("ports.80/tcp").and.eql([{
+              HostIp: config('agent:dns:ip')
+            }]);
+            h.expect(options).to.deep.have.property("ports.81/tcp").and.eql([{
+              HostIp: config('agent:dns:ip'), HostPort: "81"
+            }]);
+            h.expect(options).to.deep.have.property("ports.53/udp").and.eql([{
+              HostIp: config('agent:dns:ip')
+            }]);
+            h.expect(options).to.deep.have.property("ports.443/tcp").and.eql([{
+              HostIp: config('agent:dns:ip'), HostPort: "5252"
+            }]);
+          });
+        });
+      });
+
+      it("should disable image ports with option `disable`", function() {
         var system = manifest.system('ports-disable');
         return system.image.check().then((image) => {
           return image.inspect().then((image_data) => {
@@ -201,7 +239,7 @@ describe("Azk system class, main set", function() {
             "6379/tcp": "6379/tcp",
           }
         };
-        var system  = manifest.system('ports-test');
+        var system  = manifest.system('ports-fixed');
         var options = system.daemonOptions(custom);
 
         h.expect(options).to.deep.have.property("ports.8080/tcp").and.eql([{

--- a/spec/system/run_spec.js
+++ b/spec/system/run_spec.js
@@ -73,9 +73,16 @@ describe("Azk system class, run set", function() {
 
     it("should run and wait for port", function() {
       return async(function* () {
-        var command   = ["/bin/bash", "-c", "sleep 2; " + system.raw_command];
-        var container = yield system.runDaemon({ command: command });
-        var data      = yield container.inspect();
+        var options    = {
+          command : ["/bin/bash", "-c", "sleep 2;" + "socat TCP4-LISTEN:$HTTP_PORT,fork EXEC:`pwd`/src/bashttpd"],
+          ports: {
+            http: '81:81/tcp'
+          }
+        };
+
+        var container  = yield system.runDaemon(options);
+        var data       = yield container.inspect();
+
         h.expect(data).to.have.deep.property('Annotations.azk.sys', system.name);
         h.expect(data).to.have.deep.property('State.ExitCode', 0);
         h.expect(data).to.have.deep.property('State.Running').and.ok;

--- a/spec/system/run_spec.js
+++ b/spec/system/run_spec.js
@@ -76,7 +76,7 @@ describe("Azk system class, run set", function() {
         var options    = {
           command : ["/bin/bash", "-c", "sleep 2;" + "socat TCP4-LISTEN:$HTTP_PORT,fork EXEC:`pwd`/src/bashttpd"],
           ports: {
-            http: '81:81/tcp'
+            http: '31275:31275/tcp'
           }
         };
 

--- a/src/system/run.js
+++ b/src/system/run.js
@@ -103,12 +103,15 @@ var Run = {
       var container  = yield docker.run(system.image.name, command, docker_opt);
 
       if (options.wait) {
+        var first_tcp = _.find((docker_opt.ports_orderly || []), (data) => {
+          return /\/tcp/.test(data.name);
+        });
 
         // TODO: support to wait udp protocol
         var data = yield container.inspect();
         var port_data = _.chain(data.NetworkSettings.Access)
           .filter((port) => {
-            return port.protocol == 'tcp';
+            return port.protocol == 'tcp' && port.name == first_tcp.private;
           })
           .find()
           .value();


### PR DESCRIPTION
This pull request closes issue #309 issue.

When the Dockerfile exposes some port, can happen of AZK try to connect to port exposed by Dockerfile, rather than the user-defined port at Azkfile.js.

### Dockerfile:

- [azukiapp/azktcl](https://registry.hub.docker.com/u/azukiapp/azktcl/dockerfile/)
```
FROM scratch

# Expose ports.
EXPOSE 53/udp
EXPOSE 80
```

### Azkfile.js
```js
systems({
  'example': {
    image   : { docker: 'azukiapp/azktcl' },
    command: "socat TCP4-LISTEN:$HTTP_PORT,fork TCP:$BALANCER_IP:$BALANCER_PORT",
    wait: true,
    scalable: false,
    ports: {
      http: "81:81/tcp",
      53: disable,
    }
  },
});
```


## Test:

```sh
$ AZK_BALANCER_PORT=81 azk agent start
```
![image](https://cloud.githubusercontent.com/assets/2034678/6768991/5805e5ea-d066-11e4-94c4-e56ee2f9b7a5.png)

```sh
$ curl 192.168.50.4:81
```
![image](https://cloud.githubusercontent.com/assets/2034678/6768992/5d5e03d8-d066-11e4-8bdd-fbdf3c407552.png)

```sh
$ azk nvm grunt --grep='should run and wait for port'
```