### PR TITLE
[suggestion] Fixing suggestions: database order and postgresql mounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## dev
 
 * Bug
-  * [Suggesting] Fixed `Court` investigates subfolder even when finding files on the root.
+  * [Suggesting] Fixed postgresql suggestion mounts path;
+  * [Suggesting] Fixed the order in which the suggestion creates systems in `Azkfile.js`, applications comes first and database after;
+  * [Suggesting] Fixed `Court` investigates subfolder even when finding files on the root;
 
 * Enhancements
-  * [Suggesting] Adding support to use `app.dir` in templates.
-  * [Suggesting] Refactored suggestions for cleaner code.
+  * [Suggesting] Adding support to use `app.dir` in templates;
+  * [Suggesting] Refactored suggestions for cleaner code;
 
 ## v0.14.3 - (2015-06-19)
 

--- a/spec/generator/court_spec.js
+++ b/spec/generator/court_spec.js
@@ -14,9 +14,7 @@ describe('Azk generator tool court veredict:', function() {
       var UI  = h.mockUI(beforeEach, outputs);
       var dir = yield h.tmp_dir();
 
-      // -------
       // Gemfile
-      // -------
       rootFullPath = dir;
       var frontFolder = path.join(rootFullPath, 'front');
       yield fsAsync.mkdirs(frontFolder);
@@ -29,9 +27,7 @@ describe('Azk generator tool court veredict:', function() {
       ].join('\n');
       yield fsAsync.writeFile(gemfilePath, gemfileContent);
 
-      // -------
       // package.json
-      // -------
       var apiFolder = path.join(rootFullPath, 'api');
       yield fsAsync.mkdirs(apiFolder);
       var packageJsonPath = path.join(apiFolder, 'package.json');
@@ -160,12 +156,11 @@ describe('Azk generator tool court veredict:', function() {
 
   it('should suggest systems for the Azkfile.js template', function() {
     return court.judge(rootFullPath).then(function () {
-      var folders = Object.keys(court.systems_suggestions);
-      h.expect(folders).to.have.length(3);
-
-      h.expect(folders).to.contains('api');
-      h.expect(folders).to.contains('front');
-      h.expect(folders).to.contains('postgres');
+      var systems = Object.keys(court.systems_suggestions);
+      h.expect(systems).to.have.length(3);
+      h.expect(systems).to.contains('api');
+      h.expect(systems).to.contains('front');
+      h.expect(systems).to.contains('postgres');
     });
   });
 });

--- a/spec/generator/rules/generation/mysql_and_postgres_gen_spec.js
+++ b/spec/generator/rules/generation/mysql_and_postgres_gen_spec.js
@@ -129,7 +129,7 @@ describe('Azk generator db', function() {
         h.expect(system).to.have.deep.property('options.wait.timeout', 1000);
         h.expect(system).to.not.have.deep.property('options.workdir');
         h.expect(system).to.have.deep.property('options.mounts').and.to.eql(
-          { '/var/lib/postgresql': { type: 'persistent', value: 'postgresql', options: {} },
+          { '/var/lib/postgresql/data': { type: 'persistent', value: 'postgresql', options: {} },
             '/var/log/postgresql': { type: 'path',       value: './log/postgresql', options: {} } } );
       });
     });
@@ -160,10 +160,9 @@ describe('Azk generator db', function() {
 
         var expectedMounts = {};
         var folderSystem = `${rootFolderBasename}/${systemName}`;
-        expectedMounts[workdir] = { type: 'sync', value: `${folderSystem}`, options: {} };
         // /azk/azk-test-60957fmnsb4/railsPostgres
         expectedMounts[path.join('/azk', folderSystem)] = {
-          type: 'sync', value: `${folderSystem}`, options: {}
+          type: 'sync', value: `./${systemName}`, options: {}
         };
         expectedMounts[path.join('/azk', folderSystem, '.bundle')] = {
           type: 'path', value: `${folderSystem}/.bundle`, options: {}
@@ -206,10 +205,9 @@ describe('Azk generator db', function() {
 
         var expectedMounts = {};
         var folderSystem = `${rootFolderBasename}/${systemName}`;
-        expectedMounts[workdir] = { type: 'sync', value: `${folderSystem}`, options: {} };
         // /azk/azk-test-60957fmnsb4/railsPostgres
         expectedMounts[path.join('/azk', folderSystem)] = {
-          type: 'sync', value: `${folderSystem}`, options: {}
+          type: 'sync', value: `./${systemName}`, options: {}
         };
         expectedMounts[path.join('/azk', folderSystem, '.bundle')] = {
           type: 'path', value: `${folderSystem}/.bundle`, options: {}

--- a/src/generator/court.js
+++ b/src/generator/court.js
@@ -80,8 +80,8 @@ export class Court extends UIProxy {
 
   get rules() {
     return this.__rules.runtime
-      .concat(this.__rules.database)
       .concat(this.__rules.framework)
+      .concat(this.__rules.database)
       .concat(this.__rules.worker)
       .concat(this.__rules.task);
   }

--- a/src/generator/suggestions/postgres-9.3.js
+++ b/src/generator/suggestions/postgres-9.3.js
@@ -24,7 +24,7 @@ export class Suggestion extends UIProxy {
       command: null,
       workdir: null,
       mounts  : {
-        '/var/lib/postgresql' : {type: 'persistent', value: 'postgresql'},
+        '/var/lib/postgresql/data' : {type: 'persistent', value: 'postgresql'},
         '/var/log/postgresql' : {type: 'path', value: './log/postgresql'},
       },
       envs: {

--- a/src/generator/suggestions/ruby.js
+++ b/src/generator/suggestions/ruby.js
@@ -25,7 +25,7 @@ export class Suggestion extends DefaultSuggestion {
         http: '3000/tcp'
       },
       mounts  : {
-        '/azk/#{app.dir}'        : {type: 'sync', value: '#{app.dir}'},
+        '/azk/#{app.dir}'        : {type: 'sync', value: '.'},
         '/azk/bundler'           : {type: 'persistent', value: '#{app.dir}/bundler'},
         '/azk/#{app.dir}/tmp'    : {type: 'persistent', value: '#{app.dir}/tmp'},
         '/azk/#{app.dir}/log'    : {type: 'path', value: '#{app.dir}/log'},


### PR DESCRIPTION
This PR includes two main changes:

- Inverts the order of analysis of systems evidences, processing the identification rules for frameworks before the ones for databases. This avoids that, in the suggested Azkfile.js, the database comes before the main app (as happened with Rails + PostgreSQL apps);

- From PR https://github.com/azukiapp/docker-postgres/pull/2, we've made a minor change to fix the volumes mounting for PostgreSQL.