### PR TITLE
[Suggestions] Adding `sync` mount option to suggestions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Enhancements
+  * [Suggesting] Changing the suggestions of python and ruby ​​to give preference to sync instead of path;
+
 ## v0.13.0 - (2015-27-05)
 
 * Bug

--- a/spec/generator/rules/generation/mysql_and_postgres_gen_spec.js
+++ b/spec/generator/rules/generation/mysql_and_postgres_gen_spec.js
@@ -151,7 +151,13 @@ describe('Azk generator db', function() {
         h.expect(system).to.have.deep.property('options.workdir', workdir);
 
         var expectedMounts = {};
-        expectedMounts[workdir] = { type: 'path', value: './railsMysql', options: {} };
+        expectedMounts[workdir] = { type: 'sync', value: './railsMysql', options: {} };
+        expectedMounts[path.join('/azk', rootFolderBasename, 'log')] = {
+          type: 'persistent', value: `log-${systemName}`, options: {}
+        };
+        expectedMounts[path.join('/azk', rootFolderBasename, 'tmp')] = {
+          type: 'persistent', value: `tmp-${systemName}`, options: {}
+        };
         expectedMounts['/azk/bundler'] = { type: 'persistent', value: 'bundler', options: {} };
 
         h.expect(system).to.have.deep.property('options.mounts').and.to.eql(
@@ -184,7 +190,13 @@ describe('Azk generator db', function() {
         h.expect(system).to.have.deep.property('options.workdir', workdir);
 
         var expectedMounts = {};
-        expectedMounts[workdir] = { type: 'path', value: './railsPostgres', options: {} };
+        expectedMounts[workdir] = { type: 'sync', value: './railsPostgres', options: {} };
+        expectedMounts[path.join('/azk', rootFolderBasename, 'log')] = {
+          type: 'persistent', value: `log-${systemName}`, options: {}
+        };
+        expectedMounts[path.join('/azk', rootFolderBasename, 'tmp')] = {
+          type: 'persistent', value: `tmp-${systemName}`, options: {}
+        };
         expectedMounts['/azk/bundler'] = { type: 'persistent', value: 'bundler', options: {} };
 
         h.expect(system).to.have.deep.property('options.mounts').and.to.eql(

--- a/src/generator/court.js
+++ b/src/generator/court.js
@@ -322,9 +322,10 @@ export class Court extends UIProxy {
           systemSuggestion.workdir = path.join(systemSuggestion.workdir, folderBasename);
         }
 
-        // when in a sub-folder change default `path('.') mounts` to the subfolder
+        // when in a sub-folder change default `path('.')` or `sync('.')` to the subfolder
         var default_mount_path = _.findKey(systemSuggestion.mounts, function(mount) {
-          return (mount.type === 'path' && mount.value === '.');
+          return (mount.type === 'path' && mount.value === '.' ||
+                  mount.type === 'sync' && mount.value === '.');
         });
 
         if (default_mount_path && folderName !== this.__root_folder) {

--- a/src/generator/suggestions/django_python27.js
+++ b/src/generator/suggestions/django_python27.js
@@ -1,8 +1,7 @@
 import { _ } from 'azk';
-import { UIProxy } from 'azk/cli/ui';
-import { example_system } from 'azk/generator/rules';
+import { Suggestion as DefaultSuggestion } from 'azk/generator/suggestions/django_python_default';
 
-export class Suggestion extends UIProxy {
+export class Suggestion extends DefaultSuggestion {
   constructor(...args) {
     super(...args);
 
@@ -13,23 +12,9 @@ export class Suggestion extends UIProxy {
     this.ruleNamesList = ['djangoPython27'];
 
     // Initial Azkfile.js suggestion
-    this.suggestion = _.extend({}, example_system, {
+    this.suggestion = _.extend({}, this.suggestion, {
       __type  : 'djangoPython27',
       image   : { docker: 'azukiapp/python:2.7' },
-      provision: [
-        'pip install --user --allow-all-external -r requirements.txt',
-      ],
-      http    : true,
-      scalable: { default: 2 },
-      command : 'python manage.py runserver 0.0.0.0:$HTTP_PORT',
-      mounts  : {
-        '/azk/#{manifest.dir}': {type: 'path',       value: '.'},
-        '/azk/djangouserbase':  {type: 'persistent', value: 'djangouserbase'},
-      },
-      envs: {
-        PATH : '/azk/djangouserbase/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        PYTHONUSERBASE: '/azk/djangouserbase',
-      }
     });
   }
 

--- a/src/generator/suggestions/django_python34.js
+++ b/src/generator/suggestions/django_python34.js
@@ -1,8 +1,7 @@
 import { _ } from 'azk';
-import { UIProxy } from 'azk/cli/ui';
-import { example_system } from 'azk/generator/rules';
+import { Suggestion as DefaultSuggestion } from 'azk/generator/suggestions/django_python_default';
 
-export class Suggestion extends UIProxy {
+export class Suggestion extends DefaultSuggestion {
   constructor(...args) {
     super(...args);
 
@@ -13,23 +12,9 @@ export class Suggestion extends UIProxy {
     this.ruleNamesList = ['djangoPython34'];
 
     // Initial Azkfile.js suggestion
-    this.suggestion = _.extend({}, example_system, {
+    this.suggestion = _.extend({}, this.suggestion, {
       __type  : 'djangoPython34',
       image   : { docker: 'azukiapp/python:3.4' },
-      provision: [
-        'pip install --user --allow-all-external -r requirements.txt',
-      ],
-      http    : true,
-      scalable: { default: 2 },
-      command : 'python manage.py runserver 0.0.0.0:$HTTP_PORT',
-      mounts  : {
-        '/azk/#{manifest.dir}': {type: 'path',       value: '.'},
-        '/azk/djangouserbase':  {type: 'persistent', value: 'djangouserbase'},
-      },
-      envs: {
-        PATH : '/azk/djangouserbase/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
-        PYTHONUSERBASE: '/azk/djangouserbase',
-      }
     });
   }
 

--- a/src/generator/suggestions/django_python_default.js
+++ b/src/generator/suggestions/django_python_default.js
@@ -1,0 +1,33 @@
+import { _ } from 'azk';
+import { UIProxy } from 'azk/cli/ui';
+import { example_system } from 'azk/generator/rules';
+
+export class Suggestion extends UIProxy {
+  constructor(...args) {
+    super(...args);
+
+    // Initial Azkfile.js suggestion
+    this.suggestion = _.extend({}, example_system, {
+      __type  : 'djangoPython',
+      image   : { docker: 'azukiapp/python' },
+      provision: [
+        'pip install --user --allow-all-external -r requirements.txt',
+      ],
+      http    : true,
+      scalable: { default: 2 },
+      command : 'python manage.py runserver 0.0.0.0:$HTTP_PORT',
+      mounts  : {
+        '/azk/#{manifest.dir}': {type: 'sync',       value: '.'},
+        '/azk/djangouserbase':  {type: 'persistent', value: 'djangouserbase'},
+      },
+      envs: {
+        PATH : '/azk/djangouserbase/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin',
+        PYTHONUSERBASE: '/azk/djangouserbase',
+      }
+    });
+  }
+
+  suggest() {
+    return this.suggestion;
+  }
+}

--- a/src/generator/suggestions/node010.js
+++ b/src/generator/suggestions/node010.js
@@ -1,8 +1,8 @@
 import { _ } from 'azk';
-import { UIProxy } from 'azk/cli/ui';
-import { example_system } from 'azk/generator/rules';
 
-export class Suggestion extends UIProxy {
+import { Suggestion as DefaultSuggestion } from 'azk/generator/suggestions/node_default';
+
+export class Suggestion extends DefaultSuggestion {
   constructor(...args) {
     super(...args);
 
@@ -13,22 +13,7 @@ export class Suggestion extends UIProxy {
     this.ruleNamesList = ['node010'];
 
     // Initial Azkfile.js suggestion
-    this.suggestion = _.extend({}, example_system, {
-      __type: "node.js",
-      image : { docker: "azukiapp/node" },
-      provision: [
-        "npm install"
-      ],
-      http: true,
-      scalable: { default: 2 },
-      command : "npm start",
-      ports   : {
-        http: "8000"
-      },
-      envs    : {
-        NODE_ENV: "dev"
-      }
-    });
+    this.suggestion = _.extend({}, this.suggestion, {});
   }
 
   suggest() {

--- a/src/generator/suggestions/node012.js
+++ b/src/generator/suggestions/node012.js
@@ -1,8 +1,8 @@
 import { _ } from 'azk';
-import { UIProxy } from 'azk/cli/ui';
-import { example_system } from 'azk/generator/rules';
 
-export class Suggestion extends UIProxy {
+import { Suggestion as DefaultSuggestion } from 'azk/generator/suggestions/node_default';
+
+export class Suggestion extends DefaultSuggestion {
   constructor(...args) {
     super(...args);
 
@@ -13,18 +13,8 @@ export class Suggestion extends UIProxy {
     this.ruleNamesList = ['node012'];
 
     // Initial Azkfile.js suggestion
-    this.suggestion = _.extend({}, example_system, {
-      __type: "node.js",
+    this.suggestion = _.extend({}, this.suggestion, {
       image : { docker: "azukiapp/node:0.12" },
-      provision: [
-        "npm install"
-      ],
-      http: true,
-      scalable: { default: 2 },
-      command : "npm start",
-      envs    : {
-        NODE_ENV: "dev"
-      }
     });
   }
 

--- a/src/generator/suggestions/node08.js
+++ b/src/generator/suggestions/node08.js
@@ -1,8 +1,8 @@
 import { _ } from 'azk';
-import { UIProxy } from 'azk/cli/ui';
-import { example_system } from 'azk/generator/rules';
 
-export class Suggestion extends UIProxy {
+import { Suggestion as DefaultSuggestion } from 'azk/generator/suggestions/node_default';
+
+export class Suggestion extends DefaultSuggestion {
   constructor(...args) {
     super(...args);
 
@@ -13,18 +13,8 @@ export class Suggestion extends UIProxy {
     this.ruleNamesList = ['node08'];
 
     // Initial Azkfile.js suggestion
-    this.suggestion = _.extend({}, example_system, {
-      __type: "node.js",
+    this.suggestion = _.extend({}, this.suggestion, {
       image : { docker: "node:0.8" },
-      provision: [
-        "npm install"
-      ],
-      http: true,
-      scalable: { default: 2 },
-      command : "npm start",
-      envs    : {
-        NODE_ENV: "dev"
-      }
     });
   }
 

--- a/src/generator/suggestions/node_default.js
+++ b/src/generator/suggestions/node_default.js
@@ -1,0 +1,32 @@
+import { _ } from 'azk';
+import { UIProxy } from 'azk/cli/ui';
+import { example_system } from 'azk/generator/rules';
+
+export class Suggestion extends UIProxy {
+  constructor(...args) {
+    super(...args);
+
+    // Initial Azkfile.js suggestion
+    this.suggestion = _.extend({}, example_system, {
+      __type: "node.js",
+      image : { docker: "azukiapp/node" },
+      provision: [
+        "npm install"
+      ],
+      http: true,
+      scalable: { default: 2 },
+      command : "npm start",
+      mounts  : {
+        '/azk/#{manifest.dir}': {type: 'path', value: '.'},
+        '/azk/#{manifest.dir}/node_modules': {type: 'persistent', value: 'node-modules-#{system.name}'},
+      },
+      envs    : {
+        NODE_ENV: "dev"
+      }
+    });
+  }
+
+  suggest() {
+    return this.suggestion;
+  }
+}

--- a/src/generator/suggestions/rails.js
+++ b/src/generator/suggestions/rails.js
@@ -25,8 +25,10 @@ export class Suggestion extends UIProxy {
       scalable: { default: 2 },
       command : 'bundle exec rackup config.ru --pid /tmp/rails.pid --port $HTTP_PORT --host 0.0.0.0',
       mounts  : {
-        '/azk/#{manifest.dir}': {type: 'path', value: '.'},
-        '/azk/bundler'        : {type: 'persistent', value: 'bundler'},
+        '/azk/#{manifest.dir}'     : {type: 'sync', value: '.'},
+        '/azk/#{manifest.dir}/tmp' : {type: 'persistent', value: 'tmp-#{system.name}'},
+        '/azk/#{manifest.dir}/log' : {type: 'persistent', value: 'log-#{system.name}'},
+        '/azk/bundler'             : {type: 'persistent', value: 'bundler'},
       },
       envs    : {
         RAILS_ENV : 'development',

--- a/src/generator/suggestions/ruby19.js
+++ b/src/generator/suggestions/ruby19.js
@@ -1,8 +1,7 @@
 import { _ } from 'azk';
-import { UIProxy } from 'azk/cli/ui';
-import { example_system } from 'azk/generator/rules';
+import { Suggestion as DefaultSuggestion } from 'azk/generator/suggestions/ruby_default';
 
-export class Suggestion extends UIProxy {
+export class Suggestion extends DefaultSuggestion {
   constructor(...args) {
     super(...args);
 
@@ -13,23 +12,9 @@ export class Suggestion extends UIProxy {
     this.ruleNamesList = ['ruby19'];
 
     // Initial Azkfile.js suggestion
-    this.suggestion = _.extend({}, example_system, {
+    this.suggestion = _.extend({}, this.suggestion, {
       __type  : 'ruby 1.9',
       image   : { docker: 'azukiapp/ruby:1.9' },
-      provision: [
-        'bundle install --path /azk/bundler',
-      ],
-      http    : true,
-      scalable: { default: 2 },
-      command : 'bundle exec rackup config.ru --pid /tmp/ruby.pid --port $HTTP_PORT --host 0.0.0.0',
-      mounts  : {
-        '/azk/#{manifest.dir}': {type: 'path', value: '.'},
-        '/azk/bundler'        : {type: 'persistent', value: 'bundler'},
-      },
-      envs    : {
-        RUBY_ENV : 'development',
-        BUNDLE_APP_CONFIG : '/azk/bundler',
-      }
     });
   }
 

--- a/src/generator/suggestions/ruby20.js
+++ b/src/generator/suggestions/ruby20.js
@@ -1,8 +1,7 @@
 import { _ } from 'azk';
-import { UIProxy } from 'azk/cli/ui';
-import { example_system } from 'azk/generator/rules';
+import { Suggestion as DefaultSuggestion } from 'azk/generator/suggestions/ruby_default';
 
-export class Suggestion extends UIProxy {
+export class Suggestion extends DefaultSuggestion {
   constructor(...args) {
     super(...args);
 
@@ -13,23 +12,9 @@ export class Suggestion extends UIProxy {
     this.ruleNamesList = ['ruby20'];
 
     // Initial Azkfile.js suggestion
-    this.suggestion = _.extend({}, example_system, {
+    this.suggestion = _.extend({}, this.suggestion, {
       __type  : 'ruby 2.0',
       image   : { docker: 'azukiapp/ruby:2.0' },
-      provision: [
-        'bundle install --path /azk/bundler',
-      ],
-      http    : true,
-      scalable: { default: 2 },
-      command : 'bundle exec rackup config.ru --pid /tmp/ruby.pid --port $HTTP_PORT --host 0.0.0.0',
-      mounts  : {
-        '/azk/#{manifest.dir}': {type: 'path', value: '.'},
-        '/azk/bundler'        : {type: 'persistent', value: 'bundler'},
-      },
-      envs    : {
-        RUBY_ENV : 'development',
-        BUNDLE_APP_CONFIG : '/azk/bundler',
-      }
     });
   }
 

--- a/src/generator/suggestions/ruby21.js
+++ b/src/generator/suggestions/ruby21.js
@@ -1,8 +1,7 @@
 import { _ } from 'azk';
-import { UIProxy } from 'azk/cli/ui';
-import { example_system } from 'azk/generator/rules';
+import { Suggestion as DefaultSuggestion } from 'azk/generator/suggestions/ruby_default';
 
-export class Suggestion extends UIProxy {
+export class Suggestion extends DefaultSuggestion {
   constructor(...args) {
     super(...args);
 
@@ -13,23 +12,9 @@ export class Suggestion extends UIProxy {
     this.ruleNamesList = ['ruby21'];
 
     // Initial Azkfile.js suggestion
-    this.suggestion = _.extend({}, example_system, {
+    this.suggestion = _.extend({}, this.suggestion, {
       __type  : 'ruby 2.1',
       image   : { docker: 'azukiapp/ruby:2.1' },
-      provision: [
-        'bundle install --path /azk/bundler',
-      ],
-      http    : true,
-      scalable: { default: 2 },
-      command : 'bundle exec rackup config.ru --pid /tmp/ruby.pid --port $HTTP_PORT --host 0.0.0.0',
-      mounts  : {
-        '/azk/#{manifest.dir}': {type: 'path', value: '.'},
-        '/azk/bundler'        : {type: 'persistent', value: 'bundler'},
-      },
-      envs    : {
-        RUBY_ENV : 'development',
-        BUNDLE_APP_CONFIG : '/azk/bundler',
-      }
     });
   }
 

--- a/src/generator/suggestions/ruby22.js
+++ b/src/generator/suggestions/ruby22.js
@@ -1,8 +1,7 @@
 import { _ } from 'azk';
-import { UIProxy } from 'azk/cli/ui';
-import { example_system } from 'azk/generator/rules';
+import { Suggestion as DefaultSuggestion } from 'azk/generator/suggestions/ruby_default';
 
-export class Suggestion extends UIProxy {
+export class Suggestion extends DefaultSuggestion {
   constructor(...args) {
     super(...args);
 
@@ -13,23 +12,9 @@ export class Suggestion extends UIProxy {
     this.ruleNamesList = ['ruby22'];
 
     // Initial Azkfile.js suggestion
-    this.suggestion = _.extend({}, example_system, {
+    this.suggestion = _.extend({}, this.suggestion, {
       __type  : 'ruby 2.2',
       image   : { docker: 'azukiapp/ruby:2.2' },
-      provision: [
-        'bundle install --path /azk/bundler',
-      ],
-      http    : true,
-      scalable: { default: 2 },
-      command : 'bundle exec rackup config.ru --pid /tmp/ruby.pid --port $HTTP_PORT --host 0.0.0.0',
-      mounts  : {
-        '/azk/#{manifest.dir}': {type: 'path', value: '.'},
-        '/azk/bundler'        : {type: 'persistent', value: 'bundler'},
-      },
-      envs    : {
-        RUBY_ENV : 'development',
-        BUNDLE_APP_CONFIG : '/azk/bundler',
-      }
     });
   }
 

--- a/src/generator/suggestions/ruby_default.js
+++ b/src/generator/suggestions/ruby_default.js
@@ -1,0 +1,33 @@
+import { _ } from 'azk';
+import { UIProxy } from 'azk/cli/ui';
+import { example_system } from 'azk/generator/rules';
+
+export class Suggestion extends UIProxy {
+  constructor(...args) {
+    super(...args);
+
+    // Initial Azkfile.js suggestion
+    this.suggestion = _.extend({}, example_system, {
+      __type  : 'ruby',
+      image   : { docker: 'azukiapp/ruby' },
+      provision: [
+        'bundle install --path /azk/bundler',
+      ],
+      http    : true,
+      scalable: { default: 2 },
+      command : 'bundle exec rackup config.ru --pid /tmp/ruby.pid --port $HTTP_PORT --host 0.0.0.0',
+      mounts  : {
+        '/azk/#{manifest.dir}': {type: 'sync', value: '.'},
+        '/azk/bundler'        : {type: 'persistent', value: 'bundler'},
+      },
+      envs    : {
+        RUBY_ENV : 'development',
+        BUNDLE_APP_CONFIG : '/azk/bundler',
+      }
+    });
+  }
+
+  suggest() {
+    return this.suggestion;
+  }
+}


### PR DESCRIPTION
Since we have the [`sync` mount option](http://docs.azk.io/en/reference/azkfilejs/mounts.html), the suggestions should generate manifest files with this option by default in languages/frameworks which performance can be degraded if this options is not used, such as:
* Ruby;
* Rails;
* Django (Python).