### PR TITLE
[docker] Feature/fixing docker build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  * [Docker] Fixing bug that could prevent the work instruction `ADD . /folder/` when used in a Dockerfile;
+
+* Enhancements
+  * [Docker] Now support `Dockerfile` is complete, and similar to the docker, including support `.dockerignore`;
+
 ## v0.13.0 - (2015-27-05)
 
 * Bug

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,14 @@ ${VM_DISKS_DIR}/azk-agent.vmdk.gz:
 ${AZK_LIB_PATH}/bats:
 	@git clone -b ${BATS_VERSION} https://github.com/sstephenson/bats ${AZK_LIB_PATH}/bats
 
+slow_test: TEST_SLOW="--slow"
+slow_test: test
+	@echo "task: $@"
+
+test: bootstrap
+	@echo "task: $@"
+	${AZK_BIN} nvm gulp test ${TEST_SLOW} $(if $(filter undefined,$(origin TEST_GREP)),"",--grep "${TEST_GREP}")
+
 # PACKAGE
 AZK_PACKAGE_PATH:=${AZK_ROOT_PATH}/package
 AZK_PACKAGE_PREFIX:=${AZK_PACKAGE_PATH}/v${AZK_VERSION}
@@ -179,4 +187,4 @@ ${PATH_MAC_PACKAGE}: ${AZK_PACKAGE_PREFIX}
 
 package_build: bootstrap ${AZK_LIB_PATH}/azk $(FILES_TARGETS) $(FILES_JS_TARGETS) ${PATH_NODE_MODULES}
 
-.PHONY: bootstrap clean fast_clean package package_brew package_mac package_deb package_rpm package_build package_clean copy_files fix_permissions creating_symbolic_links dependencies check_version
+.PHONY: bootstrap clean fast_clean package package_brew package_mac package_deb package_rpm package_build package_clean copy_files fix_permissions creating_symbolic_links dependencies check_version slow_test test

--- a/docs/content/en/reference/azkfilejs/image.md
+++ b/docs/content/en/reference/azkfilejs/image.md
@@ -29,6 +29,8 @@ image: {
 
 The _build_ is performed locally. Note that it's possible to specify the **folder** that contains the `Dockerfile` file or the **`Dockerfile`** file itself, which in this case, does not need to have the name _Dockerfile_.
 
+To learn how to build your _Dockerfile_, check out the [docs](http://docs.docker.com/reference/builder/#format). Note that here we have the same behaviour of the command `docker build`, even sending all the files in the folder where is placed the Dockerfile. In order to avoid slowness, check how to create a [.dockerignore](http://docs.docker.com/reference/builder/#the-dockerignore-file) file and remove useless files from the build process.
+
 ```js
 // short mode
 image: { dockerfile: 'FOLDER_WITH_DOCKERFILE' },

--- a/docs/content/pt-BR/reference/azkfilejs/image.md
+++ b/docs/content/pt-BR/reference/azkfilejs/image.md
@@ -29,6 +29,8 @@ image: {
 
 É realizado o _build_ localmente. Observe que é possivel especificar a **pasta** que contém o arquivo `Dockerfile` ou o próprio **`Dockerfile`**, que neste caso, não precisa possuir o nome _Dockerfile_.
 
+Para saber como construir seu _Dockerfile_ consulte a [documentação](http://docs.docker.com/reference/builder/#format). Observe que aqui temos o mesmo comportamento do comando `docker build`, inclusive o comportamento de enviar ao Docker todos os arquivos que estão na pasta onde esta o Dockerfile, para evitar lentidão no processo de uma olhada em como criar um [.dockerignore](http://docs.docker.com/reference/builder/#the-dockerignore-file) e eliminar do processo de build arquivos que não são necessários.
+
 ```js
 // modo reduzido
 image: { dockerfile: 'PASTA_COM_DOCKERFILE' },

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "description": "Orchestrate development environments with agility and automation",
   "main": "index.js",
   "scripts": {
-    "test": "gulp test",
-    "test:slow": "gulp test --slow",
+    "test": "make test",
+    "test:slow": "make slow_test",
     "azk:package": "./src/libexec/package-tools/build.sh",
     "azk:package:publish": "gulp publish"
   },

--- a/spec/docker/build_spec.js
+++ b/spec/docker/build_spec.js
@@ -34,9 +34,31 @@ describe("Azk docker module, image build @slow", function() {
           );
 
           return result.then((container) => {
-            h.expect(outputs.stdout).to.equal("Sucess!!\n");
+            h.expect(outputs.stdout).to.match(/^'Sucess!!'$/m);
+            h.expect(outputs.stdout).to.match(/^Run \/entrypoint.sh$/m);
             return container.remove();
           });
+        });
+    });
+
+    it("should generate a valid image with add files", function() {
+      return build('Dockerfile', 'sucess')
+        .then((image) => {
+          var result = h.docker.run(
+            image.name,
+            ["/bin/bash", "-c", "ls -la /all" ],
+            { stdout: mocks.stdout, stderr: mocks.stderr, rm: true }
+          );
+
+          return result
+            .then((container) => {
+              return container.remove();
+            })
+            .then(() => {
+              h.expect(outputs.stdout).to.match(/^-.*DockerfileFrom404$/m);
+              h.expect(outputs.stdout).to.match(/^d.*dir_to_add$/m);
+              h.expect(outputs.stdout).to.not.match(/^d.*build$/m);
+            });
         });
     });
 

