### PR TITLE
[fix_get_rsync_version] Fixing rsync output handler to get its version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  * [File sharing] Fixing bug when trying to capture the version of rsync.
+
 ## v0.13.0 - (2015-27-05)
 
 * Bug

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -82,9 +82,16 @@ module.exports = {
                   "`v%(new_version)s` version is available.",
                   "Please, access http://azk.io to upgrade\n"].join("\n"),
         mv_resolver: "Upgrading domains error, moving files was not possible",
+        rsync: "`rsync` command is required, but not installed or it not on the $PATH. Install before continuing.",
+        check_rsync_version_error: [
+          'Checking rsync version:',
+          'Detected:    %(current_version)s',
+          'Required: >= %(min_version)s',
+          'Please update rsync before continue.'
+        ].join('\n'),
       },
       darwin: {
-        VBoxManage     : 'VirtualBox not installed. Install before continuing.',
+        VBoxManage     : 'VirtualBox command is required, but not installed or it not on the $PATH. Install before continuing.',
         network        : 'Networking error',
         custom_dns_port: 'Sorry, but Mac OS X supports only port `53` as `AZK_DNS_PORT`',
       },
@@ -99,12 +106,6 @@ module.exports = {
           "Check if docker service is running.",
           "Also check if you have write permission to socket: '%(socket)s'",
         ].join('\n'),
-        check_rsync_version_error: [
-          'Checking rsync version:',
-          'Detected:    %(current_version)s',
-          'Required: >= %(min_version)s',
-          'Please update rsync before continue.'
-          ].join('\n'),
       }
     }
   },

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -82,7 +82,7 @@ module.exports = {
                   "`v%(new_version)s` version is available.",
                   "Please, access http://azk.io to upgrade\n"].join("\n"),
         mv_resolver: "Upgrading domains error, moving files was not possible",
-        rsync: "`rsync` command is required, but not installed or it not on the $PATH. Install before continuing.",
+        rsync: "`rsync` command is required, but it's not installed or it's not in the $PATH. Please install it before continue.",
         check_rsync_version_error: [
           'Checking rsync version:',
           'Detected:    %(current_version)s',
@@ -91,7 +91,7 @@ module.exports = {
         ].join('\n'),
       },
       darwin: {
-        VBoxManage     : 'VirtualBox command is required, but not installed or it not on the $PATH. Install before continuing.',
+        VBoxManage     : 'VirtualBox command is required, but it's not installed or it's not in the $PATH. Please install it before continue.',
         network        : 'Networking error',
         custom_dns_port: 'Sorry, but Mac OS X supports only port `53` as `AZK_DNS_PORT`',
       },

--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -170,6 +170,10 @@ export class Configure extends UIProxy {
 
   _checkRsyncVersion() {
     return async(this, function* () {
+      // Check if installed
+      yield this._which('rsync', 'rsync');
+
+      // Check version
       var minRsyncVersion = (process.env.RSYNC_MIN_VERSION || '2.6.9');
       var currentRsyncVersion = yield lazy.Sync.version();
       var validRsyncVersion = semver.gte(currentRsyncVersion, minRsyncVersion);

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -50,7 +50,8 @@ var Sync = {
         if (!_.isEmpty(_version) && _version.length >= 2) {
           return resolve(_version[1]);
         } else {
-          return reject({ err: t('errors.rsync_invalid_version_format', {
+          return reject({
+            err: t('errors.rsync_invalid_version_format', {
               rsync_version: version_output
             })
           });

--- a/src/sync/index.js
+++ b/src/sync/index.js
@@ -37,16 +37,16 @@ var Sync = {
   },
 
   version() {
-    var version_output;
+    var version_output = '';
     var r = new require('rsync')().set('version').output((data) => {
-      version_output = data.toString();
+      version_output += data.toString();
     });
     return defer((resolve, reject) => {
       r.execute(function(err, code) {
         if (err) {
           return reject({ err, code });
         }
-        var _version = version_output.match(/.*version\ (\d+.\d+.\d+)/);
+        var _version = version_output.match(/.*version\ (\d+\.\d+\.\d+)/);
         if (!_.isEmpty(_version) && _version.length >= 2) {
           return resolve(_version[1]);
         } else {


### PR DESCRIPTION
This PR closes #433.

Instead of simply assigning the output result to the `version_output` variable, now we accumulates each output result to the resulting variable, avoiding multiple calls of the `output` method to vanish the desired value (that should be returned in the first method call).

Plus, the version check regexp is fixed (expecting points instead of any character as version number separator).