### PR TITLE
[Kernel] progress --> postal.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Docker] Fixing bug that could prevent the work instruction `ADD . /folder/` when used in a Dockerfile;
 
 * Enhancements
+  * [Code] Removed `progress()` Promises helper. Included postal: subscribe and publish functions #385;
   * [Docker] Now support `Dockerfile` is complete, and similar to the docker, including support `.dockerignore`;
   * [Suggesting] Changing the suggestions of python and ruby ​​to give preference to sync instead of path;
 

--- a/bin/azk.js
+++ b/bin/azk.js
@@ -26,6 +26,12 @@ if (process.env.AZK_PROFILE_REQUIRES) {
   require('azk/utils/require_debug');
 }
 
+if (process.env.AZK_SUBSCRIBE_POSTAL) {
+  var SubscriptionLogger = require("azk/utils/postal").SubscriptionLogger;
+  var subscriptionLogger = new SubscriptionLogger();
+  subscriptionLogger.subscribeTo(process.env.AZK_SUBSCRIBE_POSTAL);
+}
+
 // Load source-map to support transpiled files
 var map_opts = {};
 if (process.env.AZK_DISABLE_SOURCE_MAP) {
@@ -35,6 +41,7 @@ if (process.env.AZK_DISABLE_SOURCE_MAP) {
     }
   };
 }
+
 require('source-map-support').install(map_opts);
 
 // Process exit events

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,7 +7,7 @@ var azk_gulp = require('azk-dev/gulp')({
   src  : { src: "./src" , dest: path.join(lib, "/azk") },
   spec : { src: "./spec", dest: path.join(lib, "/spec") },
   mocha: { timeout: 10000 },
-  lint: [ "bin/**/*.js" ],
+  lint : [ "bin/**/*.js" ],
 });
 
 // Load gulp

--- a/spec/docker/containers_observer_spec.js
+++ b/spec/docker/containers_observer_spec.js
@@ -1,6 +1,5 @@
 import h from 'spec/spec_helper';
 import { _, config, lazy_require } from 'azk';
