### PR TITLE
[Sync] Fixing sync excluded folders based on mount value instead of relative dir of sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Bug
+  * [Sync] Fixing sync exclude folders based in mount value instead of relative to dir of sync;
+
 ## v0.14.2 - (2015-06-18)
 
 * Bug

--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -3,7 +3,7 @@ import { publish } from 'azk/utils/postal';
 import { async, ninvoke, nfcall, thenAll } from 'azk/utils/promises';
 import { config, set_config } from 'azk';
 import { UIProxy } from 'azk/cli/ui';
-import { AzkError, OSNotSupported, DependencyError } from 'azk/utils/errors';
+import { OSNotSupported, DependencyError } from 'azk/utils/errors';
 import { net, envDefaultArray } from 'azk/utils';
 import Azk from 'azk';
 

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -572,18 +572,17 @@ export class System {
   _mounts_to_syncs(mounts) {
     var syncs = {};
 
-    return _.reduce(mounts, (syncs, mount) => {
+    return _.reduce(mounts, (syncs, mount, mount_key) => {
       if (mount.type === 'sync') {
 
         var host_sync_path = this._resolved_path(mount.value);
 
-        var mounted_subpaths = _.reduce(mounts, (subpaths, mount) => {
-          var mount_path = this._resolved_path(mount.value);
-          if ( mount_path !== host_sync_path &&  mount_path.indexOf(host_sync_path) === 0) {
-            return subpaths.concat([path.join(mount.value, '/')]);
-          } else {
-            return subpaths;
+        var mounted_subpaths = _.reduce(mounts, (subpaths, mount, dir) => {
+          if ( dir !== mount_key && dir.indexOf(mount_key) === 0) {
+            var regex = new RegExp(`^${mount_key}`);
+            subpaths = subpaths.concat([path.normalize(dir.replace(regex, './'))]);
           }
+          return subpaths;
         }, []);
 
         mount.options        = mount.options || {};


### PR DESCRIPTION
The sync feature wasn't properly handling applications located in subfolders.

The reason of that was the folders to be excluded from sync process were being considered related from mounting point, not from the destination folder to be synced.

Log before fix:
![image](https://cloud.githubusercontent.com/assets/2034678/8249332/51d6ec9a-163f-11e5-87b7-5569b3f8fc7c.png)

`Azkfile.js`:
![image](https://cloud.githubusercontent.com/assets/2034678/8249339/5dfd40a0-163f-11e5-9c01-5f48277b8ef9.png)

In the previous example, the folders `tmp` and `log` should be excluded from sync once they are subfolders of a synced dir (`./#{system.name}`). However, because the mounting point was `.` (i.e. the folder where `Azkfile.js` is placed), the sync logic was looking for the non-existing folders `./tmp` and `./log` instead of `./#{system.name}/tmp` and `./#{system.name}/log`.