### PR TITLE
[docker] Adding docker api version lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Bug
+  * [VM] Fixing start in Virtual Box 5.0;
+
 ## v0.14.5 - (2015-08-01)
+
 * Bug
   * [Agent] Fixing bug on Docker check that caused high CPU usage;
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Bug
   * [VM] Fixing start in Virtual Box 5.0;
 
+* Enhancements
+  * [docker] Adding docker version lock
+
 ## v0.14.5 - (2015-08-01)
 
 * Bug

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7951,8 +7951,8 @@
     },
     "vboxmanage": {
       "version": "0.0.16",
-      "from": "git://github.com/nuxlli/node-vboxmanage.git#9244eac7498aab28db5c8e0cce60c914c4b73c4c",
-      "resolved": "git://github.com/nuxlli/node-vboxmanage.git#9244eac7498aab28db5c8e0cce60c914c4b73c4c",
+      "from": "gullitmiranda/node-vboxmanage",
+      "resolved": "git://github.com/gullitmiranda/node-vboxmanage.git#49f6d3b192a36a45e9e3341cdc907d39017eaf44",
       "dependencies": {
         "stream-buffers": {
           "version": "0.2.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -7951,8 +7951,8 @@
     },
     "vboxmanage": {
       "version": "0.0.16",
-      "from": "gullitmiranda/node-vboxmanage",
-      "resolved": "git://github.com/gullitmiranda/node-vboxmanage.git#49f6d3b192a36a45e9e3341cdc907d39017eaf44",
+      "from": "azukiapp/node-vboxmanage",
+      "resolved": "git://github.com/azukiapp/node-vboxmanage.git#49f6d3b192a36a45e9e3341cdc907d39017eaf44",
       "dependencies": {
         "stream-buffers": {
           "version": "0.2.5",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ssh2": "0.2.22",
     "syntax-error": "^1.1.0",
     "underscore": "^1.6.0",
-    "vboxmanage": "git+https://github.com/gullitmiranda/node-vboxmanage",
+    "vboxmanage": "git+https://github.com/azukiapp/node-vboxmanage",
     "which": "^1.0.5",
     "winston": "^0.7.3",
     "ws": "^0.7.1",

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "ssh2": "0.2.22",
     "syntax-error": "^1.1.0",
     "underscore": "^1.6.0",
-    "vboxmanage": "git+https://github.com/nuxlli/node-vboxmanage",
+    "vboxmanage": "git+https://github.com/gullitmiranda/node-vboxmanage",
     "which": "^1.0.5",
     "winston": "^0.7.3",
     "ws": "^0.7.1",

--- a/src/config.js
+++ b/src/config.js
@@ -71,6 +71,7 @@ var options = mergeConfig({
       socket        : envs('AZK_DOCKER_SOCKER', "/var/run/docker.sock"),
       host          : new Dynamic("docker:host"),
       namespace     : envs('AZK_NAMESPACE'),
+      api_version   : envs('AZK_DOCKER_API_VERSION', 'v1.16'),
       repository    : 'azk',
       default_domain: 'azk',
       build_name    : 'azkbuild',

--- a/src/docker/docker.js
+++ b/src/docker/docker.js
@@ -146,6 +146,7 @@ export class Docker extends promisifyClass('dockerode') {
   constructor(opts) {
     var info = opts.socketPath || `${opts.host}:${opts.port}`;
     log.info("Connecting to", info);
+    log.debug("[docker] connection options:", opts);
     super(opts);
 
     this.c_regex = RegExp(`\/${Utils.escapeRegExp(config('docker:namespace'))}`);

--- a/src/docker/index.js
+++ b/src/docker/index.js
@@ -1,4 +1,4 @@
-import { config } from 'azk';
+import { config, log } from 'azk';
 import { Docker, Image, Container } from 'azk/docker/docker';
 
 var url = require('url');
@@ -20,8 +20,10 @@ module.exports = {
           port : opts.port,
         };
       }
+      opts.version = config('docker:api_version');
       this.connect = new Docker(opts);
     }
+    log.debug("[docker] connect:", this.connect);
     return this.connect;
   },
 


### PR DESCRIPTION
To avoid possible incompatibility with newer versions of the docker, I added a setting that determines which version should be used.

You can change the version by environment variable `AZK_DOCKER_API_VERSION`.

For more information about the docker api versions visit https://docs.docker.com/reference/api/docker_remote_api/.