### PR TITLE
azk agent start: Fix configure errors

### DIFF
--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -77,14 +77,7 @@ export class Configure extends UIProxy {
           yield this._checkPorts(ports.balancer, balancer_key, 'balancer', 'AZK_BALANCER_PORT'),
           yield this._loadDnsServers()
         );
-      })
-      .catch(function (err) {
-        // Unhandled rejection overtakes synchronous exception through done() #471
-        // https://github.com/petkaantonov/bluebird/issues/471
-        if (err instanceof AzkError) {
-          this.fail(err.toString());
-        }
-      }.bind(this));
+      });
     }
   }
 

--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -201,6 +201,9 @@ export class Configure extends UIProxy {
       .info()
       .then(() => {
         return { 'docker:host': host };
+      })
+      .catch(() => {
+        throw new DependencyError('docker_access', { socket });
       });
   }
 


### PR DESCRIPTION
This closes #444

Now its is not necessary to catch `agent.configure` errors when agent is starting.
This way the process will correctly stop when some errors occours.

Because of https://github.com/azukiapp/azk/blob/07ee52476c/src%2Futils%2Fpromises.js#L4-L11 no more `Unhandled Rejection` will be showed to final users.

To hold 80 port and test we can use socat:
```sh
sudo apt-get install socat
sudo socat TCP4-LISTEN:80,fork EXEC:"echo `pwd`"
```

To hold 80 port with azk container we can `kill -9` the process while azk agent is up:
```sh
kill -9 $(pgrep azk);
```