--- a/spec/docker/build_spec.js
+++ b/spec/docker/build_spec.js
@@ -55,8 +55,11 @@ describe("Azk docker module, image build @slow", function() {
               return container.remove();
             })
             .then(() => {
-              h.expect(outputs.stdout).to.match(/^-.*DockerfileFrom404$/m);
               h.expect(outputs.stdout).to.match(/^d.*dir_to_add$/m);
+              h.expect(outputs.stdout).to.match(/^-.*file_to_add$/m);
+              h.expect(outputs.stdout).to.not.match(/^-.*Dockerfile$/m);
+              h.expect(outputs.stdout).to.not.match(/^-.*DockerfileFrom404$/m);
+              h.expect(outputs.stdout).to.not.match(/^-.*.dockerignore$/m);
               h.expect(outputs.stdout).to.not.match(/^d.*build$/m);
             });
         });

--- a/spec/fixtures/build/.dockerignore
+++ b/spec/fixtures/build/.dockerignore
@@ -1,0 +1,3 @@
+Dockerfile
+Dockerfile*
+.dockerignore

--- a/spec/fixtures/build/Dockerfile
+++ b/spec/fixtures/build/Dockerfile
@@ -4,6 +4,7 @@ MAINTAINER Azuki <support@azukiapp.com>
 ADD file_to_add /file_to_add
 ADD file2_dir/file2_to_add /run.sh
 ADD dir_to_add /dir_to_add
+ADD . /all
 
 COPY copy-entrypoint.sh /entrypoint.sh
 RUN chmod +x /run.sh

--- a/spec/fixtures/build/copy-entrypoint.sh
+++ b/spec/fixtures/build/copy-entrypoint.sh
@@ -2,5 +2,4 @@
 set -e
 
 echo "Run ${BASH_SOURCE:-$0}"
-echo "$@"
 exec ${@}

--- a/spec/fixtures/build/copy-entrypoint.sh
+++ b/spec/fixtures/build/copy-entrypoint.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 set -e
 
-exec "$@"
+echo "Run ${BASH_SOURCE:-$0}"
+echo "$@"
+exec ${@}

--- a/spec/fixtures/build/file2_dir/file2_to_add
+++ b/spec/fixtures/build/file2_dir/file2_to_add
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-echo "Sucess!!"
+/entrypoint.sh "echo 'Sucess!!'"

--- a/src/docker/build.js
+++ b/src/docker/build.js
@@ -64,10 +64,17 @@ function parseAddManifestFiles (archive, dockerfile, content) {
       var stats = yield qfs.stat(source);
       if (stats.isDirectory()) {
         var dirname = source.split(path.sep)[source.split(path.sep).length - 1];
-        var parent  = path.dirname(source);
-        archive.bulk([
-          { expand: true, cwd: parent, src: [path.join(dirname, '**')], dest: '/' },
-        ]);
+        var cwd, src;
+
+        if (source === base_dir) {
+          cwd = base_dir;
+          src = ['**'];
+        } else {
+          cwd = path.dirname(source);
+          src = [path.join(dirname, '**')];
+        }
+
+        archive.bulk([{ expand: true, cwd, src, dest: '/' }]);
       } else if (stats.isFile()) {
         archive.file(source, { name: capture[1] });
       }


### PR DESCRIPTION
This PR closes #419.

Besides the support to `ADD . /toFolder/` instruction, that fixes the issue, an additional improvent has been done to support the same behaviour as [docker build](http://docs.docker.com/reference/builder).

Now you can use a [.dockerignore](http://docs.docker.com/reference/builder/#the-dockerignore-file) to avoid that `azk` sends to Docker's build API useless files to the image generation process.