### PR TITLE
[docs] Improving Troubleshooting section

### DIFF
--- a/docs/Azkfile.js
+++ b/docs/Azkfile.js
@@ -18,6 +18,7 @@ systems({
     wait: {"retry": 20, "timeout": 2000},
     mounts: {
       '/azk/#{manifest.dir}': path("."),
+      '/azk/CONTRIBUTING.md': path("../CONTRIBUTING.md"),
       '/azk/node_modules': persistent("node_modules"),
     },
     scalable: {"default": 1},
@@ -26,6 +27,7 @@ systems({
       domains: [ "#{system.name}.#{azk.default_domain}" ]
     },
     ports: {
+      http:       "5000/tcp",
       livereload: "35729:35729/tcp",
     },
   },

--- a/docs/content/en/troubleshooting/README.md
+++ b/docs/content/en/troubleshooting/README.md
@@ -310,3 +310,23 @@ Then you can remove **all** persistent and sync folders:
 sudo rm -rf ~/.azk/data/persistent_folders
 sudo rm -rf ~/.azk/data/sync_folders
 ```
+
+----------------------
+
+### I'm facing `[sync] fail Error: watch ENOSPC` error when trying to start my system. How to fix it?
+
+Probably you have a system that uses the `sync` mount option in your Azkfile.js. This issue is related with the OS limitation on how many files an user can watch at the same time. The solution is simply increase this limit.
+
+### Linux
+
+#### Ubuntu or Fedora
+
+```
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+```
+
+### Arch Linux
+
+```
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.d/99-sysctl.conf && sudo sysctl --system
+```

--- a/docs/content/en/troubleshooting/README.md
+++ b/docs/content/en/troubleshooting/README.md
@@ -16,6 +16,8 @@
 
 1. [How can I clean all persistent and sync folders from all projects?](README.html#how-can-i-clean-all-persistent-and-sync-folders-from-all-projects)
 
+1. [I'm facing '[sync] fail Error: watch ENOSPC' error when trying to start my system. How to fix it?](README.html#im-facing-sync-fail-error-watch-enospc-error-when-trying-to-start-my-system-how-to-fix-it)
+
 -------------------------
 
 ### I can't access any URL *.azk.dev.io
@@ -325,7 +327,7 @@ Probably you have a system that uses the `sync` mount option in your Azkfile.js.
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 
-### Arch Linux
+#### Arch Linux
 
 ```
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.d/99-sysctl.conf && sudo sysctl --system

--- a/docs/content/en/troubleshooting/README.md
+++ b/docs/content/en/troubleshooting/README.md
@@ -101,23 +101,31 @@ $ azk stop <system_name>
 $ azk start -R <system_name>
 ```
 
-#### Check the logs
+#### Check if your start command is correct
 
-Check logs to get more information about errors:
+Check if your system is properly configured. This means the `command` set by the main system in the Azkfile.js should be successfully run.
 
-```sh
-$ azk logs <system_name>
-```
+##### Run the `command` from inside the azk shell
 
-#### Execute `command` in azk shell
-
-Get into azk shell and run the `command: ` instruction from Azkfile.js yourself:
+Get into azk shell and run the `command` instruction from Azkfile.js:
 
 ```sh
 $ azk shell <system_name>
 
 # for example in a Node.js container you can run:
 $ npm start
+```
+
+##### Check if the server is bound to the Network Interface `0.0.0.0`
+
+If the command in the previous step has been successfully run and your system runs a server (i.e. is a web system), ensure it is bound to the correct Network Interface (`0.0.0.0`, not `localhost` nor `127.0.0.1`, commonly set by default). To do this, check the server options and look for `bind` or `host` options, using the value `0.0.0.0`.
+
+#### Check the logs
+
+Check logs to get more information about errors:
+
+```sh
+$ azk logs <system_name>
 ```
 
 #### Azkfile.js: replace `sync` by `path`

--- a/docs/content/en/troubleshooting/README.md
+++ b/docs/content/en/troubleshooting/README.md
@@ -1,5 +1,7 @@
 # Troubleshooting
 
+> Just in case this troubleshooting could not help you to fix your problem, you can always get support from Azuki team at Gitter: https://gitter.im/azukiapp/azk/.
+
 1. [I can't access any URL *.azk.dev.io](README.html#i-cant-access-any-url-azkdevio)
 
 1. [The `azk start` command is not working](README.html#the-azk-start-command-is-not-working)
@@ -8,9 +10,11 @@
 
 1. [There's no Internet available / I'm not connected to any network. `azk` starts but the browser shows I'm offline. How do I fix it?](README.html#theres-no-internet-available--im-not-connected-to-any-network-azk-starts-but-the-browser-shows-im-offline-how-do-i-fix-it)
 
-1. [How can I clean Docker files?](README.html#how-can-i-clean-docker-files)
+1. [How can I clean Docker data?](README.html#how-can-i-clean-docker-data)
 
-1. [How can I clean azk persistent files?](README.html#how-can-i-clean-azk-persistent-files)
+1. [How can I clean the persistent and sync folders from a specific project?](README.html#how-can-i-clean-the-persistent-and-sync-folders-from-a-specific-project)
+
+1. [How can I clean all persistent and sync folders from all projects?](README.html#how-can-i-clean-all-persistent-and-sync-folders-from-all-projects)
 
 -------------------------
 
@@ -18,7 +22,7 @@
 
 During the instalation process, azk creates a file inside `/etc/resolver/` called `azk.dev.io`. This file is responsible for resolving every URL in the format *.azk.dev.io. In case this is not working, follow these steps:
 
-1. Check that the resolver is configured with scutil --dns:
+1. Check that the resolver is configured with `scutil --dns`:
 
    ```sh
    $ scutil --dns
@@ -39,9 +43,9 @@ During the instalation process, azk creates a file inside `/etc/resolver/` calle
 
 3. In case it was created, restart your computer. It really helps!
 
-4. If it still doesn't work, try turning off and on your computer's AirPort.
+4. If it still doesn't work, try turning off and on your computer's AirPort (Mac OS X).
 
-5. Verify that port forwarding is enabled in the system firewall (OS X Mavericks):
+5. Verify that port forwarding is enabled in the system firewall (Mac OS X Mavericks):
 
    ```sh
    $ sysctl -w net.inet.ip.fw.enable=1
@@ -50,7 +54,7 @@ During the instalation process, azk creates a file inside `/etc/resolver/` calle
 6. Yosemite Note: If this still doesn't work, enable port forwarding manually:
 
    ```sh
-   sudo pfctl -f /etc/pf.conf; sudo pfctl -e
+   $ sudo pfctl -f /etc/pf.conf; sudo pfctl -e
    ```
 
 Thanks to [pow](https://github.com/basecamp/pow/wiki/Troubleshooting#dns) for the troubleshooting tips. :)
@@ -58,65 +62,65 @@ Thanks to [pow](https://github.com/basecamp/pow/wiki/Troubleshooting#dns) for th
 
 ----------------------------------
 
-### The `azk start` command is not working.
+### The `azk start` command is not working
 
-Sometimes was a corrupted database. Sometimes was the application files. The common solutions can vary from a simple restart to a total Docker image cleanup.
+Sometimes it's a corrupted database. Sometimes it's the application files. The common solutions can vary from a simple restart to a total Docker image cleanup.
 
-Here there are some steps to get your `Azkfile.js` to work again:
+Here are some steps to get your `Azkfile.js` back to work again:
 
-#### restart agent
+#### Restart azk agent
 
-When you restart agent you restart balancer and DNS too.
+When you restart the agent you restart the load balancer and the DNS too.
 
 ```sh
-azk agent stop
-azk agent start
+$ azk agent stop
+$ azk agent start
 ```
 
-#### restart system(s)
+#### Restart the system(s)
 
 Stop and start your system:
 
 ```sh
-azk restart <system_name>
+$ azk restart <system_name>
 # or
-azk stop  <system_name>
-azk start <system_name>
+$ azk stop  <system_name>
+$ azk start <system_name>
 ```
 
-#### reprovision system(s)
+#### Reprovision the system(s)
 
-Stop and start your system with 'reprovision'.
+Stop and start your system with 'reprovision':
 
 ```sh
-azk restart -R <system_name>
+$ azk restart -R <system_name>
 # or
-azk stop <system_name>
-azk start -R <system_name>
+$ azk stop <system_name>
+$ azk start -R <system_name>
 ```
 
-#### checking logs
+#### Check the logs
 
-Check logs to get more information about errors.
+Check logs to get more information about errors:
 
 ```sh
-azk logs <system_name>
+$ azk logs <system_name>
 ```
 
-#### execute Azkfile.js `command` on azk shell
+#### Execute `command` in azk shell
 
-Get into azk shell and run your `command: ` Azkfile.js instruction yourself:
+Get into azk shell and run the `command: ` instruction from Azkfile.js yourself:
 
 ```sh
-azk shell <system_name>
+$ azk shell <system_name>
 
-# for example in a node.js container you can run:
-$> npm start
+# for example in a Node.js container you can run:
+$ npm start
 ```
 
-#### Azkfile: replace sync by path
+#### Azkfile.js: replace `sync` by `path`
 
-Edit your `Azkfile.js` and change `sync mounts` with `path mounts`. The `path` option is slower but is older and more stable.
+Edit your `Azkfile.js` and replace `sync` mounts with `path` mounts. The `path` option is slower but is more stable.
 
 ```js
 // from
@@ -131,59 +135,17 @@ mounts: {
 ```
 
 
-#### Azkfile: clean persistent folders
+#### Azkfile.js: clean persistent and sync folders
 
-1) Check persistent folders
-
-```sh
-azk info
-```
-
-2) Remove folders ..../persistent_folders/0x0x0x0x0x0x from systems that is getting errors to start
-
-```sh
-sudo rm -rf ".../persistent_folders/0x0x0x0x0x0x"
-sudo rm -rf ".../persistent_folders/1x1x1x1x1x1x"
-...
-```
-
-3) Restart systems with reprovision
-
-```sh
-azk stop
-azk start -R
-```
-
-#### VM (Mac or Linux + VM) - clean all persistent_folders e sync_folders (caution!)
-
-This will clean all `persistent_folders` and `sync_folders` inside VM.
-All data persisted will be lost forever. Every database persistent data will be lost forever.
-
-```sh
-# caution -- All data persisted will be lost forever
-azk vm ssh -- sudo rm -rf /mnt/sda1/azk
-```
-
-#### Linux - clean all persistent_folders and sync_folders (caution!)
-
-This will clean all `persistent_folders` and `sync_folders`.
-All data persisted will be lost forever. Every database persistent data will be lost forever.
-
-```sh
-# caution -- All data persisted will be lost forever
-sudo rm -rf ~/.azk/data/sync_folders
-sudo rm -rf ~/.azk/data/persistent_folders
-```
+You can check [this section](http://docs-azk.dev.azk.io/en/troubleshooting/README.html#how-can-i-clean-the-persistent-and-sync-folders-of-a-specific-project) on how to wipe off persisted data and get your system back to its initial state.
 
 #### Dockerfile
 
-Check your Dockerfile. Maybe an `environment variable` is not set.
+Check your `Dockerfile`. Maybe some environment variable is not set.
 
 #### Azkfile.js
 
-Check your `Azkfile.js` against older versions. Worked before? See some examples at http://images.azk.io/. Reade carefully the azk documentation: [Azkfile.js](../azkfilejs/README.html).
-
-Just in case you could not fix your problem to get up your systems you always can get support at Gitter: https://gitter.im/azukiapp/azk/.
+Check your `Azkfile.js` against older versions. Has something changed? Did it work before? See some examples at http://images.azk.io/. Read carefully the azk documentation: [Azkfile.js](../azkfilejs/README.html).
 
 -------------------------
 
@@ -207,9 +169,9 @@ Assuming your app domain is `demoazk.dev.azk.io` and your `azk` IP is `192.168.5
 $ echo "192.168.51.4 demoazk.dev.azk.io #azk" | sudo tee -a /etc/hosts
 ```
 
-You must add an entry for each application that you are running using `azk`: `azkdemo.dev.azio.io`, `blog.dev.azk.io`, `myapp.dev.azk.io` e `*.dev.azk.io`
+You must add an entry for each application that you are running using `azk`: `demoazk.dev.azk.io`, `blog.dev.azk.io`, `myapp.dev.azk.io` and `*.dev.azk.io`
 
-Just keep in mind to remove that line after you have Internet connection again. If you used the previous command, just run:
+Just keep in mind to remove those lines after you have Internet connection again. If you used the previous command, just run:
 
 ```bash
 $ sed '/^.*#azk$/ { N; d; }' /etc/hosts
@@ -217,17 +179,17 @@ $ sed '/^.*#azk$/ { N; d; }' /etc/hosts
 
 -------------------------
 
-### How can I clean Docker files?
+### How can I clean Docker data?
 
-#### Running Containers
+#### Killing running containers
 
-To kill running containers:
+To kill all running containers (you'll have to restart the `azk agent`):
 
 ```bash
-adocker kill $(adocker ps -q | tr '\r\n' ' '); \
+adocker kill $(adocker ps -q | tr '\r\n' ' ')
 ```
 
-#### Stopped Containers
+#### Cleaning stopped containers
 
 To delete stopped containers:
 
@@ -235,64 +197,104 @@ To delete stopped containers:
 adocker rm -f $(adocker ps -f status=exited -q | tr '\r\n' ' ')
 ```
 
-#### Docker Images
+#### Removing Docker images
 
-Remove images using filters. In this example the filter is 'azkbuild':
+To remove Docker images using filters (in this example the filter is 'azkbuild'):
 
 ```bash
-adocker rmi $(adocker images | grep "azkbuild" | awk '{print $3}' | tr '\r\n' ' ')
+$ adocker rmi $(adocker images | grep "azkbuild" | awk '{print $3}' | tr '\r\n' ' ')
 ```
 
-#### Dangling Images
+#### Removing Docker dangling images
 
 To delete dangling images:
 
 ```bash
-adocker rmi $(adocker images -q -f dangling=true | tr '\r\n' ' ')
+$ adocker rmi $(adocker images -q -f dangling=true | tr '\r\n' ' ')
 ```
 
-#### Delete all images
+#### Removing all Docker images (proceed with caution!)
 
-The following command deletes all Docker images downloaded.
-After that in the next execution you will have to download
-all future images.
+The following command deletes **all** Docker images downloaded.
+After running it, in the next execution you will have to download
+all required images.
 
 ```bash
-adocker rmi $(adocker images -q)
+$ adocker rmi $(adocker images -q | tr '\r\n' ' ')
 ```
 
 #### Other tips
 
 The following link has several Docker tips.
 Just be sure to run all commands as `adocker`,
-especially if you are using a virtual machine.
+especially if you are using a Virtual Machine.
 
 - https://github.com/wsargent/docker-cheat-sheet#tips
 
 ----------------------
 
-### How can I clean azk persistent files?
+### How can I clean the persistent and sync folders from a specific project?
 
-#### VM (Mac or Linux + VM): `persistent_folders` eand`sync_folders` (caution!)
+**WARNING:** This will clean the `persistent_folders` and `sync_folders` of a project.
+This means all persisted data (including databases) for that project will be lost forever. **Proceed with extreme caution**.
 
-You can erase `persistent_folder` and `sync_folder`.
-Let's check this folders disk usage:
+1) Check the `persistent_folders` and the `sync_folders` of the system:
 
 ```sh
-azk vm ssh -- du -sh /mnt/sda1/azk/sync_folders
+$ azk info | grep -P "(persistent|sync)_folders" 
+```
+
+2) Remove those folders:
+
+#### Mac OS X
+
+```sh
+$ azk vm ssh -- sudo rm -rf ".../persistent_folders/0x0x0x0x0x0x"
+$ azk vm ssh -- sudo rm -rf ".../sync_folders/0x0x0x0x0x0x"
+# ...
+```
+
+#### Linux
+
+```sh
+$ sudo rm -rf ".../persistent_folders/0x0x0x0x0x0x"
+$ sudo rm -rf ".../sync_folders/0x0x0x0x0x0x"
+# ...
+```
+
+3) Restart system with reprovision flag (`-R`):
+
+```sh
+$ azk stop
+$ azk start -R
+```
+
+----------------------
+
+### How can I clean **all** persistent and sync folders from all projects?
+
+**WARNING:** This will clean all `persistent_folders` and `sync_folders`. This means all persisted data (including databases) from all projects will be lost forever. **Proceed with extreme caution**.
+
+After doing this you'll need to run `azk start -R` to reprovision each system.
+
+#### Mac OS X
+
+You can erase the `persistent_folder` and the `sync_folder` from inside the Virtual Machine.
+Let's check those folders disk usage:
+
+```sh
 azk vm ssh -- du -sh /mnt/sda1/azk/persistent_folders
+azk vm ssh -- du -sh /mnt/sda1/azk/sync_folders
 ```
 
-This will delete all files on `persistent_folders` and `sync_folders`.
-You will lose all database persinted data.
-After that you need to run `azk start -R` to reprovision each system.
+Then you can remove **all** persistent and sync folders:
 
 ```sh
-azk vm ssh -- sudo rm -rf /mnt/sda1/azk/sync_folders
 azk vm ssh -- sudo rm -rf /mnt/sda1/azk/persistent_folders
+azk vm ssh -- sudo rm -rf /mnt/sda1/azk/sync_folders
 ```
 
-#### Linux: `persistent_folders` and `sync_folders` (caution!)
+#### Linux
 
 You can erase `persistent_folder` and `sync_folder`.
 Let's check this folders disk usage:
@@ -302,11 +304,9 @@ sudo du -hs ~/.azk/data/persistent_folders
 sudo du -hs ~/.azk/data/sync_folders
 ```
 
-This will delete all files on `persistent_folders` and `sync_folders`.
-You will lose all database persinted data.
-After that you need to run `azk start -R` to reprovision each system.
+Then you can remove **all** persistent and sync folders:
 
 ```sh
-sudo rm -rf ~/.azk/data/sync_folders
 sudo rm -rf ~/.azk/data/persistent_folders
+sudo rm -rf ~/.azk/data/sync_folders
 ```

--- a/docs/content/pt-BR/troubleshooting/README.md
+++ b/docs/content/pt-BR/troubleshooting/README.md
@@ -15,6 +15,9 @@
 1. [Como posso limpar os dados persistidos em um projeto específico?](README.html#como-posso-limpar-os-dados-persistidos-de-um-projeto-especfico)
 
 1. [Como posso limpar os dados persistidos de todos os projetos?](README.html#como-posso-limpar-os-dados-persistidos-de-todos-os-projetos)
+
+1. [Estou recebendo o erro '[sync] fail Error: watch ENOSPC' ao tentar iniciar meu sistema. Como corrigir isso?](README.html#estou-recebendo-o-erro-sync-fail-error-watch-enospc-ao-tentar-iniciar-meu-sistema-como-corrigir-isso)
+
 -------------------------
 
 ### Não consigo acessar nenhuma URL *.dev.azk.io
@@ -324,7 +327,7 @@ Provavelmente você tem um sistema que usa a opção de mount `sync` em seu Azkf
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 ```
 
-### Arch Linux
+#### Arch Linux
 
 ```
 echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.d/99-sysctl.conf && sudo sysctl --system

--- a/docs/content/pt-BR/troubleshooting/README.md
+++ b/docs/content/pt-BR/troubleshooting/README.md
@@ -63,7 +63,7 @@ Agradecimentos ao [pow](https://github.com/basecamp/pow/wiki/Troubleshooting#dns
 
 ----------------------------------
 
-### Estou enfrentando erros ao tentar executar o `azk start`.
+### Estou enfrentando erros ao tentar executar o `azk start`
 
 Às vezes pode acontecer de um banco de dados ficar corrompido.
 Às vezes podem ser os arquivos da aplicação.
@@ -104,17 +104,13 @@ $ azk stop <system_name>
 $ azk start -R <system_name>
 ```
 
-#### Verifique os logs
+#### Verifique se seu comando de start está correto
 
-Verifique os logs para maiores informações sobre erros:
+Verifique se seu sistema está devidamente configurado. Isso significa que item `command` definido pelo sistema principal dentro do Azkfile.js deve ser corretamente executado.
 
-```sh
-$ azk logs <system_name>
-```
+##### Execute o `command` direto no shell
 
-#### Execute o `command` direto no shell
-
-Entre no shell do sistema e execute o comando `command: ` do seu Azkfile.js.
+Entre no shell do sistema e execute o comando definido em `command` do seu Azkfile.js.
 
 ```sh
 $ azk shell <system_name>
@@ -123,6 +119,17 @@ $ azk shell <system_name>
 $ npm start
 ```
 
+##### Verifique se seu servidor está associado à interface de rede `0.0.0.0`
+
+Caso o comando executado no passo anterior seja concluído com sucesso e seu sistema envolva um servidor (é um sistema web, por exemplo), tenha certeza de que ele está associado à interface de rede correta (`0.0.0.0`, e não `localhost` ou `127.0.0.1`, que é o padrão de muitos sistemas). Para definir isso, verifique as opções de execução do servidor e busque por `bind` ou `host`, passando o valor `0.0.0.0`.
+
+#### Verifique os logs
+
+Verifique os logs para maiores informações sobre erros:
+
+```sh
+$ azk logs <system_name>
+```
 
 #### Azkfile.js: Troque o `sync` por `path`
 

--- a/docs/content/pt-BR/troubleshooting/README.md
+++ b/docs/content/pt-BR/troubleshooting/README.md
@@ -309,3 +309,23 @@ Para remover **todas** as `persistent_folders` e `sync_folders:
 sudo rm -rf ~/.azk/data/persistent_folders
 sudo rm -rf ~/.azk/data/sync_folders
 ```
+
+----------------------
+
+### Estou recebendo o erro `[sync] fail Error: watch ENOSPC` ao tentar iniciar meu sistema. Como corrigir isso?
+
+Provavelmente você tem um sistema que usa a opção de mount `sync` em seu Azkfile.js. Esse problema é relacionado com a limitação do SO em quantos arquivos um usuário pode monitorar ao mesmo tempo. A solução é simplesmente aumentar esse limite:
+
+### Linux
+
+#### Ubuntu or Fedora
+
+```
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
+```
+
+### Arch Linux
+
+```
+echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.d/99-sysctl.conf && sudo sysctl --system
+```

--- a/docs/content/pt-BR/troubleshooting/README.md
+++ b/docs/content/pt-BR/troubleshooting/README.md
@@ -1,5 +1,7 @@
 # Troubleshooting
 
+> Caso não este conteúdo não seja suficiente para você solucionar seu problema, você sempre pode contar com nossa ajuda pelo Gitter: https://gitter.im/azukiapp/azk/pt.
+
 1. [Não consigo acessar nenhuma URL *.azk.dev.io](README.html#no-consigo-acessar-nenhuma-url-devazkio)
 
 1. [Estou enfrentando erros ao tentar executar o `azk start`](README.html#estou-enfrentando-erros-ao-tentar-executar-o-azk-start)
@@ -8,18 +10,18 @@
 
 1. [Não há Internet disponível / Eu não estou conectado a nenhuma rede. O `azk` é iniciado, mas o navegador mostra que eu estou offline. Como faço para corrigir isso?](README.html#no-h-internet-disponvel--eu-no-estou-conectado-a-nenhuma-rede-o-azk--iniciado-mas-o-navegador-mostra-que-eu-estou-offline-como-fao-para-corrigir-isso)
 
-
 1. [Como posso limpar os dados do Docker?](README.html#como-posso-limpar-os-dados-do-docker)
 
-1. [Como posso limpar os dados persistidos do azk](README.html#como-posso-limpar-os-dados-persistidos-do-azk)
+1. [Como posso limpar os dados persistidos em um projeto específico?](README.html#como-posso-limpar-os-dados-persistidos-de-um-projeto-especfico)
 
+1. [Como posso limpar os dados persistidos de todos os projetos?](README.html#como-posso-limpar-os-dados-persistidos-de-todos-os-projetos)
 -------------------------
 
 ### Não consigo acessar nenhuma URL *.dev.azk.io
 
 No processo de instalação, o `azk` cria um arquivo dentro da pasta `/etc/resolver` chamado `dev.azk.io`. Esse arquivo é responsável por resolver todas as chamadas a URLs no formato `*.dev.azk.io`. Caso isso não esteja funcionando, siga os seguintes passos:
 
-1. Verifique que o resolver está configurado com scutil --dns:
+1. Verifique que o resolver está configurado com `scutil --dns`:
 
    ```sh
    $ scutil --dns
@@ -39,9 +41,9 @@ No processo de instalação, o `azk` cria um arquivo dentro da pasta `/etc/resol
 
 3. Caso ele se encontre na pasta, reinicie seu computador. Isso realmente ajuda!
 
-4. Se isso não funcionar, tente desligar e ligar o AirPort no seu computador.
+4. Se isso não funcionar, tente desligar e ligar o AirPort no seu computador (Mac OS X).
 
-5. Verifique que "port forwarding" está habilitado em seu firewall (OS X Mavericks):
+5. Verifique que o "port forwarding" está habilitado em seu firewall (Mac OS X Mavericks):
 
    ```sh
    $ sysctl -w net.inet.ip.fw.enable=1
@@ -50,7 +52,7 @@ No processo de instalação, o `azk` cria um arquivo dentro da pasta `/etc/resol
 6. Yosemite: Caso isso ainda não funcione, habilite "port forwarding" manualmente:
 
    ```sh
-   sudo pfctl -f /etc/pf.conf; sudo pfctl -e
+   $ sudo pfctl -f /etc/pf.conf; sudo pfctl -e
    ```
 
 Agradecimentos ao [pow](https://github.com/basecamp/pow/wiki/Troubleshooting#dns) pelas dicas de troubleshooting. :)
@@ -63,65 +65,65 @@ Agradecimentos ao [pow](https://github.com/basecamp/pow/wiki/Troubleshooting#dns
 Às vezes pode acontecer de um banco de dados ficar corrompido.
 Às vezes podem ser os arquivos da aplicação.
 As medidas clássicas para se tentar contornar este tipo de problema
-vão desde um simples `restart` até uma limpeza total das imagens.
+vão desde um simples `restart` até uma limpeza total das imagens do Docker.
 
 A seguir seguem alguns passos para tentar fazer que seu `Azkfile.js`
  volte a funcionar.
 
-#### restart agent
+#### Reinicie o agent do azk
 
-Ao reiniciar o `azk agent` você irá levantar o dns e o balancer novamente.
+Ao reiniciar o `azk agent` você irá levantar o DNS e o balanceador de carga novamente.
 
 ```sh
-azk agent stop
-azk agent start
+$ azk agent stop
+$ azk agent start
 ```
 
-#### restart system(s)
+#### Reinicie o(s) sistema(s)
 
-Pare e inicie o sistema novamente:
+Pare e inicie novamente cada sistema:
 
 ```sh
-azk restart <system_name>
+$ azk restart <system_name>
 # ou
-azk stop  <system_name>
-azk start <system_name>
+$ azk stop  <system_name>
+$ azk start <system_name>
 ```
 
-#### reprovision system(s)
+#### Reprovisione o(s) sistema(s)
 
-Pare e inicie o sistema novamente com 'reprovision'.
+Pare e inicie novamente cada sistema com a flag de reprovisionamento (`-R`):
 
 ```sh
-azk restart -R <system_name>
+$ azk restart -R <system_name>
 # ou
-azk stop <system_name>
-azk start -R <system_name>
+$ azk stop <system_name>
+$ azk start -R <system_name>
 ```
 
-#### vizualizar logs
+#### Verifique os logs
 
-Verifique o log para maiores informações sobre erros.
+Verifique os logs para maiores informações sobre erros:
 
 ```sh
-azk logs <system_name>
+$ azk logs <system_name>
 ```
 
-#### executar `command` direto no shell
+#### Execute o `command` direto no shell
 
-Entre no shell do sistema e simule o comando `command: ` do seu `Azkfile.js`.
+Entre no shell do sistema e execute o comando `command: ` do seu Azkfile.js.
 
 ```sh
-azk shell <system_name>
+$ azk shell <system_name>
 
-# por exemplo num container de node.js você pode executar:
-$> npm start
+# por exemplo num container de Node.js você pode executar:
+$ npm start
 ```
 
 
-#### sync -> path
+#### Azkfile.js: Troque o `sync` por `path`
 
-Edite o seu `Azkfile.js` e troque os mounts que forem `sync` pelo mais antigo e estável `path`
+Edite o seu `Azkfile.js` e troque os mounts que forem `sync` por `path`. A opção `path` é mais lenta, mas é mais estável.
 
 ```js
 // de
@@ -135,74 +137,18 @@ mounts: {
 },
 ```
 
-#### limpar persistent folders de um sistema
+#### Azkfile.js: Limpe as pastas de persistent e sync
 
-1) Verifique seus 'persistent folders'
-
-```sh
-azk info
-```
-
-2) Remova as pastas ..../persistent_folders/0x0x0x0x0x0x dos sistemas que estão dando problema
-
-```sh
-sudo rm -rf ".../persistent_folders/0x0x0x0x0x0x"
-sudo rm -rf ".../persistent_folders/1x1x1x1x1x1x"
-...
-```
-
-3) Reexecute os sistemas com reprovision
-
-```sh
-azk stop
-azk start -R
-```
-
-#### VM (Mac ou Linux + VM) - limpar todos `persistent_folders` e `sync_folders` (cuidado!)
-
-Verifique o tamnho ocupado em disco, dentro da VM:
-
-```sh
-azk vm ssh -- du -sh /mnt/sda1/azk/sync_folders
-azk vm ssh -- du -sh /mnt/sda1/azk/persistent_folders
-```
-
-Isto vai limpar completamente as `persistent_folders` e `sync_folders` dentro da VM.
-Atente para o fato que perderá todos os dados persistidos pelos bancos de dados de todos os sistemas já levantados.
-
-```sh
-azk vm ssh -- sudo rm -rf /mnt/sda1/azk/sync_folders
-azk vm ssh -- sudo rm -rf /mnt/sda1/azk/persistent_folders
-```
-
-#### Linux - limpar todos `persistent_folders` e `sync_folders` (cuidado!)
-
-Verifique o tamnho ocupado em disco:
-
-```sh
-sudo du -sh ~/.azk/data/sync_folders
-sudo du -sh ~/.azk/data/persistent_folders
-```
-
-Isto vai limpar completamente as `persistent_folders` e `sync_folders`.
-Atente para o fato que perderá todos os dados persistidos pelos bancos de dados de todos os sistemas já levantados.
-
-```sh
-sudo rm -rf ~/.azk/data/sync_folders
-sudo rm -rf ~/.azk/data/persistent_folders
-```
+Você pode checar [esta seção](README.html#como-posso-limpar-os-dados-persistidos-de-um-projeto-especfico) sobre como limpar dos dados persistidos e ter o seu sistema de volta ao estado inicial.
 
 #### Dockerfile
 
-Verifique como foi montado o Dockerfile que esta usando. Pode existir, por exemplo, uma varíavel de ambiente que não foi devidamente configurada.
+Verifique como foi montado o `Dockerfile` que está usando. Pode existir, por exemplo, uma variável de ambiente que não foi devidamente configurada.
 
 #### Azkfile.js
 
 Verifique as versão anteriores do seu `Azkfile.js`. Mudou algo? Antes funcionava?
 Veja os exemplos pelo site http://images.azk.io/. Leia atentamente a documentação do azk: [Azkfile.js](../azkfilejs/README.html).
-
-
-Caso não esteja conseguindo levantar o seu `Azkfile.js` você sempre pode contar com nossa ajuda pelo https://gitter.im/azukiapp/azk/pt.
 
 -------------------------
 
@@ -216,7 +162,7 @@ Nós recomendamos fortemente e leitura da [seção sobre `mounts`](/pt-BR/refere
 
 #### Não há Internet disponível / Eu não estou conectado a nenhuma rede. O `azk` é iniciado, mas o navegador mostra que eu estou offline. Como faço para corrigir isso?
 
-Este problema ocorre apenas no Sistema Operacional Mac OS X. Em SOs baseados em Linux, o `azk` deve funcionar tanto com Internet disponível como indisponível.
+Este problema ocorre apenas no Sistema Operacional Mac OS X. Em SOs baseados em Linux, o `azk` deve funcionar independente da disponibilidade de Internet.
 
 Uma vez que não há Internet disponível, a resolução de DNS falha, incluindo domínios `azk`. Para superar isso, você pode definir domínios `azk` em seu arquivo `/etc/hosts`.
 
@@ -226,9 +172,9 @@ Assumindo que o seu domínio de aplicativo é `demoazk.dev.azk.io` e seu IP `azk
 $ echo "192.168.51.4 demoazk.dev.azk.io #azk" | sudo tee -a /etc/hosts
 ```
 
-Você deve adicionar uma entrada para cada aplicativo que você está executando com o `azk`: `azkdemo.dev.azk.io`, `blog.dev.azk.io`, `myapp.dev.azk.io` e `*.dev.azk.io`
+Você deve adicionar uma entrada para cada aplicativo que você está executando com o `azk`: `demoazk.dev.azk.io`, `blog.dev.azk.io`, `myapp.dev.azk.io` e `*.dev.azk.io`
 
-Não se esqueça de remover estas linhas depois que você estiver com acesso a Internet estabilizado. Se você usou o comando anterior, basta executar:
+Não se esqueça de remover essas linhas depois que você estiver com acesso a Internet estabilizado. Se você usou o comando anterior, basta executar:
 
 ```bash
 $ sed '/^.*#azk$/ { N; d; }' /etc/hosts
@@ -238,91 +184,128 @@ $ sed '/^.*#azk$/ { N; d; }' /etc/hosts
 
 ### Como posso limpar os dados do Docker?
 
-#### Containers parados
+#### Matando os containers em execução
 
-Para apagar os containers parados, antigos:
+Para matar todos os containers em execução (será necessário reiniciar o `azk agent`):
 
 ```bash
-adocker rm -f $(adocker ps -f status=exited -q | tr '\r\n' ' ')
+$ adocker kill $(adocker ps -q | tr '\r\n' ' ')
 ```
 
-#### Imagens do Docker
+#### Removendo os containers parados
 
-Remover imagens usando filtros. Neste caso o filtro é 'azkbuild':
+Para remover os containers parados:
 
 ```bash
-adocker rmi $(adocker images | grep "azkbuild" | awk '{print $3}' | tr '\r\n' ' ')
+$ adocker rm -f $(adocker ps -f status=exited -q | tr '\r\n' ' ')
 ```
 
-#### Imagens do Docker sem tag
+#### Removendo as imagens do Docker
 
-Remover todas imagens sem tag:
+Para remover imagens do Docker usando filtros (neste caso o filtro é 'azkbuild'):
 
 ```bash
-adocker rmi $(adocker images -q -f dangling=true | tr '\r\n' ' ')
+$ adocker rmi $(adocker images | grep "azkbuild" | awk '{print $3}' | tr '\r\n' ' ')
 ```
 
-#### Imagens do Docker - Limpeza geral (cuidado!)
+#### Removendo as imagens do Docker sem tag
 
-O comando abaixo apaga todas as imagens baixadas do Docker Hub.
-O problema é que na próxima execução você terá que baixar
-todas imagens que for usar novamente.
+Para remover todas imagens sem tag:
 
 ```bash
-adocker rmi $(adocker images -q | tr '\r\n' ' ')
+$ adocker rmi $(adocker images -q -f dangling=true | tr '\r\n' ' ')
 ```
 
-#### Containers em execução
+#### Removendo todas as imagens do Docker (tenha cuidado!)
 
-Para matar todos os containers em execução (será necessário reiniciar o agent):
+O comando abaixo remove todas as imagens baixadas do Docker Hub.
+O problema é que, na próxima execução, você terá que baixar novamente
+todas imagens que for usar.
 
 ```bash
-adocker kill $(adocker ps -q | tr '\r\n' ' '); \
+$ adocker rmi $(adocker images -q | tr '\r\n' ' ')
 ```
 
 #### Outras dicas sobre Docker
 
-O link a seguir possui várias dicas para o dia a dia com Docker. Só não se esqueça de executar os comandos como `adocker`, principalmente se estiver usando máquina virtual.
+O link a seguir possui várias dicas para o dia a dia com Docker. Só não se esqueça de executar os comandos como `adocker`, principalmente se estiver usando uma Máquina Virtual.
 
 - https://github.com/wsargent/docker-cheat-sheet#tips
 
-
 ----------------
 
-### Como posso limpar os dados persistidos do azk?
+### Como posso limpar os dados persistidos de um projeto específico?
 
-#### VM (Mac ou Linux + VM): `persistent_folders` e `sync_folders` (cuidado!)
+**CUIDADO:** Isso irá limpar as `persistent_folders` e as `sync_folders` do projeto. Isso significa que todos os dados persistidos desse projeto (incluindo os banco de dados) serão perdidos para sempre. **Continue com extremo cuidado.**
 
-Você ainda pode apagar seus persistent_folder e sync_folder.
-Verifique o tamnho ocupado em disco, dentro da VM:
+1) Verifique as `persistent_folders` e as `sync_folders` do sistema:
+
+```sh
+$ azk info | grep -P "(persistent|sync)_folders"
+```
+
+2) Remova as `persistent_folders` e as `sync_folders` do sistema:
+
+#### Mac OS X
+
+```sh
+$ azk vm ssh -- sudo rm -rf ".../persistent_folders/0x0x0x0x0x0x"
+$ azk vm ssh -- sudo rm -rf ".../sync_folders/0x0x0x0x0x0x"
+# ...
+```
+
+#### Linux
+
+```sh
+$ sudo rm -rf ".../persistent_folders/0x0x0x0x0x0x"
+$ sudo rm -rf ".../sync_folders/0x0x0x0x0x0x"
+# ...
+```
+
+3) Reinicie os sistemas com a flag de reprovisionamento (`-R`):
+
+```sh
+$ azk stop
+$ azk start -R
+```
+
+----------------------
+
+### Como posso limpar os dados persistidos de todos os projetos?
+
+**CUIDADO:** Isso irá limpar todas as `persistent_folders` e `sync_folders`. Isso significa que todos os dados persistidos (incluindo os banco de dados) de **todos os projetos** serão perdidos para sempre. **Continue com extremo cuidado.**
+
+
+#### Mac OS X
+
+Você pode apagar todas as `persistent_folders` e `sync_folders` de dentro da Máquina Virtual.
+Verifique o tamanho ocupado em disco, dentro da VM:
 
 ```sh
 azk vm ssh -- du -sh /mnt/sda1/azk/sync_folders
 azk vm ssh -- du -sh /mnt/sda1/azk/persistent_folders
 ```
 
-Isto vai limpar completamente as `persistent_folders` e `sync_folders`.
-Atente para o fato que **perderá todos os dados persistidos pelos bancos de dados** de todos os sistemas já levantados. Será ainda necessário que todos os sistemas sejam executados com a opção `--reprovision`. Só use esta opção em último caso.
+Para remover **todas** as `persistent_folders` e `sync_folders`:
 
 ```sh
-azk vm ssh -- sudo rm -rf /mnt/sda1/azk/sync_folders
 azk vm ssh -- sudo rm -rf /mnt/sda1/azk/persistent_folders
+azk vm ssh -- sudo rm -rf /mnt/sda1/azk/sync_folders
 ```
 
-#### Linux: `persistent_folders` e `sync_folders` (cuidado!)
+#### Linux
 
-Você ainda pode apagar seus `persistent_folder` e `sync_folder`.
-Primeiro vamos verificar o quanto estes diretórios estão ocupando em disco.
+Você pode apagar as `persistent_folders` e `sync_folders`.
+Verifique o tamanho ocupado em disco:
 
 ```sh
 sudo du -hs ~/.azk/data/persistent_folders
 sudo du -hs ~/.azk/data/sync_folders
 ```
 
-Isto vai limpar completamente as `persistent_folders` e `sync_folders`.
-Atente para o fato que **perderá todos os dados persistidos pelos bancos de dados** de todos os sistemas já levantados. Será ainda necessário que todos os sistemas sejam executados com a opção `--reprovision`. Só use esta opção em último caso.
+Para remover **todas** as `persistent_folders` e `sync_folders:
 
 ```sh
-sudo rm -rf ~/.azk/data/sync_folders
 sudo rm -rf ~/.azk/data/persistent_folders
+sudo rm -rf ~/.azk/data/sync_folders
 ```


### PR DESCRIPTION
This PR is intended to improve `Troubleshooting` section in azk documentation:
- [x] Rewrite the whole troubleshooting section (fix typos and make it clearer);
- [x] Add new section: `[sync] fail Error: watch ENOSPC`;
- [x] Add new section: Bind host to 0.0.0.0 IP when running a server from inside a container;