### PR TITLE
[Docker] Fixing how azk handles `.dockerignore` file on Dockerfile build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Bug
   * [Manifest] Fixing wait not support `false` value;
+  * [Docker] Fixing support to comments and blank lines in `.dockerignore` file during Dockerfile build;
 
 ## v0.14.6 - (2015-08-20)
 

--- a/spec/fixtures/build/.dockerignore
+++ b/spec/fixtures/build/.dockerignore
@@ -1,3 +1,6 @@
 Dockerfile
 Dockerfile*
+# .dockerignore should support empty lines...
+
+# ... and comments!
 .dockerignore

--- a/src/docker/build.js
+++ b/src/docker/build.js
@@ -65,8 +65,15 @@ export function build(docker, options) {
     var exists_ignore = yield fsAsync.exists(ignore);
     if (exists_ignore) {
       var ignore_content = yield fsAsync.readFile(ignore);
-      ignore_content = ignore_content.toString().trim().split('\n');
-      src = src.concat(ignore_content.map((entry) => `!${entry}`));
+      ignore_content = ignore_content.toString()
+        .trim()
+        .split('\n')
+        .map((entry) => {
+          entry = entry.trim();
+          return (_.isEmpty(entry) || entry.startsWith('#')) ? null : `!${entry}`;
+        })
+        .filter((entry) => entry);
+      src = _.uniq(src.concat(ignore_content));
     }
 
     // Add files


### PR DESCRIPTION
This PR closes #520 .

Before using  `.dockerfile` content, azk now parses this content and remove empty lines and comments (lines started by `#`).

Also, the `.dockerignore` fixture was improved to cover those cases.