### PR TITLE
[fixing_agent_stop] Fixing issue on azk agent stop due to unresolved promises

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
+* Bug
+  * [Agent] Fixing issue between `azk` and `insight-keen-io` that prevented `azk agent` to stop;
 
 * Bug
   * [Agent] Replacing `is-online` lib with `connectivity`, #368

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## dev
 * Bug
   * [Agent] Fixing issue between `azk` and `insight-keen-io` that prevented `azk agent` to stop;
-
-* Bug
   * [Agent] Replacing `is-online` lib with `connectivity`, #368
   * [Agent] Better `azk agent start` messages on no internet is available, #371;
 

--- a/src/docker/docker.js
+++ b/src/docker/docker.js
@@ -52,7 +52,10 @@ export class Container extends Utils.qify('dockerode/lib/container') {
 
   _track(data, action) {
     var event_data = { event_type: action, id: this.Id };
-    return tracker.sendEvent("container", event_data).then(() => data);
+    return tracker.sendEvent("container", event_data).then(() => data, (err) => {
+      log.warn(err);
+      return data;
+    });
   }
 
   static parsePorts(ports) {


### PR DESCRIPTION
This PR closes #372 
When stopping `azk agent`, some promises (regard tracking) remained unresolved, preventing the agent to stop.
Fixing it and handling properly bluebird (used by insight-keen-io) and Q (used by azk) promises, the agent can now be properly shutdown.