### PR TITLE
[Docker] If running inside vm, do not monitor Docker

### DIFF
--- a/src/agent/server.js
+++ b/src/agent/server.js
@@ -38,8 +38,10 @@ var Server = {
       // Load balancer
       yield this.installBalancer();
 
-      // acive docker monitor
-      this._activeDockerMonitor();
+      // active docker monitor
+      if (config('docker:monitor')) {
+        this._activeDockerMonitor();
+      }
 
       log.info_t("commands.agent.started");
       this.starting = false;

--- a/src/config.js
+++ b/src/config.js
@@ -87,6 +87,7 @@ var options = mergeConfig({
       socket          : envs('AZK_DOCKER_SOCKER', "/var/run/docker.sock"),
       host            : new Dynamic("docker:host"),
       namespace       : envs('AZK_NAMESPACE'),
+      monitor         : envs('AZK_DOCKER_MONITOR', os.platform() === 'linux'),
       api_version     : 'v' + envs('AZK_DOCKER_API_VERSION', '1.20'),
       repository      : 'azk',
       default_domain  : 'azk',


### PR DESCRIPTION
This PR closes #525.

Add `AZK_DOCKER_MONITOR` env var which defaults to true if running on linux.