### PR TITLE
[fix_registry_downloader] Fixing registry download error updating `docker-registry-downloader` to version v0.1.36.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [cli] Fixing `--mount` option of `azk shell` command to comply with Docker's pattern (`local_folder:remote_folder`);
   * [Docker] Fixing parse invalid instructions in build a Dockerfile, #391;
   * [Tracking] Fixing timeout message when tracking an event;
+  * [Imagens] Fixing registry download error #407
 
 * Enhancements
   * [Test] Adding flag `--no-required-agent` to disable required `Agent` before tests;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  * [Imagens] Fixing registry download error #407
+
 ## v0.13.0 - (2015-27-05)
 
 * Bug
   * [cli] Fixing `--mount` option of `azk shell` command to comply with Docker's pattern (`local_folder:remote_folder`);
   * [Docker] Fixing parse invalid instructions in build a Dockerfile, #391;
   * [Tracking] Fixing timeout message when tracking an event;
-  * [Imagens] Fixing registry download error #407
 
 * Enhancements
   * [Test] Adding flag `--no-required-agent` to disable required `Agent` before tests;

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -4318,89 +4318,89 @@
       }
     },
     "docker-registry-downloader": {
-      "version": "0.1.35",
-      "from": "https://registry.npmjs.org/docker-registry-downloader/-/docker-registry-downloader-0.1.35.tgz",
-      "resolved": "https://registry.npmjs.org/docker-registry-downloader/-/docker-registry-downloader-0.1.35.tgz",
+      "version": "0.1.36",
+      "from": "docker-registry-downloader@0.1.36",
+      "resolved": "https://registry.npmjs.org/docker-registry-downloader/-/docker-registry-downloader-0.1.36.tgz",
       "dependencies": {
         "async": {
-          "version": "0.9.0",
-          "from": "https://registry.npmjs.org/async/-/async-0.9.0.tgz",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.0.tgz"
+          "version": "0.9.2",
+          "from": "async@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
         },
         "cli-color": {
           "version": "0.3.3",
-          "from": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
+          "from": "cli-color@>=0.3.2 <0.4.0",
           "resolved": "https://registry.npmjs.org/cli-color/-/cli-color-0.3.3.tgz",
           "dependencies": {
             "d": {
               "version": "0.1.1",
-              "from": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
+              "from": "d@>=0.1.1 <0.2.0",
               "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz"
             },
             "es5-ext": {
-              "version": "0.10.6",
-              "from": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
-              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.6.tgz",
+              "version": "0.10.7",
+              "from": "es5-ext@>=0.10.6 <0.11.0",
+              "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.7.tgz",
               "dependencies": {
                 "es6-iterator": {
                   "version": "0.1.3",
-                  "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                  "from": "es6-iterator@>=0.1.3 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                 },
                 "es6-symbol": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                  "from": "es6-symbol@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                 }
               }
             },
             "memoizee": {
               "version": "0.3.8",
-              "from": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
+              "from": "memoizee@>=0.3.8 <0.4.0",
               "resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.3.8.tgz",
               "dependencies": {
                 "es6-weak-map": {
                   "version": "0.1.4",
-                  "from": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
+                  "from": "es6-weak-map@>=0.1.2 <0.2.0",
                   "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
                   "dependencies": {
                     "es6-iterator": {
                       "version": "0.1.3",
-                      "from": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
+                      "from": "es6-iterator@>=0.1.3 <0.2.0",
                       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz"
                     },
                     "es6-symbol": {
                       "version": "2.0.1",
-                      "from": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
+                      "from": "es6-symbol@>=2.0.1 <2.1.0",
                       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz"
                     }
                   }
                 },
                 "event-emitter": {
                   "version": "0.3.3",
-                  "from": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz",
+                  "from": "event-emitter@>=0.3.1 <0.4.0",
                   "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.3.tgz"
                 },
                 "lru-queue": {
                   "version": "0.1.0",
-                  "from": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+                  "from": "lru-queue@>=0.1.0 <0.2.0",
                   "resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz"
                 },
                 "next-tick": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                  "from": "next-tick@>=0.2.2 <0.3.0",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                 }
               }
             },
             "timers-ext": {
               "version": "0.1.0",
-              "from": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
+              "from": "timers-ext@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.0.tgz",
               "dependencies": {
                 "next-tick": {
                   "version": "0.2.2",
-                  "from": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz",
+                  "from": "next-tick@>=0.2.2 <0.3.0",
                   "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-0.2.2.tgz"
                 }
               }
@@ -4409,54 +4409,61 @@
         },
         "indent-string": {
           "version": "1.2.1",
-          "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
+          "from": "indent-string@>=1.2.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.1.tgz",
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "from": "get-stdin@>=4.0.1 <5.0.0",
               "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
             },
             "minimist": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz",
+              "from": "minimist@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.1.tgz"
             },
             "repeating": {
               "version": "1.1.2",
-              "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
+              "from": "repeating@>=1.1.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.2.tgz",
               "dependencies": {
                 "is-finite": {
-                  "version": "1.0.0",
-                  "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz",
-                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.0.tgz"
+                  "version": "1.0.1",
+                  "from": "is-finite@>=1.0.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
+                  "dependencies": {
+                    "number-is-nan": {
+                      "version": "1.0.0",
+                      "from": "number-is-nan@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
+                    }
+                  }
                 },
                 "meow": {
                   "version": "3.1.0",
-                  "from": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
+                  "from": "meow@>=3.0.0 <4.0.0",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.1.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
+                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
-                          "version": "1.0.2",
-                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz",
-                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.0.2.tgz"
+                          "version": "1.1.0",
+                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.1.0.tgz"
                         },
                         "map-obj": {
-                          "version": "1.0.0",
-                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz",
-                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.0.tgz"
+                          "version": "1.0.1",
+                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "object-assign": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz",
+                      "from": "object-assign@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-2.0.0.tgz"
                     }
                   }
@@ -4467,73 +4474,351 @@
         },
         "progress": {
           "version": "1.1.8",
-          "from": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+          "from": "progress@>=1.1.8 <2.0.0",
           "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
         },
         "requestretry": {
-          "version": "1.2.2",
-          "from": "https://registry.npmjs.org/requestretry/-/requestretry-1.2.2.tgz",
-          "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.2.2.tgz",
+          "version": "1.3.1",
+          "from": "requestretry@>=1.2.2 <2.0.0",
+          "resolved": "https://registry.npmjs.org/requestretry/-/requestretry-1.3.1.tgz",
           "dependencies": {
             "fg-lodash": {
               "version": "0.0.2",
-              "from": "https://registry.npmjs.org/fg-lodash/-/fg-lodash-0.0.2.tgz",
+              "from": "fg-lodash@0.0.2",
               "resolved": "https://registry.npmjs.org/fg-lodash/-/fg-lodash-0.0.2.tgz",
               "dependencies": {
                 "underscore.string": {
                   "version": "2.3.3",
-                  "from": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz",
+                  "from": "underscore.string@>=2.3.3 <2.4.0",
                   "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.3.3.tgz"
+                }
+              }
+            },
+            "request": {
+              "version": "2.55.0",
+              "from": "request@>=2.55.0 <2.56.0",
+              "resolved": "https://registry.npmjs.org/request/-/request-2.55.0.tgz",
+              "dependencies": {
+                "bl": {
+                  "version": "0.9.4",
+                  "from": "bl@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/bl/-/bl-0.9.4.tgz",
+                  "dependencies": {
+                    "readable-stream": {
+                      "version": "1.0.33",
+                      "from": "readable-stream@>=1.0.26 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+                      "dependencies": {
+                        "core-util-is": {
+                          "version": "1.0.1",
+                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
+                        },
+                        "isarray": {
+                          "version": "0.0.1",
+                          "from": "isarray@0.0.1",
+                          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                        },
+                        "string_decoder": {
+                          "version": "0.10.31",
+                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                        },
+                        "inherits": {
+                          "version": "2.0.1",
+                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
+                        }
+                      }
+                    }
+                  }
+                },
+                "caseless": {
+                  "version": "0.9.0",
+                  "from": "caseless@>=0.9.0 <0.10.0",
+                  "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.9.0.tgz"
+                },
+                "forever-agent": {
+                  "version": "0.6.1",
+                  "from": "forever-agent@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+                },
+                "form-data": {
+                  "version": "0.2.0",
+                  "from": "form-data@>=0.2.0 <0.3.0",
+                  "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.2.0.tgz"
+                },
+                "json-stringify-safe": {
+                  "version": "5.0.1",
+                  "from": "json-stringify-safe@>=5.0.0 <5.1.0",
+                  "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+                },
+                "mime-types": {
+                  "version": "2.0.12",
+                  "from": "mime-types@>=2.0.1 <2.1.0",
+                  "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.12.tgz",
+                  "dependencies": {
+                    "mime-db": {
+                      "version": "1.10.0",
+                      "from": "mime-db@>=1.10.0 <1.11.0",
+                      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.10.0.tgz"
+                    }
+                  }
+                },
+                "qs": {
+                  "version": "2.4.2",
+                  "from": "qs@>=2.4.0 <2.5.0",
+                  "resolved": "https://registry.npmjs.org/qs/-/qs-2.4.2.tgz"
+                },
+                "tunnel-agent": {
+                  "version": "0.4.0",
+                  "from": "tunnel-agent@>=0.4.0 <0.5.0",
+                  "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.0.tgz"
+                },
+                "tough-cookie": {
+                  "version": "1.2.0",
+                  "from": "tough-cookie@>=0.12.0",
+                  "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-1.2.0.tgz"
+                },
+                "http-signature": {
+                  "version": "0.10.1",
+                  "from": "http-signature@>=0.10.0 <0.11.0",
+                  "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-0.10.1.tgz",
+                  "dependencies": {
+                    "assert-plus": {
+                      "version": "0.1.5",
+                      "from": "assert-plus@>=0.1.5 <0.2.0",
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.1.5.tgz"
+                    },
+                    "asn1": {
+                      "version": "0.1.11",
+                      "from": "asn1@0.1.11",
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.1.11.tgz"
+                    },
+                    "ctype": {
+                      "version": "0.5.3",
+                      "from": "ctype@0.5.3",
+                      "resolved": "https://registry.npmjs.org/ctype/-/ctype-0.5.3.tgz"
+                    }
+                  }
+                },
+                "oauth-sign": {
+                  "version": "0.6.0",
+                  "from": "oauth-sign@>=0.6.0 <0.7.0",
+                  "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.6.0.tgz"
+                },
+                "hawk": {
+                  "version": "2.3.1",
+                  "from": "hawk@>=2.3.0 <2.4.0",
+                  "resolved": "https://registry.npmjs.org/hawk/-/hawk-2.3.1.tgz",
+                  "dependencies": {
+                    "hoek": {
+                      "version": "2.14.0",
+                      "from": "hoek@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.14.0.tgz"
+                    },
+                    "boom": {
+                      "version": "2.7.2",
+                      "from": "boom@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/boom/-/boom-2.7.2.tgz"
+                    },
+                    "cryptiles": {
+                      "version": "2.0.4",
+                      "from": "cryptiles@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.4.tgz"
+                    },
+                    "sntp": {
+                      "version": "1.0.9",
+                      "from": "sntp@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                    }
+                  }
+                },
+                "aws-sign2": {
+                  "version": "0.5.0",
+                  "from": "aws-sign2@>=0.5.0 <0.6.0",
+                  "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.5.0.tgz"
+                },
+                "stringstream": {
+                  "version": "0.0.4",
+                  "from": "stringstream@>=0.0.4 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.4.tgz"
+                },
+                "combined-stream": {
+                  "version": "0.0.7",
+                  "from": "combined-stream@>=0.0.5 <0.1.0",
+                  "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+                  "dependencies": {
+                    "delayed-stream": {
+                      "version": "0.0.5",
+                      "from": "delayed-stream@0.0.5",
+                      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz"
+                    }
+                  }
+                },
+                "isstream": {
+                  "version": "0.1.2",
+                  "from": "isstream@>=0.1.1 <0.2.0",
+                  "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+                },
+                "har-validator": {
+                  "version": "1.7.0",
+                  "from": "har-validator@>=1.4.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-1.7.0.tgz",
+                  "dependencies": {
+                    "bluebird": {
+                      "version": "2.9.26",
+                      "from": "bluebird@>=2.9.25 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.9.26.tgz"
+                    },
+                    "chalk": {
+                      "version": "1.0.0",
+                      "from": "chalk@>=1.0.0 <2.0.0",
+                      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.0.0.tgz",
+                      "dependencies": {
+                        "ansi-styles": {
+                          "version": "2.0.1",
+                          "from": "ansi-styles@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.0.1.tgz"
+                        },
+                        "escape-string-regexp": {
+                          "version": "1.0.3",
+                          "from": "escape-string-regexp@>=1.0.2 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
+                        },
+                        "has-ansi": {
+                          "version": "1.0.3",
+                          "from": "has-ansi@>=1.0.3 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-1.0.3.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            },
+                            "get-stdin": {
+                              "version": "4.0.1",
+                              "from": "get-stdin@>=4.0.1 <5.0.0",
+                              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+                            }
+                          }
+                        },
+                        "strip-ansi": {
+                          "version": "2.0.1",
+                          "from": "strip-ansi@>=2.0.1 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-2.0.1.tgz",
+                          "dependencies": {
+                            "ansi-regex": {
+                              "version": "1.1.1",
+                              "from": "ansi-regex@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-1.1.1.tgz"
+                            }
+                          }
+                        },
+                        "supports-color": {
+                          "version": "1.3.1",
+                          "from": "supports-color@>=1.3.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.3.1.tgz"
+                        }
+                      }
+                    },
+                    "commander": {
+                      "version": "2.8.1",
+                      "from": "commander@>=2.8.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/commander/-/commander-2.8.1.tgz",
+                      "dependencies": {
+                        "graceful-readlink": {
+                          "version": "1.0.1",
+                          "from": "graceful-readlink@>=1.0.0",
+                          "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                        }
+                      }
+                    },
+                    "is-my-json-valid": {
+                      "version": "2.12.0",
+                      "from": "is-my-json-valid@>=2.10.1 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.12.0.tgz",
+                      "dependencies": {
+                        "generate-function": {
+                          "version": "2.0.0",
+                          "from": "generate-function@>=2.0.0 <3.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                        },
+                        "generate-object-property": {
+                          "version": "1.2.0",
+                          "from": "generate-object-property@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                          "dependencies": {
+                            "is-property": {
+                              "version": "1.0.2",
+                              "from": "is-property@>=1.0.0 <2.0.0",
+                              "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                            }
+                          }
+                        },
+                        "jsonpointer": {
+                          "version": "1.1.0",
+                          "from": "jsonpointer@>=1.1.0 <2.0.0",
+                          "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-1.1.0.tgz"
+                        },
+                        "xtend": {
+                          "version": "4.0.0",
+                          "from": "xtend@>=4.0.0 <5.0.0",
+                          "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
           }
         },
         "rimraf": {
-          "version": "2.3.2",
-          "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.2.tgz",
+          "version": "2.3.4",
+          "from": "rimraf@>=2.2.8 <3.0.0",
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.3.4.tgz",
           "dependencies": {
             "glob": {
               "version": "4.5.3",
-              "from": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
+              "from": "glob@>=4.4.2 <5.0.0",
               "resolved": "https://registry.npmjs.org/glob/-/glob-4.5.3.tgz",
               "dependencies": {
                 "inflight": {
                   "version": "1.0.4",
-                  "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
+                  "from": "inflight@>=1.0.4 <2.0.0",
                   "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.4.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 },
                 "minimatch": {
-                  "version": "2.0.4",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
-                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.4.tgz",
+                  "version": "2.0.8",
+                  "from": "minimatch@>=2.0.1 <3.0.0",
+                  "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.8.tgz",
                   "dependencies": {
                     "brace-expansion": {
                       "version": "1.1.0",
-                      "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
+                      "from": "brace-expansion@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.0.tgz",
                       "dependencies": {
                         "balanced-match": {
                           "version": "0.2.0",
-                          "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz",
+                          "from": "balanced-match@>=0.2.0 <0.3.0",
                           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.2.0.tgz"
                         },
                         "concat-map": {
                           "version": "0.0.1",
-                          "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                          "from": "concat-map@0.0.1",
                           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
                         }
                       }
@@ -4541,13 +4826,13 @@
                   }
                 },
                 "once": {
-                  "version": "1.3.1",
-                  "from": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
-                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.1.tgz",
+                  "version": "1.3.2",
+                  "from": "once@>=1.3.0 <2.0.0",
+                  "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                   "dependencies": {
                     "wrappy": {
                       "version": "1.0.1",
-                      "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
+                      "from": "wrappy@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                     }
                   }
@@ -4558,166 +4843,166 @@
         },
         "tar-pack": {
           "version": "2.0.0",
-          "from": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
+          "from": "tar-pack@>=2.0.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/tar-pack/-/tar-pack-2.0.0.tgz",
           "dependencies": {
             "uid-number": {
               "version": "0.0.3",
-              "from": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz",
+              "from": "uid-number@0.0.3",
               "resolved": "https://registry.npmjs.org/uid-number/-/uid-number-0.0.3.tgz"
             },
             "once": {
               "version": "1.1.1",
-              "from": "https://registry.npmjs.org/once/-/once-1.1.1.tgz",
+              "from": "once@>=1.1.1 <1.2.0",
               "resolved": "https://registry.npmjs.org/once/-/once-1.1.1.tgz"
             },
             "debug": {
               "version": "0.7.4",
-              "from": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz",
+              "from": "debug@>=0.7.2 <0.8.0",
               "resolved": "https://registry.npmjs.org/debug/-/debug-0.7.4.tgz"
             },
             "rimraf": {
               "version": "2.2.8",
-              "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+              "from": "rimraf@>=2.2.0 <2.3.0",
               "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz"
             },
             "fstream": {
               "version": "0.1.31",
-              "from": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
+              "from": "fstream@>=0.1.22 <0.2.0",
               "resolved": "https://registry.npmjs.org/fstream/-/fstream-0.1.31.tgz",
               "dependencies": {
                 "graceful-fs": {
-                  "version": "3.0.6",
-                  "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz",
-                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.6.tgz"
+                  "version": "3.0.7",
+                  "from": "graceful-fs@>=3.0.2 <3.1.0",
+                  "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-3.0.7.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "tar": {
               "version": "0.1.20",
-              "from": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
+              "from": "tar@>=0.1.17 <0.2.0",
               "resolved": "https://registry.npmjs.org/tar/-/tar-0.1.20.tgz",
               "dependencies": {
                 "block-stream": {
-                  "version": "0.0.7",
-                  "from": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz",
-                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.7.tgz"
+                  "version": "0.0.8",
+                  "from": "block-stream@*",
+                  "resolved": "https://registry.npmjs.org/block-stream/-/block-stream-0.0.8.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "fstream-ignore": {
               "version": "0.0.7",
-              "from": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
+              "from": "fstream-ignore@0.0.7",
               "resolved": "https://registry.npmjs.org/fstream-ignore/-/fstream-ignore-0.0.7.tgz",
               "dependencies": {
                 "minimatch": {
                   "version": "0.2.14",
-                  "from": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
+                  "from": "minimatch@>=0.2.0 <0.3.0",
                   "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
                   "dependencies": {
                     "lru-cache": {
-                      "version": "2.5.2",
-                      "from": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz",
-                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.5.2.tgz"
+                      "version": "2.6.4",
+                      "from": "lru-cache@>=2.0.0 <3.0.0",
+                      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.6.4.tgz"
                     },
                     "sigmund": {
-                      "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.0.tgz"
+                      "version": "1.0.1",
+                      "from": "sigmund@>=1.0.0 <1.1.0",
+                      "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz"
                     }
                   }
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "readable-stream": {
               "version": "1.0.33",
-              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
+              "from": "readable-stream@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
+                  "from": "core-util-is@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "from": "isarray@0.0.1",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "from": "string_decoder@>=0.10.0 <0.11.0",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                  "from": "inherits@>=2.0.1 <2.1.0",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "graceful-fs": {
               "version": "1.2.3",
-              "from": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz",
+              "from": "graceful-fs@>=1.2.0 <1.3.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-1.2.3.tgz"
             }
           }
         },
         "winston": {
           "version": "0.8.3",
-          "from": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+          "from": "winston@>=0.8.3 <0.9.0",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "from": "async@>=0.2.0 <0.3.0",
               "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
             },
             "cycle": {
               "version": "1.0.3",
-              "from": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+              "from": "cycle@>=1.0.0 <1.1.0",
               "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "from": "eyes@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "from": "isstream@>=0.1.0 <0.2.0",
               "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
             },
             "pkginfo": {
               "version": "0.3.0",
-              "from": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz",
+              "from": "pkginfo@>=0.3.0 <0.4.0",
               "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.0.tgz"
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "from": "stack-trace@>=0.0.0 <0.1.0",
               "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
             }
           }
         },
         "yargs": {
           "version": "1.3.3",
-          "from": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz",
+          "from": "yargs@>=1.3.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-1.3.3.tgz"
         }
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "colors": "^0.6.2",
     "connectivity": "^0.1.1",
     "dns-sync": "^0.1.0",
-    "docker-registry-downloader": "^0.1.35",
+    "docker-registry-downloader": "^0.1.36",
     "dockerode": "^2.1.2",
     "esprima": "^1.2.2",
     "exec-sh": "^0.1.3",

--- a/src/images/index.js
+++ b/src/images/index.js
@@ -98,7 +98,7 @@ export class Image {
           // docker pull
           image = yield lazy.docker.pull(this.repository, this.tag, output, registry_result);
         } catch (err) {
-          output = (err || err).toString();
+          output = (err || '').toString();
           throw new LostInternetConnection('  ' + output);
         }
 

--- a/src/images/index.js
+++ b/src/images/index.js
@@ -98,7 +98,7 @@ export class Image {
           // docker pull
           image = yield lazy.docker.pull(this.repository, this.tag, output, registry_result);
         } catch (err) {
-          output = err.toString();
+          output = (err || err).toString();
           throw new LostInternetConnection('  ' + output);
         }
 


### PR DESCRIPTION
This closes #407;

[`docker-registry-downloader`](https://www.npmjs.com/package/docker-registry-downloader) wasn't returning some errors, such as `404 - image not available`. This occurs because [`requestretry`](https://www.npmjs.com/package/requestretry) didn't identify this as an error. To solve this, I've made a change in the business logic that handle the result and throw the error if exists. See https://github.com/azukiapp/docker-registry-downloader/commit/5a3875a960a9691567c187276c4a99070d0572be.

In `azk`, due to a security reason, I've defined that, if the error isn't defined, it returns an empty string.

Change:
https://github.com/azukiapp/azk/commit/2798497ab9860a3eb6d61ac5d928e04e4ade9760#diff-b8227a104a604c03fa9304e391565997R101

### Steps to test

Try to access shell to an invalid image:

```shell
$ azk shell --image azukiapp/nananan
```

Response:
![screen shot 2015-05-25 at 15 12 24](https://cloud.githubusercontent.com/assets/2034678/7801038/06353ace-02f5-11e5-9385-bbaaf7908f34.png)