### PR TITLE
[Agent] Replacing periodic check agent from vm to docker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Suggesting] Fixed postgresql suggestion mounts path;
   * [Suggesting] Fixed the order in which the suggestion creates systems in `Azkfile.js`, applications comes first and database after;
   * [Suggesting] Fixed `Court` investigates subfolder even when finding files on the root;
+  * [Agent] Replacing periodic check agent from vm to docker;
 
 * Enhancements
   * [Suggesting] Adding support to use `app.dir` in templates;

--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -109,6 +109,10 @@ module.exports = {
   },
 
   status: {
+    docker: {
+      down: "Docker is down",
+    },
+
     agent: {
       running        : "Agent is running...",
       not_running    : "Agent is not running (try: `azk agent start`).",
@@ -140,7 +144,6 @@ module.exports = {
       docker_keys: "Downloading required keys to connect to docker",
       mounting   : "Mounting the shared folder in virtual machine...",
       mounted    : "Shared folder has been successfully mounted.",
-      down       : "Virtual machine is down",
     },
 
     socat: {

--- a/src/agent/balancer.js
+++ b/src/agent/balancer.js
@@ -140,14 +140,16 @@ var Balancer = {
     });
   },
 
-  stop() {
+  stop(skip_containers = false) {
     if (this.isRunnig()) {
       log.debug("call to stop balancer");
       return Tools.async_status("balancer", this, function* (change_status) {
-        yield thenAll([
-          this._stop_system('balancer-redirect', change_status),
-          this._stop_system('dns', change_status),
-        ]);
+        if (!skip_containers) {
+          yield thenAll([
+            this._stop_system('balancer-redirect', change_status),
+            this._stop_system('dns', change_status),
+          ]);
+        }
         yield this._stop_sub_service("hipache", change_status);
         yield this._stop_sub_service("memcached", change_status);
       });

--- a/src/config.js
+++ b/src/config.js
@@ -89,8 +89,9 @@ var options = mergeConfig({
     },
     // jscs:enable maximumLineLength
     agent: {
-      requires_vm: requires_vm,
+      requires_vm    : requires_vm,
       portrange_start: 11000,
+      check_interval : envs('AZK_AGENT_CHECK_INTERVAL', 10000),
       balancer: {
         ip  : new Dynamic("agent:balancer:ip"),
         host: envs('AZK_BALANCER_HOST'),
@@ -105,7 +106,7 @@ var options = mergeConfig({
         defaultserver: ['8.8.8.8', '8.8.4.4'],
       },
       vm: {
-        wait_ready : 180000,
+        wait_ready : envs('AZK_VM_WAIT_READY', 180000),
         ip         : new Dynamic("agent:vm:ip"),
         name       : envs('AZK_AGENT_VM_NAME', "azk-vm-" + namespace),
         user       : "docker",

--- a/src/utils/net.js
+++ b/src/utils/net.js
@@ -182,7 +182,8 @@ var net = {
   waitService(uri, retry = 15, opts = {}) {
     opts = _.defaults(opts, {
       timeout: 10000,
-      retry_if: () => { return promiseResolve(true); }
+      retry_if: () => { return promiseResolve(true); },
+      publish_retry: true,
     });
 
     // Parse options to try connect
@@ -202,10 +203,12 @@ var net = {
       var connect  = () => {
         var t = null;
 
-        publish("utils.net.waitService.status", _.merge({
-          uri : uri,
-          type: 'try_connect', attempts: attempts, max: max, context: opts.context
-        }, address ));
+        if (opts.publish_retry) {
+          publish("utils.net.waitService.status", _.merge({
+            uri : uri,
+            type: 'try_connect', attempts: attempts, max: max, context: opts.context
+          }, address ));
+        }
 
         client = nativeNet.connect(address, function() {
           client.end();


### PR DESCRIPTION
This change replaces the Virtual Machine periodic verification strategy by Docker service check, for both Mac OS X and Linux.

This should reduce issues with agent being stopped even when Docker is available.