### PR TITLE
[ci] Increasing timeout values for tests failing at ci-box

### DIFF
--- a/spec/system/balancer_spec.js
+++ b/spec/system/balancer_spec.js
@@ -2,7 +2,7 @@ import h from 'spec/spec_helper';
 import { async } from 'azk';
 
 describe("Azk system class, balancer set", function() {
-  this.timeout(10000);
+  this.timeout(20000);
   var manifest, system;
 
   before(function() {

--- a/spec/system/scale_spec.js
+++ b/spec/system/scale_spec.js
@@ -3,7 +3,7 @@ import { async } from 'azk';
 import { SystemDependError, SystemNotScalable } from 'azk/utils/errors';
 
 describe("Azk system class, scale set", function() {
-  this.timeout(10000);
+  this.timeout(20000);
   var manifest, system, system_db;
 
   before(function() {


### PR DESCRIPTION
Couple tests were failing at ci-box, causing the build to fail.

Failed builds due to tests timeout:
* http://azkci.ngrok.com/job/azk-build/57/console
* http://azkci.ngrok.com/job/azk-build/43/console

Increasing the timeout value is not the best solution, it's just a workaround enough for now.