### PR TITLE
Fixing sending command action to Keen-io

### DIFF
--- a/src/cli/cli_tracker_controller.js
+++ b/src/cli/cli_tracker_controller.js
@@ -36,7 +36,14 @@ export class CliTrackerController extends CliController {
           'quiet', 'open', 'verbose', 'to', 'force', 'log', 'colored', 'child',
         ]);
 
-        command_opts.action = action_name;
+        if (this.route.actions && this.route.actions.length > 0) {
+          var route_first_action = this.route.actions[0];
+          if (route_first_action !== 'index') {
+            command_opts.action = route_first_action;
+          } else {
+            command_opts.action = action_name;
+          }
+        }
 
         this.trackerEvent = this.ui.tracker.newEvent('command', {
           event_type: this.name,


### PR DESCRIPTION
After cli changes keen-io is not receiving the 'sub-commands' like `azk agent start`:

![image](https://cloud.githubusercontent.com/assets/155953/8168040/8769c1b2-1378-11e5-9f10-faf8587ecd5b.png)

This fixes that.