### PR TITLE
[vm] Fixing removal of VM without net interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Bug
   * [VM] Fixing start in Virtual Box 5.0;
+  * [VM] Fixing removal of VM without net interface;
 
 ## v0.14.5 - (2015-08-01)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Bug
+  * [VM] Fixing start in Virtual Box 5.0;
+
 ## v0.14.5 - (2015-08-01)
+
 * Bug
   * [Agent] Fixing bug on Docker check that caused high CPU usage;
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7951,8 +7951,8 @@
     },
     "vboxmanage": {
       "version": "0.0.16",
-      "from": "git://github.com/nuxlli/node-vboxmanage.git#9244eac7498aab28db5c8e0cce60c914c4b73c4c",
-      "resolved": "git://github.com/nuxlli/node-vboxmanage.git#9244eac7498aab28db5c8e0cce60c914c4b73c4c",
+      "from": "gullitmiranda/node-vboxmanage",
+      "resolved": "git://github.com/gullitmiranda/node-vboxmanage.git#49f6d3b192a36a45e9e3341cdc907d39017eaf44",
       "dependencies": {
         "stream-buffers": {
           "version": "0.2.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7951,8 +7951,8 @@
     },
     "vboxmanage": {
       "version": "0.0.16",
-      "from": "gullitmiranda/node-vboxmanage",
-      "resolved": "git://github.com/gullitmiranda/node-vboxmanage.git#49f6d3b192a36a45e9e3341cdc907d39017eaf44",
+      "from": "azukiapp/node-vboxmanage",
+      "resolved": "git://github.com/azukiapp/node-vboxmanage.git#49f6d3b192a36a45e9e3341cdc907d39017eaf44",
       "dependencies": {
         "stream-buffers": {
           "version": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ssh2": "0.2.22",
     "syntax-error": "^1.1.0",
     "underscore": "^1.6.0",
-    "vboxmanage": "git+https://github.com/gullitmiranda/node-vboxmanage",
+    "vboxmanage": "git+https://github.com/azukiapp/node-vboxmanage",
     "which": "^1.0.5",
     "winston": "^0.7.3",
     "ws": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ssh2": "0.2.22",
     "syntax-error": "^1.1.0",
     "underscore": "^1.6.0",
-    "vboxmanage": "git+https://github.com/nuxlli/node-vboxmanage",
+    "vboxmanage": "git+https://github.com/gullitmiranda/node-vboxmanage",
     "which": "^1.0.5",
     "winston": "^0.7.3",
     "ws": "^0.7.1",

--- a/src/agent/vm.js
+++ b/src/agent/vm.js
@@ -464,8 +464,9 @@ var vm = {
         // Remove networking interface
         if (!isBlank(info.hostonlyadapter1)) {
           var net    = yield hostonly.getByName(info.hostonlyadapter1);
-          var server = yield dhcp.getByNetworkName(net.VBoxNetworkName);
           if (!_.isEmpty(net)) {
+            var server = yield dhcp.getByNetworkName(net.VBoxNetworkName);
+
             if (!_.isEmpty(server)) {
               yield dhcp.remove_hostonly_server(info.hostonlyadapter1);
             }


### PR DESCRIPTION
A simple fix in VM removal: the issue is that `VM.remove` tried to remove DHCP servers even when no network interfaces existed in the VM