### PR TITLE
Loose checking of docker version

### DIFF
--- a/src/agent/configure.js
+++ b/src/agent/configure.js
@@ -165,7 +165,7 @@ export class Configure extends UIProxy {
     return lazy.docker.version()
       .then((data) => {
         var currentDockerVersion = data.Version;
-        var validDockerVersion   = semver.gte(currentDockerVersion, minDockerVersion);
+        var validDockerVersion   = semver.gte(currentDockerVersion, minDockerVersion, true);
         if ( !validDockerVersion ) {
           throw new DependencyError('check_docker_version_error', {
             current_version: currentDockerVersion,


### PR DESCRIPTION
Helps with distributions that identify themselves in the package name say Fedora 22 docker version: `1.8.1.fc22`
Since `semver.gte()` can throw, it might be good idea to wrap it in try/catch block and either warn and continue or bail ourselves.