### PR TITLE
[Manifest] Adding `env` as a manifest system template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Deprecations
   * [Manifest] `docker_extra.start` and `docker_extra.create` is no longer supported, now you must use the container creation options directly, check in: https://docs.docker.com/reference/api/docker_remote_api_v1.20/#create-a-container;
 
+* Enhancements
+  * [Manifest] Adding `env` as a manifest system template;
+
 ## v0.14.6 - (2015-08-20)
 
 * Bug

--- a/spec/spec_helpers/mock_manifest.js
+++ b/spec/spec_helpers/mock_manifest.js
@@ -165,6 +165,8 @@ export function extend(h) {
             "azk.default_dns: #{azk.default_dns}",
             "azk.balancer_port: #{azk.balancer_port}",
             "azk.balancer_ip: #{azk.balancer_ip}",
+            "env.FOO: #{env.FOO}",
+            "env.BAR: #{env.BAR}",
           ],
         },
         'example-sync': {

--- a/spec/system/index_spec.js
+++ b/spec/system/index_spec.js
@@ -68,17 +68,27 @@ describe("Azk system class, main set", function() {
 
     describe("in a system with volumes to be mounted", function() {
       it("should expand options with template", function() {
-        var system    = manifest.system('expand-test');
-        var provision = system.options.provision;
-        h.expect(provision).to.include(`system.name: ${system.name}`);
-        h.expect(provision).to.include(`manifest.dir: ${manifest.manifestDirName}`);
-        h.expect(provision).to.include(`manifest.path: ${manifest.manifestPath}`);
-        h.expect(provision).to.include(`manifest.project_name: ${manifest.manifestDirName}`);
-        h.expect(provision).to.include(`azk.version: ${version}`);
-        h.expect(provision).to.include(`azk.default_domain: ${config('agent:balancer:host')}`);
-        h.expect(provision).to.include(`azk.default_dns: ${net.nameServers().toString()}`);
-        h.expect(provision).to.include(`azk.balancer_port: ${config('agent:balancer:port').toString()}`);
-        h.expect(provision).to.include(`azk.balancer_ip: ${config('agent:balancer:ip')}`);
+        process.env.FOO = 'foo';
+        var data = { };
+        return h.mockManifest(data).then((mf) => {
+          var manifest = mf;
+          var system   = manifest.system('expand-test');
+
+          var provision = system.options.provision;
+          h.expect(provision).to.include(`system.name: ${system.name}`);
+          h.expect(provision).to.include(`manifest.dir: ${manifest.manifestDirName}`);
+          h.expect(provision).to.include(`manifest.path: ${manifest.manifestPath}`);
+          h.expect(provision).to.include(`manifest.project_name: ${manifest.manifestDirName}`);
+          h.expect(provision).to.include(`azk.version: ${version}`);
+          h.expect(provision).to.include(`azk.default_domain: ${config('agent:balancer:host')}`);
+          h.expect(provision).to.include(`azk.default_dns: ${net.nameServers().toString()}`);
+          h.expect(provision).to.include(`azk.balancer_port: ${config('agent:balancer:port').toString()}`);
+          h.expect(provision).to.include(`azk.balancer_ip: ${config('agent:balancer:ip')}`);
+          h.expect(provision).to.include(`env.FOO: ${process.env.FOO}`);
+          h.expect(provision).to.include(`env.BAR: `);
+        }).finally(() => {
+          process.env.FOO = undefined;
+        });
       });
 
       it("should return a mounts property", function() {

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -509,7 +509,8 @@ export class System {
         default_dns   : net.nameServers(),
         balancer_port : config('agent:balancer:port'),
         balancer_ip   : config('agent:balancer:ip'),
-      }
+      },
+      env: process.env,
     };
 
     var template = this._replace_keep_keys(JSON.stringify(options));


### PR DESCRIPTION
This PR adds `env` as a manifest system manifest templace, such as: `azk`, `manifest`, `system` etc.

With this template, one can refer to a env var inside the manifest file using:

```
#{env.FOO}
```

instead of

```
#{process.env.FOO}
```

It's cleaner and safer.