### PR TITLE
Fixing tracking agent start command

### DIFF
--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -128,7 +128,7 @@ var Agent = {
     // Start server and subsistems
     return lazy.Server.start().then(() => {
       this.change_status("started");
-      lazy.channel.publish("started", {});
+      lazy.channel.publish("agent:started", {});
       log.info("agent start with pid: " + process.pid);
     });
   },

--- a/src/cli/tracked_cmds.js
+++ b/src/cli/tracked_cmds.js
@@ -7,7 +7,6 @@ export class TrackedCmds extends Command {
 
   constructor(...args) {
     super(...args);
-    this._command_tracked = false;
     this.tracker = tracker;
   }
 
@@ -46,10 +45,6 @@ export class TrackedCmds extends Command {
 
   sendTrackerData() {
     if (this.trackerEvent) {
-      if (this._command_tracked) { return Q(true); }
-      this._command_tracked = true;
-
-      // track
       return this.trackerEvent.send();
     } else {
       return Q(false);

--- a/src/cmds/agent.js
+++ b/src/cmds/agent.js
@@ -66,7 +66,7 @@ class Cmd extends InteractiveCmds {
       process.chdir(config('paths:azk_root'));
 
       // use VM?
-      var subscription = lazy.channel.subscribe("started", (/* data, envelope */) => {
+      var subscription = lazy.channel.subscribe("agent:started", (/* data, envelope */) => {
         var vm_data = {};
 
         if (config("agent:requires_vm")) {


### PR DESCRIPTION
This fixes azk tracking that was not sending the docker info;

- no more `this._command_tracked` check. Was not sending important info on  agent start command complete
- refactoring 'started' postal event to 'agent:started'

### How to test

```sh
azk agent start --no-daemon
# go check

azk agent start
# go check
```

**go check**

- check if "command" on https://keen.io/project/5526968d672e6c5a0d0ebec6 has docker.version and vm (if you are using VM)

#### OBS

This PR was made on top of https://github.com/azukiapp/azk/pull/373

