### PR TITLE
[kernel] Updating `vboxmanage` to fix parse in Virtual Box 5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Bug
+  * [VM] Fixing start in Virtual Box 5.0;
+
 ## v0.14.5 - (2015-08-01)
+
 * Bug
   * [Agent] Fixing bug on Docker check that caused high CPU usage;
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7951,8 +7951,8 @@
     },
     "vboxmanage": {
       "version": "0.0.16",
-      "from": "git://github.com/nuxlli/node-vboxmanage.git#9244eac7498aab28db5c8e0cce60c914c4b73c4c",
-      "resolved": "git://github.com/nuxlli/node-vboxmanage.git#9244eac7498aab28db5c8e0cce60c914c4b73c4c",
+      "from": "gullitmiranda/node-vboxmanage",
+      "resolved": "git://github.com/gullitmiranda/node-vboxmanage.git#49f6d3b192a36a45e9e3341cdc907d39017eaf44",
       "dependencies": {
         "stream-buffers": {
           "version": "0.2.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7951,8 +7951,8 @@
     },
     "vboxmanage": {
       "version": "0.0.16",
-      "from": "gullitmiranda/node-vboxmanage",
-      "resolved": "git://github.com/gullitmiranda/node-vboxmanage.git#49f6d3b192a36a45e9e3341cdc907d39017eaf44",
+      "from": "azukiapp/node-vboxmanage",
+      "resolved": "git://github.com/azukiapp/node-vboxmanage.git#49f6d3b192a36a45e9e3341cdc907d39017eaf44",
       "dependencies": {
         "stream-buffers": {
           "version": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ssh2": "0.2.22",
     "syntax-error": "^1.1.0",
     "underscore": "^1.6.0",
-    "vboxmanage": "git+https://github.com/gullitmiranda/node-vboxmanage",
+    "vboxmanage": "git+https://github.com/azukiapp/node-vboxmanage",
     "which": "^1.0.5",
     "winston": "^0.7.3",
     "ws": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ssh2": "0.2.22",
     "syntax-error": "^1.1.0",
     "underscore": "^1.6.0",
-    "vboxmanage": "git+https://github.com/nuxlli/node-vboxmanage",
+    "vboxmanage": "git+https://github.com/gullitmiranda/node-vboxmanage",
     "which": "^1.0.5",
     "winston": "^0.7.3",
     "ws": "^0.7.1",


### PR DESCRIPTION
This PR closes #481, closes #502 .

In Virtual Box 5.0, there is a slight change in the ouput of the command `VBoxManage showvminfo azk-vm-dev.azk.io --machinereadable`:

```
# Virtual Box < v5.0:
VideoMode="720,400,0"@0,0
# Virtual Box v5.0:
VideoMode="720,400,0"@0,0 1
```

Updating [gullitmiranda/node-vboxmanage](https://github.com/gullitmiranda/node-vboxmanage), this isse was solved.
