### PR TITLE
[Manifest] Improving support to env vars on http domains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Deprecations
   * [Manifest] `docker_extra.start` and `docker_extra.create` is no longer supported, now you must use the container creation options directly, check in: https://docs.docker.com/reference/api/docker_remote_api_v1.20/#create-a-container;
 
+* Enhancements
+  * [Manifest] Improving how azk handles multiple `http.domains` set by env vars;
+
 ## v0.14.6 - (2015-08-20)
 
 * Bug

--- a/shared/templates/Azkfile.mustache.js
+++ b/shared/templates/Azkfile.mustache.js
@@ -70,7 +70,7 @@ systems({
       domains: [ "#{system.name}.#{azk.default_domain}" ]
       {{~else}}
       domains: [
-        {{~#each http}}
+        {{~#each http.domains}}
         {{&json this}},{{/each}}
       ],
       {{~/formatDomains}}

--- a/spec/generator/index_spec.js
+++ b/spec/generator/index_spec.js
@@ -149,10 +149,10 @@ describe('Azk generator tool index:', function() {
 
       it('should generate a multiple hosts', function() {
         var data = _.clone(default_data);
-        data.systems.front.http = [
+        data.systems.front.http = { domains: [
           '#{system.name}.#{azk.default_domain}',
           'custom.#{azk.default_domain}',
-        ];
+        ] };
 
         return generate_manifest(dir, data).then(function(manifest) {
           var system     = manifest.systemDefault;

--- a/spec/manifest/index_spec.js
+++ b/spec/manifest/index_spec.js
@@ -65,12 +65,8 @@ describe("Azk manifest class, main set", function() {
       it("should return all systems", function() {
         var systems = manifest.getSystemsByName();
         h.expect(systems).to.length(_.keys(manifest.systems).length);
-        h.expect(systems).to.has.deep.property("[0]").to.equal(
-          manifest.system("expand-test")
-        );
-        h.expect(systems).to.has.deep.property("[11]").to.equal(
-          manifest.system("example")
-        );
+        h.expect(systems[0]).to.equal(manifest.system("expand-test"));
+        h.expect(systems[systems.length-1]).to.equal(manifest.system("example"));
       });
 
       it("should raise error if get a not set system", function() {
@@ -98,7 +94,8 @@ describe("Azk manifest class, main set", function() {
     describe("with a tree of the requireds systems", function() {
       it("should return a systems in required order", function() {
         var systems = [ "expand-test", "mount-test", "ports-disable", "ports-static", "ports-test",
-                        "test-image-opts", "empty", "db", "api", "example-sync", "example-extends", "example"];
+                        "test-image-opts", "empty", "db", "api", "example-http-domain", "example-sync",
+                        "example-extends", "example"];
 
         h.expect(manifest.systemsInOrder()).to.eql(systems);
       });

--- a/spec/spec_helpers/mock_manifest.js
+++ b/spec/spec_helpers/mock_manifest.js
@@ -171,6 +171,16 @@ export function extend(h) {
           extends: "example",
           mounts: _.cloneDeep(mounts_with_sync),
         },
+        'example-http-domain': {
+          extends: "example",
+          http: {
+            domains: [
+              "#{process.env.HOST_DOMAIN}",
+              "#{process.env.HOST_IP}",
+              "#{system.name}.#{azk.default_domain}",
+            ]
+          },
+        },
       },
       defaultSystem: 'api',
       bins: [

--- a/spec/system/index_spec.js
+++ b/spec/system/index_spec.js
@@ -153,6 +153,40 @@ describe("Azk system class, main set", function() {
       h.expect(names).to.eql(["db", "api"]);
     });
 
+    describe("with custom http domains", function() {
+      it("should return the correct default domain", function() {
+        var system = manifest.system("example-http-domain");
+        h.expect(system.hostname).to.eql(`${system.name}.${config('agent:balancer:host')}`);
+      });
+
+      it("should return the correct custom ip", function() {
+        var custom_ip = '192.168.0.1';
+        process.env.HOST_IP = custom_ip;
+
+        var data = { };
+        return h.mockManifest(data).then((mf) => {
+          manifest = mf;
+          system   = manifest.system('example-http-domain');
+          h.expect(system.hostname).to.eql(custom_ip);
+        });
+      });
+
+      it("should return the correct custom ip", function() {
+        var custom_ip           = '192.168.0.1';
+        process.env.HOST_IP     = custom_ip;
+        var custom_domain       = 'my.domain.com';
+        process.env.HOST_DOMAIN = custom_domain;
+
+        var data = { };
+        return h.mockManifest(data).then((mf) => {
+          manifest = mf;
+          system   = manifest.system('example-http-domain');
+          h.expect(system.hostname).to.eql(custom_domain);
+        });
+      });
+
+    });
+
     it("should be marked as supporting provisioned", function() {
       h.expect(system).to.have.property("provisioned").and.null;
 

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -172,9 +172,8 @@ export class System {
       hostnames = [this.http.hostname];
     }
 
-    hostnames = _.map(hostnames, function(hostname) {
-      return hostname.toLowerCase();
-    });
+    hostnames = _.filter(hostnames, (hostname) => { return ! _.isEmpty(hostname) })
+      .map((hostname) => hostname.toLowerCase());
 
     return hostnames;
   }


### PR DESCRIPTION
This PR intends to improve support to env vars on http domains in the Manifest file.

The current behavior is to use the first domain in the `http.domains` array as the system hostname.
However, when using env vars as domains (useful for deployment, as instance), it may break.

The new behavior, removes empty values (in case those env vars are not set) and the use the first one. This way, it's possible to do the following:

*Azkfile.js*
```javascript
systems({
  example: {
  // ...
    http: {
      domains: [
        "#{env.HOST_DOMAIN}",
        "#{env.HOST_IP}",
        "#{system.name}.#{azk.default_domain}",
      ]
    }
  }
});
```

```
$ HOST_DOMAIN= HOST_IP= azk status
┌───┬─────────┬───────────┬────────────────────┬─────────────────┬─────────────┐
│   │ System  │ Instances │ Hostname/url       │ Instances-Ports │ Provisioned │
├───┼─────────┼───────────┼────────────────────┼─────────────────┼─────────────┤
│ ↓ │ example │ 0         │ example.dev.azk.io │ -               │ -           │
└───┴─────────┴───────────┴────────────────────┴─────────────────┴─────────────┘
```
```
$ HOST_DOMAIN= HOST_IP=192.168.0.1 azk status
┌───┬─────────┬───────────┬────────────────────┬─────────────────┬─────────────┐
│   │ System  │ Instances │ Hostname/url       │ Instances-Ports │ Provisioned │
├───┼─────────┼───────────┼────────────────────┼─────────────────┼─────────────┤
│ ↓ │ example │ 0         │ 192.168.0.1        │ -               │ -           │
└───┴─────────┴───────────┴────────────────────┴─────────────────┴─────────────┘
```
```
$ HOST_DOMAIN=my.domain.com HOST_IP=192.168.0.1 azk status
┌───┬─────────┬───────────┬────────────────────┬─────────────────┬─────────────┐
│   │ System  │ Instances │ Hostname/url       │ Instances-Ports │ Provisioned │
├───┼─────────┼───────────┼────────────────────┼─────────────────┼─────────────┤
│ ↓ │ example │ 0         │ my.domain.com      │ -               │ -           │
└───┴─────────┴───────────┴────────────────────┴─────────────────┴─────────────┘
```