### PR TITLE
[Scale] Fixing scalable.default = 0 and optimizing start, restart, status commands.

### DIFF
--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -402,6 +402,7 @@ module.exports = {
     start: {
       description: "Starts an instance of the system(s)",
       already_started: "System `%(name)s` already started",
+      skip: "Skip starting, system `" + "%(name)s".blue + "` does not scale.",
       fail: "Due to the above error azk will stop all instances already running.\n",
       options: {
         verbose: verbose,
@@ -419,7 +420,8 @@ module.exports = {
     },
     stop: {
       description: "Stops an instance of the system(s)",
-      not_running: "System `%(name)s` not running",
+      not_running: "System `" + "%(name)s".blue + "` not running",
+      skip: "Skip stoping, system `" + "%(name)s".blue + "` does not scale.",
       options: {
         verbose : verbose,
         quiet   : quiet,

--- a/spec/generator/rules/generation/node_gen_spec.js
+++ b/spec/generator/rules/generation/node_gen_spec.js
@@ -44,7 +44,7 @@ describe('Azk generator generation node rule', function() {
     h.expect(system).to.have.deep.property('options.provision')
       .and.to.eql(['npm install']);
 
-    h.expect(system).to.have.property('scalable').and.eql({ default: 2, limit: -1 });
+    h.expect(system).to.have.property('scalable').and.eql({ default: 1, limit: -1 });
     h.expect(system).to.have.property('hostname').and.match(new RegExp(project_folder_name));
   });
 

--- a/src/cmds/scale.js
+++ b/src/cmds/scale.js
@@ -24,10 +24,23 @@ class Scale extends CliTrackerController {
 
       Helpers.manifestValidate(this.ui, manifest);
       var systems = manifest.getSystemsByName(opts.system);
+      var status_systems = _.flatten(_.map(systems, (system) => {
+        var result = [system];
+        if (!_.isEmpty(system.depends)) {
+          result = result.concat(
+            _.map(system.depends, (depend) => {
+              return manifest.getSystemsByName(depend);
+            })
+          );
+        }
+        return result;
+      }));
+      status_systems = _.flatten(status_systems);
+
       var result  = yield this[`${this.name}`](manifest, systems, opts);
 
       this.ui.output("");
-      yield lazy.Status.status(this, manifest, systems);
+      yield lazy.Status.status(this, manifest, status_systems);
 
       return result;
     })

--- a/src/cmds/scale.js
+++ b/src/cmds/scale.js
@@ -24,7 +24,7 @@ class Scale extends CliTrackerController {
 
       Helpers.manifestValidate(this.ui, manifest);
       var systems = manifest.getSystemsByName(opts.system);
-      var status_systems = _.flatten(_.map(systems, (system) => {
+      var status_systems = _.map(systems, (system) => {
         var result = [system];
         if (!_.isEmpty(system.depends)) {
           result = result.concat(
@@ -34,8 +34,8 @@ class Scale extends CliTrackerController {
           );
         }
         return result;
-      }));
-      status_systems = _.flatten(status_systems);
+      });
+      status_systems = _.uniq(_.flatten(status_systems)).reverse();
 
       var result  = yield this[`${this.name}`](manifest, systems, opts);
 

--- a/src/cmds/status.js
+++ b/src/cmds/status.js
@@ -45,9 +45,20 @@ class Status extends CliTrackerController {
         } else {
           hostname = system.hostname;
         }
+        var name;
+        var status;
+        if (instances.length > 0) {
+          name   = `${system.name}`.green;
+          status = `↑`.green;
+        } else if (!system.auto_start) {
+          name   = `${system.name}`.yellow;
+          status = `−`.yellow;
+        } else {
+          name   = `${system.name}`.red;
+          status = `↓`.red;
+        }
+
         var ports   = Status._ports_map(system, instances);
-        var name    = instances.length > 0 ? `${system.name}`.green : `${system.name}`.red;
-        var status  = instances.length > 0 ? `↑`.green : `↓`.red;
         var counter = instances.length.toString().blue;
 
         // Provisioned

--- a/src/generator/suggestions/django_python_default.js
+++ b/src/generator/suggestions/django_python_default.js
@@ -14,7 +14,7 @@ export class Suggestion extends UIProxy {
         'pip install --user --allow-all-external -r requirements.txt',
       ],
       http    : true,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       command : 'python manage.py runserver 0.0.0.0:$HTTP_PORT',
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'sync',       value: '.'},

--- a/src/generator/suggestions/elixir.js
+++ b/src/generator/suggestions/elixir.js
@@ -25,7 +25,7 @@ export class Suggestion extends DefaultSuggestion {
         "/azk/#{manifest.dir}/deps"           : {type: 'persistent', value: "#{manifest.dir}/deps"},
         "/azk/#{manifest.dir}/_build"         : {type: 'persistent', value: "#{manifest.dir}/_build"},
       },
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       http    : true,
       ports: {
         http: "4000",

--- a/src/generator/suggestions/jruby17.js
+++ b/src/generator/suggestions/jruby17.js
@@ -20,7 +20,7 @@ export class Suggestion extends UIProxy {
         'bundle install --path /azk/bundler',
       ],
       http    : true,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       command : 'bundle exec rackup config.ru --port $HTTP_PORT',
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'path', value: '.'},

--- a/src/generator/suggestions/node_default.js
+++ b/src/generator/suggestions/node_default.js
@@ -14,7 +14,7 @@ export class Suggestion extends UIProxy {
         "npm install"
       ],
       http: true,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       command : "npm start",
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'path', value: '.'},

--- a/src/generator/suggestions/php.js
+++ b/src/generator/suggestions/php.js
@@ -21,7 +21,7 @@ export class Suggestion extends UIProxy {
         http: "80/tcp",
       },
       command: null,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'path', value: '.'}
       },

--- a/src/generator/suggestions/php55.js
+++ b/src/generator/suggestions/php55.js
@@ -24,7 +24,7 @@ export class Suggestion extends UIProxy {
         http: "80/tcp",
       },
       command: null,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'path', value: '.'}
       },

