### PR TITLE
[manifest] Fixing wait not support `false` value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Bug
+  * [Manifest] Fixing wait not support `false` value;
+
 ## v0.14.5 - (2015-08-01)
+
 * Bug
   * [Agent] Fixing bug on Docker check that caused high CPU usage;
 

--- a/spec/manifest/validate/wait_spec.js
+++ b/spec/manifest/validate/wait_spec.js
@@ -25,6 +25,15 @@ describe('Validate manifest option - wait:', function () {
 
   describe('valid:', function () {
 
+    it('should accept false value', function () {
+      return check_valid(`
+        system('system1', {
+          image: { docker: "any" },
+          wait: false,
+        });
+      `);
+    });
+
     it('should accept positive numbers', function () {
       return check_valid(`
         system('system1', {

--- a/src/manifest/validate.js
+++ b/src/manifest/validate.js
@@ -50,8 +50,8 @@ export class Validate {
   static _validate_wait_option(manifest) {
     return _.reduce(manifest.systems, (errors, system) => {
 
-      // ignore if it is not present
-      if (typeof system.options.wait === 'undefined') {
+      // ignore if it is not present or equal false
+      if (typeof system.options.wait === 'undefined' || system.options.wait === false) {
         return errors;
       }
 


### PR DESCRIPTION
In some cases you must set the `wait` as `false`, but the validation of the Manifest did not allow it. This PR adds a rule to allow the value `false`.

e.g. of error:
```shell
$ azk shell test
azk: Manifest file (`Azkfile.js`) is not valid (see  more at http://docs.azk.io/en/azkfilejs/), error:
azk: Error parsing `wait` value. Invalid type. Value: `false`.
azk: Please, change `test` system to a valid `wait` type and value.
azk: Check http://docs.azk.io/en/reference/azkfilejs/wait.html for further information.
```