### PR TITLE
[Docker] Fixing flag `--pull` to force pull of docker image not working`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  * [Docker] Fixing flag `--pull` to force pull of docker image not working`;
+
 ## v0.11.0 - (2015-25-03)
 
 * Bug

--- a/src/images/index.js
+++ b/src/images/index.js
@@ -71,7 +71,7 @@ export class Image {
       }
 
       // download from registry
-      if (isBlank(image)) {
+      if (isBlank(image) || options.build_force) {
         this.repository = namespace + '/' + repository;
         notify({ type: "action", context: "image", action: "pull_image", data: this });
 


### PR DESCRIPTION
This pull request closes #349 issues.

The `Images` was not getting the flag `--pull`, so the force pull is not working.

![image](https://cloud.githubusercontent.com/assets/2034678/7007450/7eb90054-dc60-11e4-92a4-9010c65ac070.png)

### To test:

- Remove image and start
```
$ adocker rmi [image]
$ azk start
```

- Force pull
```
$ azk start --pull
```

- Start without pull
```
$ azk start
```
