### PR TITLE
[Init] Improving Suggestions for Node.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Enhancements
+  * [Suggesting] Now node.js suggestions have a env `PORT` for to get a `HTTP_PORT`, this change makes this suggestion more "compatible" with most of the apps that await env `PORT`.
+
 ## v0.13.0 - (2015-X-05)
 
 * Bug

--- a/shared/templates/Azkfile.mustache.js
+++ b/shared/templates/Azkfile.mustache.js
@@ -85,7 +85,12 @@ systems({
     {{~/if}}
     {{~#if envs}}
     envs: {
+      {{~#if envs_comment}}
+      {{~#each envs_comment}}
+      // {{&this}}{{/each}}
+      {{~else}}
       // set instances variables
+      {{~/if}}
       {{~#each envs}}
       {{&hash_key @key}}: "{{this}}",{{/each}}
     },

--- a/src/generator/suggestions/node_default.js
+++ b/src/generator/suggestions/node_default.js
@@ -20,8 +20,20 @@ export class Suggestion extends UIProxy {
         '/azk/#{manifest.dir}': {type: 'path', value: '.'},
         '/azk/#{manifest.dir}/node_modules': {type: 'persistent', value: 'node-modules-#{system.name}'},
       },
+      envs_comment: [
+        'Make sure that the PORT value is the same as the one',
+        'in ports/http below, and that it\'s also the same',
+        'if you\'re setting it in a .env file'
+      ],
       envs    : {
-        NODE_ENV: "dev"
+        NODE_ENV: "dev",
+        // Make sure that the PORT value is the same as the one
+        // in ports/http below, and that it's also the same
+        // if you're setting it in a .env file
+        PORT: 3000
+      },
+      ports: {
+        http: '3000/tcp'
       }
     });
   }


### PR DESCRIPTION
This closes #358. 

It adds support for `envs_comment` in the Azkfile.mustache template. It also adds an initial setup for having the environment variable PORT in Node.js applications, after running `azk init`.