### PR TITLE
[cli] Fixing `azk shell --mount` option to comply with docs and help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
+* Bug
+  * [cli] Fixing `--mount` option of `azk shell` command to comply with Docker's pattern (`local_folder:remote_folder`)
 
 ## v0.12.1 - (2015-25-04)
 

--- a/docs/content/en/reference/azkfilejs/shell.md
+++ b/docs/content/en/reference/azkfilejs/shell.md
@@ -1,6 +1,6 @@
 ## shell
 
-Indicates which shell binary to run once the command [azk shell](../command-line/shell.md) runs. If not informed, it'll use the system default: `/bin/sh`.
+Indicates which shell binary to run once the command [azk shell](../cli/shell.md) runs. If not informed, it'll use the system default: `/bin/sh`.
 
 #### Usage:
 

--- a/docs/content/en/reference/cli/shell.md
+++ b/docs/content/en/reference/cli/shell.md
@@ -28,7 +28,7 @@ $ azk shell --shell /bin/bash
 
 # Start the system [system_name] mounting the folder in /azk/root
 #  inside the container and setting the environment variable RAILS_ENV=dev
-$ azk shell [system_name] --mount /=/azk/root -e RAILS_ENV=dev
+$ azk shell [system_name] --mount /:/azk/root -e RAILS_ENV=dev
 
 # Runs the command `ls` within the system [system_name]
 $ azk shell [system_name] -c "ls -l /"

--- a/docs/content/pt-BR/reference/azkfilejs/shell.md
+++ b/docs/content/pt-BR/reference/azkfilejs/shell.md
@@ -1,6 +1,6 @@
 ## shell
 
-Indica qual será o binário de shell a ser executado assim que o comando [azk shell](../command-line/shell.md) for executado. Caso não seja informado utilizará o padrão do sistema: `/bin/sh`.
+Indica qual será o binário de shell a ser executado assim que o comando [azk shell](../cli/shell.md) for executado. Caso não seja informado utilizará o padrão do sistema: `/bin/sh`.
 
 #### Uso:
 

--- a/docs/content/pt-BR/reference/cli/shell.md
+++ b/docs/content/pt-BR/reference/cli/shell.md
@@ -28,7 +28,7 @@ $ azk shell --shell /bin/bash
 
 # Inicia o sistema [system_name] montando a pasta / em /azk/root
 #  dentro do container e definindo a variável de ambiente RAILS_ENV=dev
-$ azk shell [system_name] --mount /=/azk/root -e RAILS_ENV=dev
+$ azk shell [system_name] --mount /:/azk/root -e RAILS_ENV=dev
 
 # Executa o comando `ls` dentro do sistema [system_name]
 $ azk shell [system_name] -c "ls -l /"

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -351,7 +351,7 @@ module.exports = {
       },
       examples: [
         '$ azk shell --shell /bin/bash',
-        '$ azk shell [system_name] --mount /=/azk/root -e RAILS_ENV=dev',
+        '$ azk shell [system_name] --mount /:/azk/root -e RAILS_ENV=dev',
         '$ azk shell [system_name] -c "ls -l /"',
         '$ azk shell --image azukiapp/budybox -t -c "/bin/bash"',
       ]

--- a/src/cmds/shell.js
+++ b/src/cmds/shell.js
@@ -48,8 +48,8 @@ class Cmd extends InteractiveCmds {
 
       // Support extra envs, ports and mount volumes
       options.envs   = this._parse_option(opts.env  , /.+=.+/, '=', 'invalid_env');
-      options.mounts = this._parse_option(opts.mount, /.+:.+:?.*/, ':', 'invalid_mount', (opts) => {
-        return { type: (opts[2] ? opts[1] : 'path'), value: (opts[2] ? opts[2] : opts[1]) };
+      options.mounts = this._parse_option(opts.mount, /.+:.+:?.*/, ':', 'invalid_mount', 1, (opts) => {
+        return { type: (opts[2] ? opts[1] : 'path'), value: (opts[2] ? opts[2] : opts[0]) };
       });
 
       cmd = [opts.shell || system.shell];
@@ -131,13 +131,13 @@ class Cmd extends InteractiveCmds {
     };
   }
 
-  _parse_option(option, regex, split, fail, format = null) {
+  _parse_option(option, regex, split, fail, key_index = 0, format = null) {
     var result = {};
     for (var j = 0; j < option.length; j++) {
       var opt = option[j];
       if (opt.match(regex)) {
         opt = opt.split(split);
-        result[opt[0]] = format ? format(opt) : opt[1];
+        result[opt[key_index]] = format ? format(opt) : opt[1];
       } else {
         this.fail('commands.shell.' + fail, { value: opt });
         return 1;


### PR DESCRIPTION
This PR closes #378 

The `--mount` option of `azk shell` command was using the pattern `docker_folder:local_folder`, differently from its docs and help.

In order to make it comply with Docker's pattern, we preserved docs and help and fixed its implementation.