### PR TITLE
[Agent] fix agent loop

### DIFF
--- a/shared/locales/en-US.js
+++ b/shared/locales/en-US.js
@@ -150,7 +150,7 @@ module.exports = {
       removed    : "Virtual machine has been successfully removed.",
       waiting    : "Waiting for virtual machine boot...",
       ready      : "Virtual machine is ready to use.",
-      progress   : "Trying to connect to vm (%(uri)s) (%(attempts)d/%(max)d)...",
+      progress   : "Trying to connect to vm (%(uri)s) (timeout: %(timeout)ds)...",
       sshkey     : "Setting the ssh key to vm...",
       error      : "Error in vm process: %(data)s",
       docker_keys: "Downloading required keys to connect to docker",
@@ -159,11 +159,11 @@ module.exports = {
     },
 
     socat: {
-      progress: "Trying to connect to docker (%(attempts)d/%(max)d)...",
+      progress: "Trying to connect to docker (timeout: %(timeout)ds)...",
     },
 
     'balancer-redirect_connect': {
-      progress: "Check if balancer redirect service is up (%(uri)s) (%(attempts)d/%(max)d)...",
+      progress: "Check if balancer redirect service is up (%(uri)s) (timeout: %(timeout)ds)...",
     },
 
     balancer: {
@@ -188,7 +188,7 @@ module.exports = {
       started_dns : "Dns service started.",
       stopping_dns: "Stopping dns service...",
       stopped_dns : "Dns service was stopped.",
-      progress    : "Trying to connect to docker (%(uri)s) (%(attempts)d/%(max)d)...",
+      progress    : "Trying to connect to docker (%(uri)s) (timeout: %(timeout)ds)...",
     },
   },
 

--- a/src/agent/server.js
+++ b/src/agent/server.js
@@ -141,19 +141,23 @@ var Server = {
       publish_retry: false,
     };
 
+    var check_docker_interval = config('agent:check_interval');
     var interval_fn = () => {
       net
         .waitService(docker_host, wait_options)
         .then((success) => {
           if (!success) {
+            log.debug(`[agent] _activeDockerMonitor - docker_host is stopped!`);
             return stop();
           }
-          setTimeout(interval_fn, config('agent:vm:check_interval'));
+
+          log.debug(`[agent] _activeDockerMonitor - docker_host checked (${docker_host}). Waiting for more ${check_docker_interval / 1000} seconds.`);
+          setTimeout(interval_fn, check_docker_interval);
         })
         .catch(stop);
     };
 
-    setTimeout(interval_fn, config('agent:vm:check_interval'));
+    setTimeout(interval_fn, check_docker_interval);
   },
 };
 

--- a/src/utils/net.js
+++ b/src/utils/net.js
@@ -220,7 +220,11 @@ var net = {
         if (opts.publish_retry) {
           publish("utils.net.waitService.status", _.merge({
             uri : uri,
-            type: 'try_connect', attempts: attempts, max: max, context: opts.context
+            type: 'try_connect',
+            timeout: (opts.timeout / 1000), // show in seconds
+            attempts: attempts,
+            max: max,
+            context: opts.context
           }, address ));
         }
 

--- a/src/utils/net.js
+++ b/src/utils/net.js
@@ -222,8 +222,6 @@ var net = {
             uri : uri,
             type: 'try_connect',
             timeout: (opts.timeout / 1000), // show in seconds
-            attempts: attempts,
-            max: max,
             context: opts.context
           }, address ));
         }


### PR DESCRIPTION
- fixed agent to loop and use 50% of CPU

- showing log when agent check for docker:
![image](https://cloud.githubusercontent.com/assets/155953/9017846/c79eb854-37af-11e5-9f58-e90214c4c241.png)

- when starting agent, shows timeout now, not attempts count:
![image](https://cloud.githubusercontent.com/assets/155953/9017855/e1679576-37af-11e5-82d1-895d3943a74a.png)
