### PR TITLE
[tracking] Fixing timeout message when tracking an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
+* Bug
+  * [Tracking] Fixing timeout message when tracking an event;
 
 ## v0.12.1 - (2015-25-04)
 

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -551,6 +551,10 @@ module.exports = {
         },
       },
     },
+  },
+  
+  tracking: {
+    timeout: "Analytics tracker timed out."
   }
 };
 // jscs:enable maximumLineLength

--- a/src/utils/tracker.js
+++ b/src/utils/tracker.js
@@ -1,5 +1,5 @@
 import Azk from 'azk';
-import { Q, _, config, log } from 'azk';
+import { Q, _, config, log, t } from 'azk';
 import { meta as azkMeta } from 'azk';
 import { calculateHash } from 'azk/utils';
 
@@ -76,7 +76,7 @@ export class TrackerEvent {
         }
         return tracking_result;
       }, () => {
-        log.info('Analytics tracker timed out.');
+        log.info(t("tracking.timeout"));
         return false;
       });
   }

--- a/src/utils/tracker.js
+++ b/src/utils/tracker.js
@@ -75,8 +75,8 @@ export class TrackerEvent {
           });
         }
         return tracking_result;
-      }, (error) => {
-        log.error(error.stack);
+      }, () => {
+        log.info('Analytics tracker timed out.');
         return false;
       });
   }


### PR DESCRIPTION
This PR closes #390 

Instead of a say-nothing stack trace, when tracking an event fails, a specific message should be properly logged using the `info` level.
This allow the user to know when tracker times out but doesn't show error messages by default.