--- a/src/generator/suggestions/php56.js
+++ b/src/generator/suggestions/php56.js
@@ -24,7 +24,7 @@ export class Suggestion extends UIProxy {
         http: "80/tcp",
       },
       command: null,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'path', value: '.'}
       },

--- a/src/generator/suggestions/php_laravel.js
+++ b/src/generator/suggestions/php_laravel.js
@@ -24,7 +24,7 @@ export class Suggestion extends UIProxy {
         http: "80/tcp",
       },
       command: null,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'path', value: '.'}
       },

--- a/src/generator/suggestions/python27.js
+++ b/src/generator/suggestions/python27.js
@@ -20,7 +20,7 @@ export class Suggestion extends UIProxy {
         'pip install --user --allow-all-external -r requirements.txt',
       ],
       http    : true,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       command : 'python server.py',
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'path',       value: '.'},

--- a/src/generator/suggestions/python34.js
+++ b/src/generator/suggestions/python34.js
@@ -20,7 +20,7 @@ export class Suggestion extends UIProxy {
         'pip install --user --allow-all-external -r requirements.txt',
       ],
       http    : true,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       command : 'python server.py',
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'path',       value: '.'},

--- a/src/generator/suggestions/rails.js
+++ b/src/generator/suggestions/rails.js
@@ -22,7 +22,7 @@ export class Suggestion extends UIProxy {
         'bundle exec rake db:migrate',
       ],
       http    : true,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       command : 'bundle exec rackup config.ru --pid /tmp/rails.pid --port $HTTP_PORT --host 0.0.0.0',
       mounts  : {
         '/azk/#{manifest.dir}'     : {type: 'sync', value: '.'},

--- a/src/generator/suggestions/ruby_default.js
+++ b/src/generator/suggestions/ruby_default.js
@@ -14,7 +14,7 @@ export class Suggestion extends UIProxy {
         'bundle install --path /azk/bundler',
       ],
       http    : true,
-      scalable: { default: 2 },
+      scalable: { default: 1 },
       command : 'bundle exec rackup config.ru --pid /tmp/ruby.pid --port $HTTP_PORT --host 0.0.0.0',
       mounts  : {
         '/azk/#{manifest.dir}': {type: 'sync', value: '.'},

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -134,6 +134,10 @@ export class System {
     return this.scalable.default === 0 && this.scalable.limit === 0;
   }
 
+  get auto_start() {
+    return this.scalable.default !== 0;
+  }
+
   get wait_scale() {
     var wait = this.options.wait;
     return _.isEmpty(wait) && wait !== false ? true : wait;


### PR DESCRIPTION
- [x] Closed #405 (even with `scalable.default = 0`, the system was run);
- [x] Set as `skipped` systems with `scalable.default = 0` on `status`;
- [x] Adding status `not auto scale` in `azk status`;

![image](https://cloud.githubusercontent.com/assets/2034678/8145143/0d966cfc-11d2-11e5-8490-f405aa961643.png)

- [x] Closed #275 - Not showing output for all systems when starting a single one that depends on others;

![image](https://cloud.githubusercontent.com/assets/2034678/8145415/d9683ba2-11dd-11e5-9b39-6a438bdb4058.png)
