### PR TITLE
[info_manifest_id] Adding `manifest_id` on return of the command `azk info`, #323

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,10 +26,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Cli] New output when pulling images: show total count and size of layers to downloaded. Shows only a single progress bar with total download status. Integrate docker-registry-downloader with azk. #234 #119;
   * [Package] Adding update npm after install node;
   * [Package] Fixing of usage npm-sheringwrap in package;
-  * [agent] Using VM static ip (set via guestproperty) instead of VirtualBox DHCP servers;
-  * [agent] Adding verification of ip conflicts with existent networks interfaces;
-  * [agent] Suggesting an altertive ip in case of a conflict;
+  * [Agent] Using VM static ip (set via guestproperty) instead of VirtualBox DHCP servers;
+  * [Agent] Adding verification of ip conflicts with existent networks interfaces;
+  * [Agent] Suggesting an altertive ip in case of a conflict;
   * [Agent] Adding tests to verify DNS port exchange between Agent instances and rewrite `/etc/resolver/dev.azk.io` file;
+  * [Cli] Adding `manifest_id` on return of the command `azk info`, issue #323
 
 ## v0.10.2 - (2015-24-02)
 

--- a/spec/cmds/info_spec.js
+++ b/spec/cmds/info_spec.js
@@ -33,6 +33,9 @@ describe("Azk command info, run in an", function() {
         var rx_manifest = RegExp("manifest:.*" + h.escapeRegExp(manifest.file));
         h.expect(outputs[0]).to.match(rx_manifest);
 
+        var rx_manifest_id = RegExp("manifest_id:.*" + h.escapeRegExp(manifest.namespace));
+        h.expect(outputs[0]).to.match(rx_manifest_id);
+
         var rx_cache = RegExp("cache_dir:.*" + h.escapeRegExp(manifest.cache_dir));
         h.expect(outputs[0]).to.match(rx_cache);
 

--- a/src/cmds/info.js
+++ b/src/cmds/info.js
@@ -40,6 +40,7 @@ class Cmd extends InteractiveCmds {
         return data;
       }, {
         manifest: manifest.file,
+        manifest_id: manifest.namespace,
         cache_dir: manifest.cache_dir,
         default_system: manifest.systemDefault.name,
         systems: {}


### PR DESCRIPTION
This pull request closes #323 issue.

### Test:

Run the `azk info` on a project that has a Azkfile.js

```sh
$ azk info
```

![image](https://cloud.githubusercontent.com/assets/2034678/6810915/fcf6249c-d242-11e4-9493-bfc231b0177b.png)