-import { async } from 'azk';
 
 var l = lazy_require({
   ContainersObserver: ['azk/docker/containers_observer']
@@ -34,73 +33,67 @@ describe("Azk docker, ContainersObserver class", function() {
     }
   });
 
-  it("should postal events about the containers", function() {
-    return async(function* () {
-      var topic    = "containers.observer.*";
-      var filter   = (msg) => msg.status === "die";
-      var wait_msg = null;
-      [wait_msg, sub] = yield h.wait_subscription(topic, filter);
+  it("should postal events about the containers", function* () {
+    var topic    = "containers.observer.*";
+    var filter   = (msg) => msg.status === "die";
+    var wait_msg = null;
+    [wait_msg, sub] = yield h.wait_subscription(topic, filter);
 
-      observer = new l.ContainersObserver();
-      yield observer.start();
-      yield run_container();
+    observer = new l.ContainersObserver();
+    yield observer.start();
+    yield run_container();
 
-      h.expect(outputs.stdout).to.equal("out\n");
-      h.expect(outputs.stderr).to.equal("error\n");
+    h.expect(outputs.stdout).to.equal("out\n");
+    h.expect(outputs.stderr).to.equal("error\n");
 
-      var msgs = yield wait_msg;
-      h.expect(msgs).to.containSubset([{from: image, status: 'create'}]);
-      h.expect(msgs).to.containSubset([{from: image, status: 'start'}]);
-      h.expect(msgs).to.containSubset([{from: image, status: 'die'}]);
-    });
+    var msgs = yield wait_msg;
+    h.expect(msgs).to.containSubset([{from: image, status: 'create'}]);
+    h.expect(msgs).to.containSubset([{from: image, status: 'start'}]);
+    h.expect(msgs).to.containSubset([{from: image, status: 'die'}]);
   });
 
-  it("should filter events about the containers", function() {
-    return async(function* () {
-      var topic    = "containers.observer.*";
-      var filter   = (_, msgs) => msgs.length == 2;
-      var wait_msg = null;
-      [wait_msg, sub] = yield h.wait_subscription(topic, filter);
+  it("should filter events about the containers", function* () {
+    var topic    = "containers.observer.*";
+    var filter   = (_, msgs) => msgs.length == 2;
+    var wait_msg = null;
+    [wait_msg, sub] = yield h.wait_subscription(topic, filter);
 
-      observer = new l.ContainersObserver({ event: ["create", "start"]});
-      yield observer.start();
-      yield run_container();
+    observer = new l.ContainersObserver({ event: ["create", "start"]});
+    yield observer.start();
+    yield run_container();
 
-      h.expect(outputs.stdout).to.equal("out\n");
-      h.expect(outputs.stderr).to.equal("error\n");
+    h.expect(outputs.stdout).to.equal("out\n");
+    h.expect(outputs.stderr).to.equal("error\n");
 
-      var msgs = yield wait_msg;
-      h.expect(msgs).to.containSubset([{from: image, status: 'create'}]);
-      h.expect(msgs).to.containSubset([{from: image, status: 'start'}]);
-      h.expect(msgs).to.not.containSubset([{from: image, status: 'die'}]);
-    });
+    var msgs = yield wait_msg;
+    h.expect(msgs).to.containSubset([{from: image, status: 'create'}]);
+    h.expect(msgs).to.containSubset([{from: image, status: 'start'}]);
+    h.expect(msgs).to.not.containSubset([{from: image, status: 'die'}]);
   });
 
-  it("should support stop observer", function() {
-    return async(function* () {
-      var topic    = "containers.observer.*";
-      var filter   = (_, msgs) => msgs.length == 1;
-      var wait_msg = null;
-      [wait_msg, sub] = yield h.wait_subscription(topic, filter);
+  it("should support stop observer", function* () {
+    var topic    = "containers.observer.*";
+    var filter   = (_, msgs) => msgs.length == 1;
+    var wait_msg = null;
+    [wait_msg, sub] = yield h.wait_subscription(topic, filter);
 
-      observer = new l.ContainersObserver();
-      yield observer.start();
-      yield run_container();
+    observer = new l.ContainersObserver();
+    yield observer.start();
+    yield run_container();
 
-      h.expect(outputs.stdout).to.equal("out\n");
-      h.expect(outputs.stderr).to.equal("error\n");
+    h.expect(outputs.stdout).to.equal("out\n");
+    h.expect(outputs.stderr).to.equal("error\n");
 
-      var msgs = yield wait_msg;
-      h.expect(msgs).to.containSubset([{from: image, status: 'create'}]);
+    var msgs = yield wait_msg;
+    h.expect(msgs).to.containSubset([{from: image, status: 'create'}]);
 
-      yield observer.stop();
-      [wait_msg, sub] = yield h.wait_subscription(topic, filter);
-      yield run_container();
-      setImmediate(() => observer.publish("fake", { status: "fake" }));
+    yield observer.stop();
+    [wait_msg, sub] = yield h.wait_subscription(topic, filter);
+    yield run_container();
+    setImmediate(() => observer.publish("fake", { status: "fake" }));
 
-      msgs = yield wait_msg;
-      h.expect(msgs).to.not.containSubset([{from: image, status: 'create'}]);
-      h.expect(msgs).to.be.eql([{status: 'fake'}]);
-    });
+    msgs = yield wait_msg;
+    h.expect(msgs).to.not.containSubset([{from: image, status: 'create'}]);
+    h.expect(msgs).to.be.eql([{status: 'fake'}]);
   });
 });

--- a/spec/docker/run_spec.js
+++ b/spec/docker/run_spec.js
@@ -39,7 +39,7 @@ describe("Azk docker module, run method @slow", function() {
 
     return result.then((container) => {
       _subscription.unsubscribe();
-      
+
       h.expect(outputs.stdout).to.match(/Linux/);
       return container.remove();
     })

--- a/spec/generator/rules/generation/node_gen_spec.js
+++ b/spec/generator/rules/generation/node_gen_spec.js
@@ -39,9 +39,6 @@ describe('Azk generator generation node rule', function() {
     var expectedMounts = {};
     var workdir = '/azk/' + project_folder_name;
     expectedMounts[workdir] = utils.docker.resolvePath(manifest.manifestPath);
-    // FIXME: where does this api name comes from when all 'Azk generator' are run?
-    // h.expect(system).to.have.deep.property('mounts')
-    //  .and.to.eql(expectedMounts);
 
     h.expect(system).to.have.deep.property('options.workdir', workdir);
     h.expect(system).to.have.deep.property('options.provision')

--- a/spec/spec_helper.js
+++ b/spec/spec_helper.js
@@ -15,6 +15,12 @@ var lazy = lazy_require({
 var chai = require('azk-dev/chai');
 chai.use(require('chai-subset'));
 
+if (process.env.AZK_SUBSCRIBE_POSTAL) {
+  var SubscriptionLogger = require("azk/utils/postal").SubscriptionLogger;
+  var subscriptionLogger = new SubscriptionLogger();
+  subscriptionLogger.subscribeTo(process.env.AZK_SUBSCRIBE_POSTAL);
+}
+
 var Helpers = {
   pp: pp,
   expect: chai.expect,

--- a/spec/spec_helper.js
+++ b/spec/spec_helper.js
@@ -33,9 +33,7 @@ var Helpers = {
   },
 
   get docker() {
-    if (!Helpers.no_required_agent) {
-      return require('azk/docker').default;
-    }
+    return require('azk/docker').default;
   },
 
   tmp_dir(opts = { prefix: "azk-test-"}) {
@@ -101,6 +99,7 @@ after(() => {
   if (process.env.AZK_ENABLE_NJS_TRACE_PROFILER) {
     global.njstrace.save('/home/julio/_git/njstrace/examples/02-es5/execute/TRACE_RESULT.json');
   }
+  require('azk/utils/postal').unsubscribeAll();
 });
 
 // Helpers

--- a/spec/spec_helpers/dustman.js
+++ b/spec/spec_helpers/dustman.js
@@ -58,6 +58,8 @@ export function extend(Helpers) {
   }
 
   after(() => {
-    _subscription.unsubscribe();
+    if (_subscription) {
+      _subscription.unsubscribe();
+    }
   });
 }

--- a/spec/system/run_spec.js
+++ b/spec/system/run_spec.js
@@ -1,5 +1,5 @@
 import h from 'spec/spec_helper';
-import { _, async, defer, Q } from 'azk';
+import { _, async, defer, Q, publish, subscribe } from 'azk';
 import { ImageNotAvailable } from 'azk/utils/errors';
 
 describe("Azk system class, run set", function() {
@@ -181,16 +181,12 @@ describe("Azk system class, run set", function() {
       // TODO: Replace this merge for a mock class
       var system, image_mock = {
         pull() {
-          return defer((resolve, reject, notify) => {
+          return defer((resolve) => {
             process.nextTick(() => {
-              notify({ type: "event" });
+              publish("spec.image_mock.status", { type: "event" });
               resolve(this);
             });
           });
-        },
-
-        check() {
-          return Q.resolve(null);
         },
 
         inspect() {
@@ -198,27 +194,73 @@ describe("Azk system class, run set", function() {
         }
       };
 
+      var events;
+      var _subscription;
+      var _subscription2;
+
       before(() => {
         system = manifest.system("empty");
-        system.image = _.merge(_.clone(system.image), image_mock);
+        system.image = _.merge({}, system.image, image_mock);
+
+        _subscription = subscribe('spec.image_mock.status', (event) => {
+          events.push(event);
+        });
+
+      });
+      after(() => {
+        _subscription.unsubscribe();
+      });
+
+      beforeEach(() => {
+        events   = [];
       });
 
       it("should raise error if image not found", function() {
+
+        // mock check to return null
+        system.image.check = function () {
+          return defer((resolve) => {
+            process.nextTick(() => {
+              publish("image.check.status", { type: "action", context: "image", action: "check_image" });
+              resolve(null);
+            });
+          });
+        };
+
         var result = system.runShell([], { image_pull: false});
         return h.expect(result).to.rejectedWith(ImageNotAvailable);
       });
 
       it("should add system to event object", function() {
         return async(function* () {
-          var events   = [];
-          var progress = (event) => {
-            events.push(event);
-            return event;
+
+          // force azk to think that the image is builded
+          system.image.builded = true;
+
+          // mock check to return null
+          system.image.check = function () {
+            return defer((resolve) => {
+              process.nextTick(() => {
+                publish("image.check.status", { type: "action", context: "image", action: "check_image" });
+                resolve(system.image);
+              });
+            });
           };
 
-          yield system.runDaemon().progress(progress).fail(() => {});
+          _subscription2 = subscribe('system.run.image.check.status', (event) => {
+            events.push(event);
+          });
+
+          yield system.runDaemon()
+                .catch(() => {});
+
+          _subscription2.unsubscribe();
+
           h.expect(events).to.have.deep.property("[0]").and.eql(
-            { type: "event", system: system }
+            { type: 'action',
+              context: 'image',
+              action: 'check_image',
+              system: system }
           );
         });
       });

--- a/spec/utils/capture_io_spec.js
+++ b/spec/utils/capture_io_spec.js
@@ -1,10 +1,14 @@
-import { Q, publish, subscribe } from 'azk';
+import { Q, lazy_require } from 'azk';
+import { publish, subscribe } from 'azk/utils/postal';
 import h from 'spec/spec_helper';
-import capture_io from 'azk/utils/capture_io';
+
+var lazy = lazy_require({
+  capture_io: ["azk/utils/capture_io"],
+});
 
 describe("Azk capture_io utils helper", function() {
   it("should capture outputs", function() {
-    var promise = capture_io( () => {
+    var promise = lazy.capture_io( () => {
       process.stdout.write('stdout write ');
       console.log('output to stdout');
       console.error('output to stderr');
@@ -35,14 +39,14 @@ describe("Azk capture_io utils helper", function() {
     };
 
     it("should capture outputs", function() {
-      return capture_io(block).spread((result, outs) => {
+      return lazy.capture_io(block).spread((result, outs) => {
         h.expect(result).to.equal(1);
         h.expect(outs.stdout).to.equal("output in stdout\n");
       });
     });
 
     it("should support progress", function() {
-      var promise = capture_io(block);
+      var promise = lazy.capture_io(block);
       var notify  = [];
 
       var _subscription = subscribe('capture_io_spec', (notification) => notify.push(notification));

--- a/spec/utils/capture_io_spec.js
+++ b/spec/utils/capture_io_spec.js
@@ -1,4 +1,4 @@
-import { Q } from 'azk';
+import { Q, publish, subscribe } from 'azk';
 import h from 'spec/spec_helper';
 import capture_io from 'azk/utils/capture_io';
 
@@ -24,7 +24,9 @@ describe("Azk capture_io utils helper", function() {
       var done = Q.defer();
 
       setImmediate( () => {
-        done.notify('notification');
+
+        publish("capture_io_spec", 'notification');
+
         console.log('output in stdout');
         done.resolve(1);
       });
@@ -42,9 +44,12 @@ describe("Azk capture_io utils helper", function() {
     it("should support progress", function() {
       var promise = capture_io(block);
       var notify  = [];
-      promise.progress((notification) => notify.push(notification));
+
+      var _subscription = subscribe('capture_io_spec', (notification) => notify.push(notification));
 
       return promise.spread((result, outs) => {
+        _subscription.unsubscribe();
+
         h.expect(notify).to.eql(['notification']);
         h.expect(result).to.equal(1);
         h.expect(outs.stdout).to.equal("output in stdout\n");

--- a/spec/utils/capture_io_spec.js
+++ b/spec/utils/capture_io_spec.js
@@ -47,14 +47,16 @@ describe("Azk capture_io utils helper", function() {
 
     it("should support progress", function() {
       var promise = lazy.capture_io(block);
-      var notify  = [];
+      var events  = [];
 
-      var _subscription = subscribe('capture_io_spec', (notification) => notify.push(notification));
+      var _subscription = subscribe('capture_io_spec', (event) => {
+        events.push(event);
+      });
 
       return promise.spread((result, outs) => {
         _subscription.unsubscribe();
 
-        h.expect(notify).to.eql(['notification']);
+        h.expect(events).to.eql(['notification']);
         h.expect(result).to.equal(1);
         h.expect(outs.stdout).to.equal("output in stdout\n");
       });

--- a/spec/utils/index_spec.js
+++ b/spec/utils/index_spec.js
@@ -105,9 +105,8 @@ describe("Azk utils module", function() {
     var async = utils.async;
 
     var will_solve = () => {
-      return defer((resolve, reject, notify) => {
+      return defer((resolve) => {
         process.nextTick(() => {
-          notify("notify");
           resolve(1);
         });
       });
@@ -135,20 +134,14 @@ describe("Azk utils module", function() {
     });
 
     it("should support a async alias", function() {
-      var events   = [];
-      var progress = (event) => events.push(event);
-
-      var promise = async(function* (notify) {
-        notify("fromasync");
+      var promise = async(function* () {
         var number = yield will_solve();
         h.expect(number).to.equal(1);
         return true;
-      }).progress(progress);
+      });
 
       return promise.then((result) => {
         h.expect(result).to.equal(true);
-        h.expect(events).to.include("notify");
-        h.expect(events).to.include("fromasync");
       });
     });
 

--- a/spec/utils/net_spec.js
+++ b/spec/utils/net_spec.js
@@ -1,7 +1,5 @@
 import h from 'spec/spec_helper';
-import { async, Q } from 'azk';
-import { config, set_config } from 'azk';
-import { path } from 'azk';
+import { async, Q, config, set_config, path, subscribe } from 'azk';
 import { net as net_utils, envDefaultArray } from 'azk/utils';
 var net = require('net');
 
@@ -90,24 +88,40 @@ describe("Azk utils.net module", function() {
       server = net.createServer(() => {});
       return Q
         .ninvoke(server, 'listen', port_or_path)
-        .then(() => { return Q.delay(1000); });
+        .then(() => {
+          return Q.delay(1000).then(function (result) {
+            return result;
+          });
+        });
     };
 
     it("should wait for server", function() {
-      var progress = (event) => {
-        // Connect before 2 attempts
-        if (event.type == "try_connect" && event.attempts == 2) {
-          return runServer(port);
-        }
-      };
+
+      var _subscription;
 
       var connect = () => {
         return net_utils.waitService("tcp://localhost:" + port, 2, { timeout: 100 });
       };
 
       return async(function* () {
+        // not listening to utils.net.waitService.status
         yield h.expect(connect()).to.eventually.equal(false);
-        yield h.expect(connect().progress(progress)).to.eventually.equal(true);
+
+        // listening to utils.net.waitService.status
+        _subscription = subscribe('utils.net.waitService.status', (event) => {
+          // Connect before 2 attempts
+          if (event.type == "try_connect" && event.attempts == 2) {
+            runServer(port);
+          }
+        });
+        yield h.expect(connect()).to.eventually.equal(true);
+        _subscription.unsubscribe();
+      })
+      .catch(function (err) {
+        if (_subscription) {
+          _subscription.unsubscribe();
+        }
+        throw err;
       });
     });
 

--- a/spec/utils/postal_spec.js
+++ b/spec/utils/postal_spec.js
@@ -52,5 +52,18 @@ describe("Azk utils, postal module", function() {
       var obj = new MyClass();
       obj.test_publish('subtopic', data);
     });
+
+    it("should support subscribe with default prefix topic", function(done) {
+      var data = { data: true };
+      var obj  = new MyClass();
+
+      var subs = obj.subscribe((msg) => {
+        h.expect(msg).to.eql(data);
+        subs.unsubscribe();
+        done();
+      });
+
+      obj.test_publish('subtopic', data);
+    });
   });
 });

--- a/spec/utils/postal_spec.js
+++ b/spec/utils/postal_spec.js
@@ -2,14 +2,21 @@ import h from 'spec/spec_helper';
 import { lazy_require } from 'azk';
 
 var l = lazy_require({
-  IPublisher: ['azk/utils/postal'],
-  subscribe : ['azk/utils/postal'],
-  publish   : ['azk/utils/postal'],
+  IPublisher    : ['azk/utils/postal'],
+  channel       : ['azk/utils/postal'],
+  subscribe     : ['azk/utils/postal'],
+  publish       : ['azk/utils/postal'],
+  subscriptions : ['azk/utils/postal'],
+  unsubscribeAll: ['azk/utils/postal'],
 });
 
 describe("Azk utils, postal module", function() {
+  beforeEach(() => {
+    l.channel.unsubscribeAll();
+  });
+
   it("should support subscribe and publish with defailt channel", function(done) {
-    var topic = 'test.postal.module';
+    var topic = "test.postal.module";
     var data  = { data: true };
     var subs  = l.subscribe(topic, (msg) => {
       h.expect(msg).to.eql(data);
@@ -18,6 +25,23 @@ describe("Azk utils, postal module", function() {
     });
 
     l.publish(topic, data);
+  });
+
+  it("should return all subscribe for default channel if call subscriptions", function() {
+    var topic = "test.subscriptions";
+    var sub   = l.subscribe(topic, () => {});
+    var subs  = l.subscriptions();
+    h.expect(subs).to.eql([sub]);
+  });
+
+  it("should support unsubscribe all subscriptions", function() {
+    var topic = "test.subscriptions";
+    var sub   = l.subscribe(topic, () => {});
+    var subs  = l.subscriptions();
+    h.expect(subs).to.eql([sub]);
+    l.unsubscribeAll();
+    subs = l.subscriptions();
+    h.expect(subs).to.not.eql([sub]);
   });
 
   it("should raise erro if subscribe without topic", function() {

--- a/src/agent/api/ws.js
+++ b/src/agent/api/ws.js
@@ -57,7 +57,7 @@ var Controller = {
     var guest_folder = data.guest_folder;
     var opts         = data.opts;
 
-    // TODO: add progress to log single file sync
+    // TODO: add log single file sync
     this._send(ws, req_id, { status: 'start' });
     this.rsync_watcher.watch(host_folder, guest_folder, opts)
     .then(() => {

--- a/src/agent/balancer.js
+++ b/src/agent/balancer.js
@@ -108,7 +108,7 @@ var Balancer = {
   start_hipache(ip, port, socket) {
     var pid  = config("paths:hipache_pid");
     var file = this._check_config(ip, port, socket);
-    var cmd = [ 'nvm', 'hipache', '--config', file ];
+    var cmd  = [ 'nvm', 'hipache', '--config', file ];
     var name = "hipache";
 
     return this._start_service(name, cmd, pid).then((child) => {
@@ -168,14 +168,14 @@ var Balancer = {
     return manifest.system(system, true);
   },
 
-  _waitDocker() {
+  _waitDocker(shoot = true, retry = 10) {
     var docker_host = config("docker:host");
-    var promise = net.waitService(docker_host, 10, { timeout: 2000, context: "balancer" });
+    var promise = net.waitService(docker_host, retry, { timeout: 2000, context: "balancer" });
     return promise.then((success) => {
-      if (!success) {
+      if ((!success) && shoot) {
         throw new AgentStartError(t('errors.connect_docker_unavailable'));
       }
-      return true;
+      return success;
     });
   },
 
@@ -188,7 +188,7 @@ var Balancer = {
       var system = this._getSystem(system_name);
 
       // Wait docker
-      yield this._waitDocker();
+      yield this._waitDocker(false, 3);
 
       // Save outputs to use in error
       var output = "";

--- a/src/agent/balancer.js
+++ b/src/agent/balancer.js
@@ -269,7 +269,7 @@ var Balancer = {
     };
 
     return Tools.defer_status("balancer", (resolve, reject, change_status) => {
-      // Log and notify
+      // Log and post msgs
       log.info("starting " + name);
       change_status("starting_" + name);
 

--- a/src/agent/client.js
+++ b/src/agent/client.js
@@ -168,15 +168,15 @@ var Client = {
   },
 
   watch(host_folder, guest_folder, opts = {}) {
-    return defer((resolve, reject, notify) => {
+    return defer((resolve, reject) => {
       var req = { action: 'watch', data: { host_folder, guest_folder, opts } };
       WebSocketClient.send(req, (res, end) => {
         switch (res.status) {
           case 'start':
-            notify({ type: "status", status: "starting" });
+            publish("sync.status", { type: "starting" });
             break;
           case 'sync':
-            notify({ type: "sync", status: res.data });
+            publish("sync.status", { type: "sync", status: res.data });
             break;
           case 'done' :
             end();
@@ -204,7 +204,6 @@ var Client = {
             end();
             resolve(true);
             break;
-
         }
       });
     });

--- a/src/agent/client.js
+++ b/src/agent/client.js
@@ -1,4 +1,4 @@
-import { _, Q, defer, lazy_require, log } from 'azk';
+import { _, Q, defer, lazy_require, log, publish } from 'azk';
 import { config, set_config } from 'azk';
 import { Agent } from 'azk/agent';
 import { AgentNotRunning } from 'azk/utils/errors';
@@ -127,19 +127,21 @@ var WebSocketClient = {
 };
 
 var Client = {
-  status() {
+  status(action_name) {
     var status_obj = {
       agent   : false,
       docker  : false,
       balancer: false,
     };
 
-    return defer((resolve, _reject, notify) => {
+    return defer((resolve) => {
       if (Agent.agentPid().running) {
-        notify({ type: "status", status: "running" });
+        publish("agent.client.status", { type: "status", status: "running" });
         status_obj.agent = true;
       } else {
-        notify({ type: "status", status: "not_running" });
+        if (action_name !== 'start') {
+          publish("agent.client.status", { type: "status", status: "not_running" });
+        }
       }
       resolve(status_obj);
     });
@@ -150,10 +152,10 @@ var Client = {
   },
 
   stop(opts) {
-    return defer((_resolve, _reject, notify) => {
-      notify({ type: "status", status: "stopping" });
+    return defer(() => {
+      publish("agent.client.stop.status", { type: "status", status: "stopping" });
       return Agent.stop(opts).then((result) => {
-        if (result) { notify({ type: "status", status: "stopped" }); }
+        if (result) { publish("agent.client.stop.status", { type: "status", status: "stopped" }); }
         return { agent: result };
       });
     });

--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -1,4 +1,4 @@
-import { _, t, os, Q, async, log, lazy_require } from 'azk';
+import { _, t, os, Q, async, log, lazy_require, publish } from 'azk';
 import { config, set_config } from 'azk';
 import { UIProxy } from 'azk/cli/ui';
 import { OSNotSupported, DependencyError } from 'azk/utils/errors';
@@ -113,7 +113,7 @@ export class Configure extends UIProxy {
   }
 
   _checkAzkVersion() {
-    return async(this, function* (notify) {
+    return async(this, function* () {
       try {
         // check connectivity
         var currentOnline = yield net.isOnlineCheck();
@@ -133,7 +133,7 @@ export class Configure extends UIProxy {
           json: true,
         };
 
-        notify({ type: "status", keys: "configure.check_version"});
+        publish("agent.configure.check_version.status", { type: "status", keys: "configure.check_version"});
         var [response, body] = yield Q.ninvoke(request, 'get', config('urls:github:api:tags_url'), options);
         var statusCode = response.statusCode;
 
@@ -154,7 +154,7 @@ export class Configure extends UIProxy {
           this.ok('configure.latest_azk_version', { current_version: Azk.version });
         }
       } catch (err) {
-        notify({
+        publish("agent.configure.check_version.status", {
           type: "status",
           status: "error",
           data: new Error(t("configure.check_version_error", {

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -10,7 +10,6 @@ var lazy = lazy_require({
 });
 
 var blank_observer = {
-  notify() {},
   resolve() {},
   reject() {},
 };

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -106,7 +106,9 @@ var Agent = {
     process.on('SIGINT' , gracefullExit('SIGINT'));
     process.on('SIGQUIT', gracefullExit('SIGQUIT'));
     process.on('SIGUSR2', () => {
-      log.info('clear observer');
+      log.info('[azk] mock output');
+
+      unsubscribeAll();
       this.observer = blank_observer;
     });
   },

--- a/src/agent/migrations.js
+++ b/src/agent/migrations.js
@@ -1,5 +1,4 @@
-import { async, lazy_require } from 'azk';
-import { config } from 'azk';
+import { async, lazy_require, publish, config } from 'azk';
 var qfs = require('q-io/fs');
 
 var lazy = lazy_require({
@@ -49,7 +48,7 @@ var Migrations = {
   ],
 
   run(configure) {
-    return async(this, function* (notify) {
+    return async(this, function* () {
       // Meta options
       var meta_tag  = "last_migration";
 
@@ -60,7 +59,7 @@ var Migrations = {
       // Azk agent was set up at least once?
       if (yield qfs.exists(lazy.meta.cache_dir) && be_run.length > 0) {
         // Warns on the run of migrations
-        notify({ type: "status", keys: "configure.migrations.alert"});
+        publish("agent.migrations.run.status", { type: "status", keys: "configure.migrations.alert"});
 
         // Run migrations
         for (var i = 0; i < be_run.length; i++) {

--- a/src/agent/migrations.js
+++ b/src/agent/migrations.js
@@ -21,7 +21,7 @@ var Migrations = {
 
         if ((yield qfs.exists(origin)) && !(yield qfs.exists(target))) {
           yield configure.execShWithSudo('mv_resolver', (sudo_path) => {
-            // Moving resolver files and notify
+            // Moving resolver files and log
             configure.info('configure.migrations.moving_resolver', { origin, target });
             var result = `
               echo "" &&

--- a/src/agent/server.js
+++ b/src/agent/server.js
@@ -1,4 +1,4 @@
-import { config, async, log } from 'azk';
+import { config, async, log, publish } from 'azk';
 import { VM  }   from 'azk/agent/vm';
 import { Balancer } from 'azk/agent/balancer';
 import { Api } from 'azk/agent/api';
@@ -53,10 +53,10 @@ var Server = {
 
   installVM(start = false) {
     var vm_name = config("agent:vm:name");
-    return async(this, function* (notify) {
+    return async(this, function* () {
       var installed = yield VM.isInstalled(vm_name);
       var running   = (installed) ? yield VM.isRunnig(vm_name) : false;
-      var vm_notify = (status) => notify({ type: "status", context: "vm", status });
+      var vm_publish = (status) => publish("agent.server.installVM.status", { type: "status", context: "vm", status });
 
       if (!installed) {
         var opts = {
@@ -69,7 +69,7 @@ var Server = {
         yield VM.init(opts);
 
         // Set ssh key
-        vm_notify("sshkey");
+        vm_publish("sshkey");
         var file    = config("agent:vm:ssh_key") + ".pub";
         var content = yield qfs.read(file);
         VM.setProperty(vm_name, "/VirtualBox/D2D/SSH_KEY", content);
@@ -85,9 +85,9 @@ var Server = {
       }
 
       // Mount shared
-      vm_notify("mounting");
+      vm_publish("mounting");
       yield VM.mount(vm_name, "Root", config("agent:vm:mount_point"));
-      vm_notify("mounted");
+      vm_publish("mounted");
 
       // Mark installed
       this.vm_started = true;

--- a/src/agent/server.js
+++ b/src/agent/server.js
@@ -54,9 +54,13 @@ var Server = {
   installVM(start = false) {
     var vm_name = config("agent:vm:name");
     return async(this, function* () {
-      var installed = yield VM.isInstalled(vm_name);
-      var running   = (installed) ? yield VM.isRunnig(vm_name) : false;
-      var vm_publish = (status) => publish("agent.server.installVM.status", { type: "status", context: "vm", status });
+      var installed  = yield VM.isInstalled(vm_name);
+      var running    = (installed) ? yield VM.isRunnig(vm_name) : false;
+      var vm_publish = (status) => {
+        publish("agent.server.installVM.status", {
+          type: "status", context: "vm", status
+        });
+      };
 
       if (!installed) {
         var opts = {

--- a/src/agent/tools.js
+++ b/src/agent/tools.js
@@ -1,10 +1,10 @@
-import { async, defer, log } from 'azk';
+import { async, defer, log, publish } from 'azk';
 
 var Tools = {
   change_status(key, notify, status, data) {
     var keys = ["commands", key, "status", status];
     (status != "error") ?  log.info_t(keys, data) : null;
-    notify({ type: "status", context: key, status: status, data: data });
+    publish("agent." + key + ".status", { type: "status", context: key, status: status, data: data });
   },
 
   defer_status(key, func) {

--- a/src/agent/tools.js
+++ b/src/agent/tools.js
@@ -1,28 +1,25 @@
 import { async, defer, log, publish } from 'azk';
 
 var Tools = {
-  change_status(key, notify, status, data) {
+  change_status(key, status, data) {
     var keys = ["commands", key, "status", status];
     (status != "error") ?  log.info_t(keys, data) : null;
     publish("agent." + key + ".status", { type: "status", context: key, status: status, data: data });
   },
 
   defer_status(key, func) {
-    return defer((resolve, reject, notify) => {
+    return defer((resolve, reject) => {
       return func(resolve, reject, (status, data) => {
-        this.change_status(key, notify, status, data);
+        this.change_status(key, status, data);
       });
     });
   },
 
   async_status(key, ...args) {
-    return defer((_resolve, _reject, notify) => {
-      var args_to_call = [...args];
-      args_to_call.push((status, data) => {
-        this.change_status(key, notify, status, data);
-      });
-      return async(...args_to_call);
+    args.push((status, data) => {
+      this.change_status(key, status, data);
     });
+    return async(...args);
   },
 };
 

--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -96,6 +96,8 @@ var Helpers = {
           // running, starting, not_running, already_installed
           switch (event.status) {
             case "not_running":
+              cmd.fail([...keys].concat(event.status), event.data);
+              break;
             case "already_installed":
               cmd.fail([...keys].concat(event.status), event.data);
               break;
@@ -132,7 +134,7 @@ var Helpers = {
     };
   },
 
-  newPullProgress(cmd) {
+  newPullProgressBar(cmd) {
     return (msg) => {
       if (msg.type !== "pull_msg") {
         return msg;

--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -223,7 +223,7 @@ var Helpers = {
             stream.write(key);
           } else {
             if (escape) {
-              stopped = callback(ch, container);
+              stopped = callback(ch, container, () => stopped = false);
               escape = false;
             } else {
               stream.write(key);

--- a/src/cli/ui.js
+++ b/src/cli/ui.js
@@ -72,6 +72,7 @@ var UI = {
 
   // TOOD: Flush log (https://github.com/flatiron/winston/issues/228)
   exit(code = 0) {
+    require('azk/utils/postal').unsubscribeAll();
     setTimeout(() => {
       process.emit("azk:command:exit", code);
     }, 500);

--- a/src/cmds/agent.js
+++ b/src/cmds/agent.js
@@ -7,9 +7,6 @@ var lazy = lazy_require({
   Client : [ 'azk/agent/client' ],
   spawn  : ['child-process-promise'],
   net    : 'net',
-  channel: function() {
-    return require('postal').channel("agent");
-  }
 });
 
 class Cmd extends InteractiveCmds {

--- a/src/cmds/agent.js
+++ b/src/cmds/agent.js
@@ -1,4 +1,5 @@
-import { _, t, log, config, lazy_require, subscribe, defer, async, asyncUnsubscribe } from 'azk';
+import { _, t, log, config, lazy_require } from 'azk';
+import { defer, subscribe, asyncUnsubscribe } from 'azk';
 import { InteractiveCmds } from 'azk/cli/interactive_cmds';
 import { Helpers } from 'azk/cli/command';
 
@@ -80,7 +81,6 @@ class Cmd extends InteractiveCmds {
             memory: config("agent:vm:memory")
           };
         }
-
 
         // Track agent start
         this.docker.version().then((result) => {

--- a/src/cmds/shell.js
+++ b/src/cmds/shell.js
@@ -1,4 +1,5 @@
-import { _, t, async, asyncUnsubscribe, defer, lazy_require, subscribe } from 'azk';
+import { _, t, lazy_require } from 'azk';
+import { defer, subscribe, asyncUnsubscribe } from 'azk';
 import { InteractiveCmds } from 'azk/cli/interactive_cmds';
 import { Helpers } from 'azk/cli/command';
 
@@ -66,14 +67,15 @@ class Cmd extends InteractiveCmds {
       options.remove = opts.remove;
 
       var result = defer((resolver, reject) => {
-        var escape = (key, container) => {
+        var escape = (key, container, next) => {
           if (key === ".") {
             process.nextTick(() => {
               lazy.docker.getContainer(container).stop({ t: 5000 }).fail(reject);
             });
             return true;
           } else if (key === "?") {
-            this.ok("show help");
+            this.ok("coming soon...");
+            process.nextTick(() => next());
             return true;
           }
           return false;

--- a/src/cmds/shell.js
+++ b/src/cmds/shell.js
@@ -1,4 +1,4 @@
-import { _, t, async, defer, lazy_require } from 'azk';
+import { _, t, async, asyncUnsubscribe, defer, lazy_require, subscribe } from 'azk';
 import { InteractiveCmds } from 'azk/cli/interactive_cmds';
 import { Helpers } from 'azk/cli/command';
 
@@ -9,8 +9,12 @@ var lazy = lazy_require({
 
 class Cmd extends InteractiveCmds {
   action(opts) {
-    var progress = Helpers.newPullProgress(this);
-    return async(this, function* () {
+
+    var _subscription = subscribe('docker.pull.status', (data) => {
+      Helpers.newPullProgressBar(this)(data);
+    });
+
+    return asyncUnsubscribe(this, _subscription, function* () {
       var cmd = [opts.cmd, ...opts.__leftover];
       var dir = this.cwd;
       var manifest, system;
@@ -75,11 +79,21 @@ class Cmd extends InteractiveCmds {
           return false;
         };
 
-        var shell_progress = this._escapeAndPullProgress(escape, system, !opts.silent, opts.verbose, options.stdout);
+        var _subscription_run = subscribe('docker.run.status', (data) => {
+          this._escapeAndPullProgress(escape, system, !opts.silent, opts.verbose, options.stdout)(data);
+        });
 
-        system.runShell(cmd, options).
-          progress(shell_progress).
-          then(resolver, reject);
+        system.runShell(cmd, options)
+          .then(function (result) {
+            _subscription_run.unsubscribe();
+            return result;
+          })
+          .then(resolver, reject)
+          .catch(function (err) {
+            _subscription_run.unsubscribe();
+            throw err;
+          });
+
       });
 
       result = yield result.fail((error) => {
@@ -87,7 +101,7 @@ class Cmd extends InteractiveCmds {
       });
 
       return result.code;
-    }).progress(progress);
+    });
   }
 
   parseError(error) {
@@ -108,8 +122,8 @@ class Cmd extends InteractiveCmds {
 
   _escapeAndPullProgress(escape, system, show_logs, verbose) {
     return (event) => {
-      var pull_progress = Helpers.newPullProgress(this);
-      var escape_progress = Helpers.escapeCapture(escape);
+      var pullProgressBar = Helpers.newPullProgressBar(this);
+      var escapeCapture = Helpers.escapeCapture(escape);
 
       // show verbose output
       if (verbose && event.stream) {
@@ -117,10 +131,10 @@ class Cmd extends InteractiveCmds {
       }
 
       if (event.type === "stdin_pipe") {
-        escape_progress(event);
+        escapeCapture(event);
       } else if (show_logs) {
         if (show_logs && event.type === "pull_msg") {
-          pull_progress(event);
+          pullProgressBar(event);
         } else if (event.type === "action") {
           var keys = ["commands", "scale"];
           var actions = ["pull_image", "build_image"];

--- a/src/docker/build.js
+++ b/src/docker/build.js
@@ -1,4 +1,4 @@
-import { _, Q, async, lazy_require, path } from 'azk';
+import { _, Q, async, lazy_require, path, publish } from 'azk';
 import { DockerBuildError } from 'azk/utils/errors';
 
 var lazy = lazy_require({
@@ -39,7 +39,7 @@ function parse_stream(msg) {
 }
 
 export function build(docker, options) {
-  return async(function* (notify) {
+  return async(function* () {
     var opts = _.extend({
       cache: true
     }, options);
@@ -97,7 +97,7 @@ export function build(docker, options) {
           opts.stdout.write('  ' + msg.stream);
         }
         if (msg.statusParsed) {
-          notify(msg);
+          publish("docker.build.status", msg);
           if (msg.statusParsed.type == "building_from") {
             from = msg.statusParsed.FROM;
           }

--- a/src/docker/docker.js
+++ b/src/docker/docker.js
@@ -173,7 +173,7 @@ export class Docker extends Utils.qify('dockerode') {
   azkListContainers(...args) {
     return this.listContainers(...args).then((containers) => {
       return _.reduce(containers, (result, container) => {
-        if (container.Names[0].match(this.c_regex)) {
+        if (container.Names && container.Names[0].match(this.c_regex)) {
           container.Name = container.Names[0];
           container.Annotations = Container.unserializeAnnotations(container.Name);
           container.State = Container.parseStatus(container.Status);

--- a/src/docker/pull.js
+++ b/src/docker/pull.js
@@ -1,4 +1,4 @@
-import { _, defer, lazy_require } from 'azk';
+import { _, defer, lazy_require, publish } from 'azk';
 import { ProvisionNotFound, ProvisionPullError } from 'azk/utils/errors';
 
 var lazy = lazy_require({
@@ -42,7 +42,7 @@ export function pull(docker, repository, tag, stdout, registry_result) {
     tag: tag,
   });
   return promise.then((stream) => {
-    return defer((resolve, reject, notify) => {
+    return defer((resolve, reject) => {
       stream.on('data', (data) => {
         try {
           var msg             = JSON.parse(data.toString());
@@ -57,13 +57,13 @@ export function pull(docker, repository, tag, stdout, registry_result) {
           } else {
             // parse message
             msg.statusParsed = parse_status(msg.status);
-            notify(msg); // -> cli.helpers.newPullProgress
+            publish("docker.pull.status", msg);
           }
         } catch (e) {}
       });
 
       stream.on('end', () => {
-        notify({ type: "pull_msg", end: true, image});
+        publish("docker.pull.status", { type: "pull_msg", end: true, image});
         resolve(docker.findImage(image));
       });
     });

--- a/src/docker/run.js
+++ b/src/docker/run.js
@@ -1,4 +1,4 @@
-import { _, async, config, log } from 'azk';
+import { _, async, config, log, publish } from 'azk';
 import { default as tracker } from 'azk/utils/tracker';
 
 function new_resize(container) {
@@ -78,17 +78,17 @@ export function run(docker, Container, image, cmd, opts = { }) {
     'name': name,
   };
 
-  return async(docker, function* (notify) {
+  return async(docker, function* () {
     var resize, isRaw, stream;
     var create_opts = _.merge(optsc, docker_opts.create || {});
     log.debug("[docker] creating a container with ", create_opts);
     container = yield this.createContainer(create_opts);
 
-    var c_notify = (type, ...data) => {
-      return notify({ type, context: "container_run", id: container.id, data: data });
+    var c_publish = (type, ...data) => {
+      publish("docker.run.status", { type, context: "container_run", id: container.id, data: data });
     };
-    c_notify("created");
-    notify({type: "created", id: container.id});
+    c_publish("created");
+    publish("docker.run.status", {type: "created", id: container.id});
 
     // Resize tty
     if (interactive) {
@@ -102,7 +102,7 @@ export function run(docker, Container, image, cmd, opts = { }) {
         log: true, stream: true,
         stdin: interactive, stdout: true, stderr: true
       });
-      c_notify("attached");
+      c_publish("attached");
 
       if (interactive) {
         stream.pipe(opts.stdout);
@@ -125,7 +125,7 @@ export function run(docker, Container, image, cmd, opts = { }) {
           opts.stdin.pipe(stream);
         }
 
-        c_notify("stdin_pipe", { stdin: opts.stdin, stream });
+        c_publish("stdin_pipe", { stdin: opts.stdin, stream });
       }
     }
 
@@ -152,7 +152,7 @@ export function run(docker, Container, image, cmd, opts = { }) {
       tracker.logAnalyticsError(err);
     }
 
-    c_notify("started");
+    c_publish("started");
 
     if (!daemon) {
       if (interactive && opts.tty) {
@@ -161,7 +161,7 @@ export function run(docker, Container, image, cmd, opts = { }) {
       }
 
       // Wait container
-      c_notify("wait");
+      c_publish("wait");
       yield container.wait();
       if (interactive) {
         opts.stdout.removeListener('resize', resize);

--- a/src/images/index.js
+++ b/src/images/index.js
@@ -1,5 +1,4 @@
-import { _, fs, t, path, isBlank } from 'azk';
-import { async, defer, lazy_require } from 'azk';
+import { _, fs, t, path, isBlank, publish, async, defer, lazy_require } from 'azk';
 import { ManifestError, NoInternetConnection, LostInternetConnection } from 'azk/utils/errors';
 import { net } from 'azk/utils';
 import Utils from 'azk/utils';
@@ -43,14 +42,14 @@ export class Image {
   }
 
   check() {
-    return defer((_resolve, _reject, notify) => {
-      notify({ type: "action", context: "image", action: "check_image" });
+    return defer(() => {
+      publish("image.check.status", { type: "action", context: "image", action: "check_image" });
       return lazy.docker.findImage(this.name);
     });
   }
 
   pull(options, stdout) {
-    return async(this, function* (notify) {
+    return async(this, function* () {
       // split docker namespace and docker repository
       var namespace   = '';
       var repository  = '';
@@ -76,7 +75,7 @@ export class Image {
       // download from registry
       if (isBlank(image) || options.build_force) {
         this.repository = namespace + '/' + repository;
-        notify({ type: "action", context: "image", action: "pull_image", data: this });
+        publish("image.pull.status", { type: "action", context: "image", action: "pull_image", data: this });
 
         var registry_result;
         var output;
@@ -109,7 +108,7 @@ export class Image {
   }
 
   getDownloadInfo(dockerode_modem, namespace, repository, repo_tag) {
-    return async(this, function* (notify) {
+    return async(this, function* () {
 
       var docker_socket   = { dockerode_modem: dockerode_modem };
       var request_options = {
@@ -127,14 +126,11 @@ export class Image {
       var getLayersDiff_result;
 
       hubResult = yield syncronizer.dockerHub.images(namespace, repository);
-      // Check what layer we do not have locally
-      notify({  type       : "pull_msg",
-                traslation : "commands.helpers.pull.pull_getLayersDiff",
-                data       : registry_infos });
 
       // Get layers diff
       getLayersDiff_result = yield syncronizer.getLayersDiff(hubResult, tag);
 
+      // Check what layer we do not have locally
       var registry_layers_ids       = getLayersDiff_result.registry_layers_ids;
       var non_existent_locally_ids  = getLayersDiff_result.non_existent_locally_ids;
 
@@ -143,15 +139,22 @@ export class Image {
         non_existent_locally_ids_count : non_existent_locally_ids.length
       };
 
+      publish("image.getDownloadInfo.status", {
+        type       : "pull_msg",
+        traslation : "commands.helpers.pull.pull_getLayersDiff",
+        data       : registry_infos
+      });
+
       return registry_infos;
     });
   }
 
   build(options) {
-    return async(this, function* (notify) {
+    return async(this, function* () {
       var image = yield this.check();
       if (options.build_force || isBlank(image)) {
-        notify({ type: 'action', context: 'image', action: 'build_image', data: this });
+        publish("image.build.status",
+          { type: 'action', context: 'image', action: 'build_image', data: this });
         image = yield lazy.docker.build({
                                     dockerfile: this.path,
                                     tag: this.name,

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import { Q, _, defer, async, isBlank } from 'azk/utils';
+import { Q, _, defer, async, isBlank, asyncUnsubscribe } from 'azk/utils';
 
 Q.longStackSupport = true;
 
@@ -47,6 +47,7 @@ module.exports = {
   // Promise helpers
   get defer() { return defer; },
   get async() { return async; },
+  get asyncUnsubscribe() { return asyncUnsubscribe; },
 
   // Internals alias
   get os     () { return require('os'); },
@@ -66,4 +67,9 @@ module.exports = {
     }
     return _log;
   },
+
+  // Postal helpers
+  get subscribe() { return require("azk/utils/postal").subscribe; },
+  get publish() { return require("azk/utils/postal").publish; },
+
 };

--- a/src/system/run.js
+++ b/src/system/run.js
@@ -77,8 +77,14 @@ var Run = {
       var container  = yield lazy.docker.run(system.image.name, command, docker_opt);
       var data       = yield container.inspect();
 
+      log.debug("[system] container shell ended: %s", container.id);
+
       // Remove after run
-      if (options.remove) { yield container.remove(); }
+      if (options.remove) {
+        log.debug("[system] call to remove container %s", container.id);
+        yield container.remove();
+        log.debug("[system] container removed %s", container.id);
+      }
 
       yield system.stopWatching();
 

--- a/src/system/scale.js
+++ b/src/system/scale.js
@@ -1,4 +1,4 @@
-import { Q, async, _, lazy_require } from 'azk';
+import { Q, async, _, lazy_require, publish } from 'azk';
 import { calculateHash } from 'azk/utils';
 import { SystemDependError, SystemNotScalable } from 'azk/utils/errors';
 import { Balancer } from 'azk/system/balancer';
@@ -27,7 +27,7 @@ var Scale = {
       dependencies: true,
     });
 
-    return async(this, function* (notify) {
+    return async(this, function* () {
       // how many times the
       var containers = yield this.instances(system);
 
@@ -42,7 +42,7 @@ var Scale = {
       }
 
       if (icc !== 0) {
-        notify({ type: "scale", from: from, to: from + icc, system: system.name });
+        publish("system.scale.status", { type: "scale", from: from, to: from + icc, system: system.name });
       }
 
       if (icc > 0) {

--- a/src/utils/capture_io.js
+++ b/src/utils/capture_io.js
@@ -36,4 +36,5 @@ function capture_io(block) {
   });
 }
 
+export { capture_io };
 export default capture_io;

--- a/src/utils/net.js
+++ b/src/utils/net.js
@@ -1,5 +1,4 @@
-import { Q, _, async, defer, fs, lazy_require } from 'azk';
-import { config, set_config } from 'azk';
+import { Q, _, async, defer, fs, lazy_require, publish, config, set_config } from 'azk';
 import { envDefaultArray, isBlank } from 'azk/utils';
 
 var portscanner = require('portscanner');
@@ -195,12 +194,13 @@ var net = {
       };
     }
 
-    return defer((resolve, reject, notify) => {
+    return defer((resolve) => {
       var client   = null;
       var attempts = 1, max = retry;
       var connect  = () => {
         var t = null;
-        notify(_.merge({
+
+        publish("utils.net.waitService.status", _.merge({
           uri : uri,
           type: 'try_connect', attempts: attempts, max: max, context: opts.context
         }, address ));
@@ -232,11 +232,11 @@ var net = {
 
   // TODO: change for a generic service wait function
   waitForwardingService(host, port, retry = 15, timeout = 10000) {
-    return defer((resolve, reject, notify) => {
+    return defer((resolve, reject) => {
       var client   = null;
       var attempts = 1, max = retry;
       var connect  = () => {
-        notify({ type: 'try_connect', attempts: attempts, max: max });
+        publish("utils.net.waitForwardingService.status", { type: 'try_connect', attempts: attempts, max: max });
 
         var timeout_func = function() {
           attempts += 1;

--- a/src/utils/postal.js
+++ b/src/utils/postal.js
@@ -32,3 +32,110 @@ export class IPublisher {
     publish(this.topic_prefix + '.' + topic, ...args);
   }
 }
+
+export class SubscriptionLogger {
+  constructor() {
+    this.date_now = Date.now();
+    this.loggerSubscription = null;
+  }
+
+  subscribeTo(topic) {
+    if (topic) {
+      var subscribe_topic = topic;
+      var subscribe = require("azk").subscribe;
+      var log = require("azk/utils/log").log;
+
+      if (!this.date_now) {
+        this.date_now = Date.now();
+      }
+
+      // unsubscribe if already subscribed
+      if (this.loggerSubscription) {
+        this.unsubscribeLogger();
+      }
+
+      this.loggerSubscription = subscribe(subscribe_topic, function (data, envelope) {
+        try {
+          var final_string = '';
+
+          //  timespan
+          var timespan = Date.now() - this.date_now;
+          this.date_now = Date.now();
+          var timespan_string = timespan.toString();
+          var spaces_to_add = 6 - timespan_string.length;
+          var spaces_to_add_string = '';
+          for (var i = 0; i < spaces_to_add; i++) {
+            spaces_to_add_string = spaces_to_add_string + ' ';
+          }
+          final_string += '[postal]'.grey + spaces_to_add_string + timespan_string.grey + '.ms'.grey;
+
+          // # topic
+          final_string += ' # '.grey;
+          final_string += envelope.topic.white.italic;
+
+          // context
+          if (data.context) {
+            final_string += ' :'.blue + data.context.blue;
+          }
+
+          // type
+          if (data.type) {
+            final_string += ' :'.magenta + data.type.magenta;
+          }
+
+          // statusParsed or status
+          if (typeof data.statusParsed === 'string') {
+            final_string += ' :'.green + data.statusParsed.green;
+          } else if (data.statusParsed && data.statusParsed.type) {
+            final_string += ' :'.green + data.statusParsed.type.toString().green;
+          } else if (data.status) {
+            final_string += ' :'.green + data.status.green;
+          }
+
+          // id
+          if (data.id) {
+            var id = data.id.toString();
+            if (id.length > 8) {
+              id = id.substring(0, 8);
+            }
+            final_string += ' #'.cyan + id.cyan;
+          }
+
+          // data content substring
+          var length = 10;
+          var mydata_prefix = ' data: '.grey;
+          var mydata = null;
+          if (data.stream) {
+            mydata_prefix = ' stream: '.grey;
+            mydata = data.stream.toString();
+          } else if (data.progressDetail) {
+            mydata_prefix = ' progressDetail: '.grey;
+            mydata = JSON.stringify(data.progressDetail);
+          } else if (typeof data === 'string') {
+            mydata = data;
+          }
+
+          if (mydata) {
+            mydata = mydata.replace(/\n/gm, ''); // remove new lines
+            if (mydata.length >= length) {
+              length = mydata.length;
+            }
+            final_string += mydata_prefix + mydata.substring(0, length).grey;
+          }
+
+          log.debug(final_string);
+        } catch (err) {
+          log.error(err.stack);
+          // log.debug({ log_label: "[postal]", data: err});
+        }
+      }.bind(this));
+    }
+  }
+
+  unsubscribeLogger() {
+    if (this.loggerSubscription) {
+      this.loggerSubscription.unsubscribe();
+    }
+  }
+
+}

--- a/src/utils/postal.js
+++ b/src/utils/postal.js
@@ -31,6 +31,14 @@ export class IPublisher {
   publish(topic, ...args) {
     publish(this.topic_prefix + '.' + topic, ...args);
   }
+
+  subscribe(topic, func = null) {
+    if (typeof topic === 'function') {
+      [func, topic] = [topic, null];
+    }
+    topic = topic || "*";
+    return subscribe(`${this.topic_prefix}.${topic}`, func);
+  }
 }
 
 export class SubscriptionLogger {


### PR DESCRIPTION
This PR closes #385

> Before run tests or azk you can enable postal log enabling with "#".
> You will see all messages transmitted.

```sh
export AZK_SUBSCRIBE_POSTAL=#
```

- [x] List all the places where we're using notify/progress
- [x] Define which channels and the format of the messages we're going to use with the postal lib
- [x] Create a subscribe and a publish utils functions
- [x] Show all messages when using this env: `AZK_SUBSCRIBE_POSTAL=#`
- [x] Find a better way to unsubscribe directly from async function 
  - `docker rmi -f azukiapp/azktcl:0.0.1; azk shell --image azukiapp/azktcl:0.0.1 -t -c "/bin/bash"`
- [x] Unsubscribe from all subscriptions after use (double check)
- [x] Fix test bellow
```sh
azk nvm gulp test --grep="should wait for server"
```
- [x] Fix test bellow
```sh
azk nvm gulp test --grep="should stop retry"
```
- [x] Replace then/catch unsubscribes with the new utils function: `asyncUnsubscribe`
- [x] Check all `progress` with `return` to catch `chain progress calls` on the old code;
- [x] Fix WIP commits with `git rebase -i master`
- [x] Update CHANGELOG

- [x] Fix test bellow

```sh
azk nvm gulp test --grep="azk project check image before"
```
- [x] merge utils/postal with utils/postal_helper
- [x] global SubscriptionLogger must log to log() not to console.log

### enable postal logs

```sh
export AZK_LOG_LEVEL=debug
export AZK_SUBSCRIBE_POSTAL=#                        
```

### tests: see postal logs

```sh
tail -f ~/.azk/data/logs/azk_test.log | sed -n '/\[postal\]/p'
```

### azk: see postal logs

```sh
tail -f ~/.azk/data/logs/azk.log | sed -n '/\[postal\]/p'
```

- [x] Remove message when starting agent: `azk: Agent is not running (try: azk agent start).`
  - [x] Compare all messages send to output on master version
- [x] fix `spec/docker/build_spec.js` merge
- [ ] When 80 port is used, occours an error on at /azk:0.12.1/src/cmds/agent.js:144:22: `var buff = Buffer(JSON.stringify(cmd_options.configs));` - try to catch this error
- [x] when running azk as daemon, container is not remove after `azk agent stop`
- [x] rebase from master after azk 0.13.1
  - [x] fix sync support (using notify)
- [x] Clean the progress and notify that are not strictly necessary