### PR TITLE
[Test] Adding flag `--no-required-agent` to disable required `Agent` before tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [cli] Fixing `--mount` option of `azk shell` command to comply with Docker's pattern (`local_folder:remote_folder`)
   * [Tracking] Fixing timeout message when tracking an event;
 
+* Enhancements
+  * [Test] Adding to flag `--no-required-agent` to disable required `Agent` before tests.
+
 ## v0.12.1 - (2015-25-04)
 
 * Bug

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -78,7 +78,7 @@ gulp.task('publish', function() {
 
   var add_prefix = function(cond, prefix) {
     return gulpif(cond, rename(function (path) {
-        path.dirname = path_join(prefix, path.dirname);
+      path.dirname = path_join(prefix, path.dirname);
     }));
   };
 

--- a/spec/spec_helper.js
+++ b/spec/spec_helper.js
@@ -19,8 +19,14 @@ var Helpers = {
   capture_io: capture_io,
   expect : chai.expect,
 
+  get no_required_agent() {
+    return (_.contains(process.argv, '--no-required-agent') || process.env.AZK_NO_REQUIRED_AGENT);
+  },
+
   get docker() {
-    return require('azk/docker').default;
+    if (!Helpers.no_required_agent) {
+      return require('azk/docker').default;
+    }
   },
 
   tmp_dir(opts = { prefix: "azk-test-"}) {
@@ -67,7 +73,7 @@ var Helpers = {
 };
 
 // In specs the virtual machine is required
-if (!_.contains(process.argv, '--no-required-agent') || !process.env.AZK_NO_REQUIRED_AGENT) {
+if (!Helpers.no_required_agent) {
   before(() => {
     console.log(t('test.before'));
     return AgentClient.require();

--- a/spec/spec_helper.js
+++ b/spec/spec_helper.js
@@ -1,6 +1,6 @@
 require('source-map-support').install();
 
-import { Q, pp, config, t } from 'azk';
+import { Q, pp, config, t, _ } from 'azk';
 import { Client as AgentClient } from 'azk/agent/client';
 import Utils from 'azk/utils';
 
@@ -67,10 +67,12 @@ var Helpers = {
 };
 
 // In specs the virtual machine is required
-before(() => {
-  console.log(t('test.before'));
-  return AgentClient.require();
-});
+if (!_.contains(process.argv, '--no-required-agent') || !process.env.AZK_NO_REQUIRED_AGENT) {
+  before(() => {
+    console.log(t('test.before'));
+    return AgentClient.require();
+  });
+}
 
 // Helpers
 require('spec/spec_helpers/dustman').extend(Helpers);

--- a/spec/spec_helpers/dustman.js
+++ b/spec/spec_helpers/dustman.js
@@ -44,14 +44,17 @@ export function extend(Helpers) {
   };
 
   // Remove all containers before run
-  before(function() {
-    this.timeout(0);
-    var progress = (event) => console.log(`  ${event}`);
-    var funcs = [
-      Helpers.remove_containers,
-      Helpers.remove_images,
-      () => console.log("\n")
-    ];
-    return funcs.reduce(Q.when, Q()).progress(progress);
-  });
+  // if no_required_agent is disabled
+  if (!Helpers.no_required_agent) {
+    before(function() {
+      this.timeout(0);
+      var progress = (event) => console.log(`  ${event}`);
+      var funcs = [
+        Helpers.remove_containers,
+        Helpers.remove_images,
+        () => console.log("\n")
+      ];
+      return funcs.reduce(Q.when, Q()).progress(progress);
+    });
+  }
 }


### PR DESCRIPTION
If you need to make `gulp watch: test --grep 'message'` without the `Agent` is running, you can now turn off this requirement.

```sh
$ gulp watch:test --grep 'message' --no-required-agent
```