### PR TITLE
[tracker] Fixing insightkeenio

### DIFF
--- a/spec/utils/tracker_spec.js
+++ b/spec/utils/tracker_spec.js
@@ -1,7 +1,6 @@
 import h from 'spec/spec_helper';
 import { default as tracker } from 'azk/utils/tracker';
-
-// azk nvm grunt --grep='Azk Tracker'
+import { meta as azkMeta } from 'azk';
 
 describe("Azk Tracker", function() {
   this.timeout(2000);
@@ -21,5 +20,13 @@ describe("Azk Tracker", function() {
     var sessionId = tracker.generateNewAgentSessionId();
     var expectedSessionId = tracker.loadAgentSessionId();
     h.expect(sessionId).to.equal(expectedSessionId);
+  });
+
+  it("should override insight get/set for optout", function() {
+    return azkMeta.cleanAsync().then(() => {
+      tracker.insight.optOut = true;
+      var metaOptout = azkMeta.get(tracker.insight_opts.opt_out_key);
+      h.expect(metaOptout).to.equal(false);
+    });
   });
 });

--- a/src/config.js
+++ b/src/config.js
@@ -80,6 +80,7 @@ var options = mergeConfig({
     },
     // jscs:disable maximumLineLength
     tracker: {
+      permission_key: 'tracker_permission',
       disable: envs('AZK_DISABLE_TRACKER', false),
       projectId: envs('AZK_KEEN_PROJECT_ID', '552818c790e4bd7f7bd8baba'),
       writeKey:  envs('AZK_KEEN_WRITE_KEY', 'e2c70b3dd3ed3003a09a1bc7d8622ad9220fe33069d81164f0fafa13baf11458e48736f6cbcc995a8346183b290597504feb4bef06f71350f4859df5eb271a1d845f7cff5c9dfddf2f03de1e39760c6e51a06fb9e347c2e1fb98d3c6d370e6916e5db8810ddd9c0d5d83540386ccfe2e'),
@@ -136,11 +137,8 @@ var options = mergeConfig({
   },
   test: {
     paths: {
-      // jscs:disable maximumLineLength
-      log : path.join(paths.logs, 'azk_test.log'),
-      projectId: envs('AZK_KEEN_PROJECT_ID', '5526968d672e6c5a0d0ebec6'),
-      writeKey:  envs('AZK_KEEN_WRITE_KEY', '5dbce13e376070e36eec0c7dd1e7f42e49f39b4db041f208054617863832309c14a797409e12d976630c3a4b479004f26b362506e82a46dd54df0c977a7378da280c05ae733c97abb445f58abb56ae15f561ac9ad774cea12c3ad8628d896c39f6e702f6b035541fc1a562997cb05768'),
-      // jscs:enabled maximumLineLength
+      log     : path.join(paths.logs, 'azk_test.log'),
+      azk_meta: path.join(data_path, azk_dir, "shared", "test-Azkfile.js"),
     },
     docker: {
       namespace   : 'azk.test',
@@ -150,6 +148,11 @@ var options = mergeConfig({
     },
     tracker: {
       disable: true,
+      // jscs:disable maximumLineLength
+      permission_key: 'tracker_permission_test',
+      projectId : envs('AZK_KEEN_PROJECT_ID', '5526968d672e6c5a0d0ebec6'),
+      writeKey  : envs('AZK_KEEN_WRITE_KEY', '5dbce13e376070e36eec0c7dd1e7f42e49f39b4db041f208054617863832309c14a797409e12d976630c3a4b479004f26b362506e82a46dd54df0c977a7378da280c05ae733c97abb445f58abb56ae15f561ac9ad774cea12c3ad8628d896c39f6e702f6b035541fc1a562997cb05768'),
+      // jscs:enabled maximumLineLength
     },
     logs_level: {
       console: (envs('AZK_DEBUG') ? 'debug' : 'warn'),

--- a/src/utils/tracker.js
+++ b/src/utils/tracker.js
@@ -96,6 +96,10 @@ export class Tracker {
     this.ids_keys      = ids_keys;
     this.insight_opts  = opts;
     this.meta          = {
+
+    /**/console.log('\n>>---------\n this.insight:\n', require('util').inspect(this.insight, { showHidden: false, depth: null, colors: true }), '\n>>---------\n');/*-debug-*/
+
+    this.meta     = {
       "ip_address"      : "${keen.ip}",
       "agent_session_id": this.loadAgentSessionId(),
       "command_id"      : this.generateRandomId('command_id'),
@@ -115,7 +119,7 @@ export class Tracker {
 
   get insight() {
     if (!this.__insight) {
-      this.__insight = new lazy.InsightKeenIo(this.insight_opts);
+      this.__insight = new InsightKeenIoWithMeta(this.insight_opts);
     }
     return this.__insight;
   }
@@ -181,27 +185,14 @@ export class Tracker {
   }
 }
 
-export class InsightKeenIoWithMeta extends InsightKeenIo {
-
-  constructor() {
-    console.log("* Constructing InsightKeenIoWithMeta..");
-    super();
-    this.redefineOptOut();
+export class InsightKeenIoWithMeta extends lazy.InsightKeenIo {
+  get optOut() {
+    return azkMeta.get('optOut');
   }
 
-  redefineOptOut() {
-    Object.defineProperty(InsightKeenIo.prototype, 'optOut', {
-      get: function () {
-        console.log("* InsightKeenIoWithMeta.get...");
-        return azkMeta.get('optOut');
-      },
-      set: function (val) {
-        console.log("* InsightKeenIoWithMeta.set...");
-        azkMeta.set('optOut', val);
-      }
-    });
+  set optOut(val) {
+    azkMeta.set('optOut', val);
   }
-
 }
 
 // Default tracker

--- a/src/utils/tracker.js
+++ b/src/utils/tracker.js
@@ -202,7 +202,7 @@ export class Tracker {
 
 // Default tracker
 var default_tracker = new Tracker({}, {
-  permission: 'tracker_permission',
+  permission: config('tracker:permission_key'),
   user_id   : 'tracker_user_id',
   agent_id  : 'agent_session_id',
 });

--- a/src/utils/tracker.js
+++ b/src/utils/tracker.js
@@ -181,6 +181,29 @@ export class Tracker {
   }
 }
 
+export class InsightKeenIoWithMeta extends InsightKeenIo {
+
+  constructor() {
+    console.log("* Constructing InsightKeenIoWithMeta..");
+    super();
+    this.redefineOptOut();
+  }
+
+  redefineOptOut() {
+    Object.defineProperty(InsightKeenIo.prototype, 'optOut', {
+      get: function () {
+        console.log("* InsightKeenIoWithMeta.get...");
+        return azkMeta.get('optOut');
+      },
+      set: function (val) {
+        console.log("* InsightKeenIoWithMeta.set...");
+        azkMeta.set('optOut', val);
+      }
+    });
+  }
+
+}
+
 // Default tracker
 var default_tracker = new Tracker({}, {
   permission: 'tracker_permission',


### PR DESCRIPTION
This PR closes #398

To avoid conflict between the instruction if azk should either or not to track actions and Insight's original system, the class `InsightKeenIo` was extended in azk and the get/set methods for `optOut` was overridden in order to use metadata (where azk stores this kind of data).