### PR TITLE
[docs] Fixing link to docker docs (Create docker group)

### DIFF
--- a/docs/content/links.md
+++ b/docs/content/links.md
@@ -7,6 +7,6 @@
 [docker_ubuntu-trusty-1404-lts-64-bit]: https://docs.docker.com/installation/ubuntulinux/#ubuntu-trusty-1404-lts-64-bit
 [docker_ubuntu_12_04]: https://docs.docker.com/installation/ubuntulinux/#ubuntu-precise-1204-lts-64-bit
 [docker_ubuntu_dns]: https://docs.docker.com/installation/ubuntulinux/#configure-a-dns-server-for-use-by-docker
-[docker_root_access]: https://docs.docker.com/installation/ubuntulinux/#giving-non-root-access
+[docker_root_access]: https://docs.docker.com/installation/ubuntulinux/#create-a-docker-group
 [postgres]: http://www.postgresql.org/
 [redis]: http://redis.io/


### PR DESCRIPTION
This PR closes #425.

Fixing link in our docs to Docker's ("Create a docker group" section).