### PR TITLE
[Kernel] Adds current `azk` bin folder to the PATH

### DIFF
--- a/bin/azk
+++ b/bin/azk
@@ -10,6 +10,7 @@ abs_dir() {
 }
 
 export AZK_ROOT_PATH=`cd \`abs_dir ${BASH_SOURCE:-$0}\`/..; pwd`
+export PATH=$AZK_ROOT_PATH/bin:$PATH
 
 # Namespace and domain
 default_namespace="dev.azk.io"

--- a/src/agent/api/index.js
+++ b/src/agent/api/index.js
@@ -24,13 +24,15 @@ var Api = {
 
   start() {
     log.debug("[api] starting server api");
-    try {
-      lazy.hotswap.on('swap', () => {
-        log.debug("[api] reloading server api");
-        this._make_new_app();
-      });
-    } catch (err) {
-      log.debug("[api] install hotswap.", err.stack ? err.stack : err.toString());
+    if (config('agent:dev:hotswap_code')) {
+      try {
+        lazy.hotswap.on('swap', () => {
+          log.debug("[api] reloading server api");
+          this._make_new_app();
+        });
+      } catch (err) {
+        log.debug("[api] install hotswap.", err.stack ? err.stack : err.toString());
+      }
     }
 
     return this._make_new_app();

--- a/src/agent/server.js
+++ b/src/agent/server.js
@@ -16,7 +16,7 @@ var Server = {
   stop_handler() {},
 
   // Warning: Only use test in mac
-  vm_enabled: true,
+  vm_enabled: !config('agent:dev:force_disable_vm'),
 
   // TODO: log start machine steps
   start(stop_handler) {

--- a/src/config.js
+++ b/src/config.js
@@ -123,6 +123,12 @@ var options = mergeConfig({
 
       // Used to carry global configuration switches the agent
       config_keys: [],
+
+      // Azk develop helpers
+      dev: {
+        force_disable_vm: envs('AZK_AGENT_FORCE_VM_DISABLE', false),
+        hotswap_code    : envs('AZK_AGENT_HOTSWAP', false),
+      }
     },
 
     urls: {


### PR DESCRIPTION
This PR adds the current `azk` bin folder to the PATH.

This is useful when you have more than one `azk` bin in your machine and want to be sure which one you are running.

Plus, the code hot swap present in `azk agent` API has been disabled by default and can be turned on by setting env var `AZK_AGENT_HOTSWAP=true`