### PR TITLE
[make] Fixing Makefile assumption: azk is not in the $PATH at the first time

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ ${NODE}:
 		mkdir -p ${NVM_DIR} && \
 		. ${NVM_BIN_PATH} && \
 		nvm install $(NVM_NODE_VERSION) && \
-		azk nvm npm install npm -g
+		${AZK_BIN} nvm npm install npm -g
 
 clean:
 	@echo "task: $@"


### PR DESCRIPTION
This PR fixes an issue when running `make` for the very first time (without `azk` in the PATH).