### PR TITLE
[building_and_packaging] Updating Azkfile.js to support manifest dir name set by Jenkins

### DIFF
--- a/Azkfile.js
+++ b/Azkfile.js
@@ -89,7 +89,7 @@ systems({
     provision: [
       "cd /azk/aptly/public",
       "[ -L fedora20 ] && ( rm fedora20 )",
-      "ln -s /azk/azk/package/fedora20",
+      "ln -s /azk/#{manifest.dir}/package/fedora20",
     ],
     shell: "/bin/bash",
     command: "aptly serve",


### PR DESCRIPTION
This PR updates Azkfile.js to support manifest dir name set by Jenkins ("workspace" instead of "azk" -- usually used)
