### PR TITLE
[docker 1.8 fix] Fixing stopping/kill containers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Bug
+  * [Docker] Do not try to stop or kill a not running container;
+
 ## v0.14.5 - (2015-08-01)
 * Bug
   * [Agent] Fixing bug on Docker check that caused high CPU usage;

--- a/spec/docker/pull_spec.js
+++ b/spec/docker/pull_spec.js
@@ -27,16 +27,14 @@ describe("Azk docker module, image pull @slow", function() {
           'pulling_layers',
           'pulling_metadata',
           'pulling_fs_layer',
-          'pulling_up_to_date',
           'pulling_image',
           'download',
           'download_complete',
         ];
-        _.each(events, (event) => {
-          if (event.statusParsed) {
-            h.expect(status_list)
-              .to.include(event.statusParsed.type);
-          }
+
+        _.each(status_list, (status) => {
+          h.expect(events)
+          .to.contain.an.item.with.deep.property('statusParsed.type', status);
         });
       })
       .catch(function (err) {

--- a/spec/docker/pull_spec.js
+++ b/spec/docker/pull_spec.js
@@ -22,18 +22,21 @@ describe("Azk docker module, image pull @slow", function() {
       .then(() => {
         _subscription.unsubscribe();
 
-        var status = [
+        var status_list = [
           'pulling_repository',
           'pulling_layers',
           'pulling_metadata',
           'pulling_fs_layer',
+          'pulling_up_to_date',
           'pulling_image',
           'download',
           'download_complete',
         ];
-        _.each(status, (status) => {
-          h.expect(events)
-            .to.contain.an.item.with.deep.property('statusParsed.type', status);
+        _.each(events, (event) => {
+          if (event.statusParsed) {
+            h.expect(status_list)
+              .to.include(event.statusParsed.type);
+          }
         });
       })
       .catch(function (err) {

--- a/spec/docker/run_spec.js
+++ b/spec/docker/run_spec.js
@@ -1,6 +1,6 @@
 import { config, utils } from 'azk';
 import { subscribe } from 'azk/utils/postal';
-import { async, defer, delay } from 'azk/utils/promises';
+import { async, defer, delay, promiseResolve } from 'azk/utils/promises';
 import h from 'spec/spec_helper';
 
 var default_img = config('docker:image_default');
@@ -123,7 +123,13 @@ describe("Azk docker module, run method @slow", function() {
       yield h.docker.run(default_img, _cmd, { stdout: mocks.stdout });
       h.expect(outputs.stdout).to.match(/HTTP\/1\.1/);
 
-      return container.kill();
+      var container_info = yield container.inspect();
+      yield container.inspect();
+      if (container_info.State.Running) {
+        return container.kill();
+      } else {
+        return promiseResolve();
+      }
     });
   });
 
@@ -158,7 +164,13 @@ describe("Azk docker module, run method @slow", function() {
       var regex = new RegExp(h.escapeRegExp(`AZK_NAME=${data.Name.slice(1)}`), 'm');
       h.expect(log).to.match(regex);
 
-      return container.kill();
+      var container_info = yield container.inspect();
+      yield container.inspect();
+      if (container_info.State.Running) {
+        return container.kill();
+      } else {
+        return promiseResolve();
+      }
     });
   });
 

--- a/spec/spec_helpers/dustman.js
+++ b/spec/spec_helpers/dustman.js
@@ -20,8 +20,14 @@ export function extend(Helpers) {
         publish("spec.dustman.remove_containers.message", t('test.remove_containers', containers.length));
         return thenAll(_.map(containers, (container) => {
           var c = h.docker.getContainer(container.Id);
-          return c.kill().then(() => {
-            return c.remove({ force: true });
+          return c.inspect().then(function(container_info) {
+            if (container_info.State.Running) {
+              return c.kill().then(() => {
+                return c.remove({ force: true });
+              });
+            } else {
+              return c.remove({ force: true });
+            }
           });
         }));
       });

--- a/src/config.js
+++ b/src/config.js
@@ -153,7 +153,7 @@ var options = mergeConfig({
       namespace   : 'azk.test',
       repository  : 'azk_test',
       build_name  : 'azkbuildtest',
-      image_empty : 'cevich/empty_base_image',
+      image_empty : 'cevich/empty_base_image:latest',
     },
     tracker: {
       disable: true,

--- a/src/docker/pull.js
+++ b/src/docker/pull.js
@@ -13,6 +13,7 @@ var msg_regex = {
   get pulling_layers     () { return new lazy.XRegExp('Pulling dependent layers'); },
   get pulling_metadata   () { return new lazy.XRegExp('Pulling metadata'); },
   get pulling_fs_layer   () { return new lazy.XRegExp('Pulling fs layer'); },
+  get pulling_up_to_date () { return new lazy.XRegExp('Image is up to date'); },
   get pulling_image      () { return new lazy.XRegExp(
     'Pulling image \((?<tag>.*)\) from (?<repository>.*), endpoint: (?<endpoint>.*)'
   ); },


### PR DESCRIPTION
Do not try to stop or kill a not running container
Break because of this change:

- 'docker kill returns error when container is not running' (https://github.com/docker/docker/blob/master/CHANGELOG.md)

to test this issue you can use this commit that have an error on command:

```
git clone https://github.com/saitodisse/task-cerebral.git
cd task-cerebral
git checkout 3bb9be151d2d9449a6595910ac858032efbd7bc9
azk start -Rvv
```

you should get this error if everything is correct:
```
azk: Run system `task-cerebral` return: (1), for command: /bin/bash -c npm run deploy && npm start:
azk:  .task-cerebral [log] >  
azk:  .task-cerebral [log] >  > task-cerebral@0.0.1 predeploy /azk/t4
azk:  .task-cerebral [log] >  > rm -rf dist/** && cp src/index.html dist && cp src/styles.css dist
```