### PR TITLE
[cli] Adding `azk deploy` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## dev
 
+* Enhancements
+  * [Cli] Adding `deploy` command to cli;
+
 ## v0.15.0 - (2015-09-15)
 
 * Bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Enhancements
   * [Cli] Adding `deploy` command to cli;
+  * [Kernel] Changing system to get `command` from image, but respect this priority for `azk shell`: shell option (`--shell`) > Azkfile.js > docker image;
 
 ## v0.15.0 - (2015-09-15)
 
@@ -332,7 +333,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Manifest] Adding support `docker_extra`
   * [Manifest] Adding support to 'disable' value in ports.
   * [Kernel] Now `azk` supports Linux \o/
-  * [Kenrel] You can now use the AZK to test and develop the AZK for Linux (see Azkfile.js).
+  * [Kernel] You can now use the AZK to test and develop the AZK for Linux (see Azkfile.js).
   * [Cmds] Now supports the `ssh escape sequence` in `shell` command.
 
 * Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Enhancements
   * [Cli] Adding `deploy` command to cli;
-  * [Kernel] Changing system to get `command` from image, but respect this priority for `azk shell`: shell option (`--shell`) > Azkfile.js > docker image;
+  * [Kernel] Changing system to get `command` from image, but respect this priority for `azk shell`: shell option (`--shell`) > Azkfile.js > docker image #534;
 
 ## v0.15.0 - (2015-09-15)
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -3994,18 +3994,18 @@
       }
     },
     "cli-router": {
-      "version": "0.3.6",
-      "from": "https://registry.npmjs.org/cli-router/-/cli-router-0.3.6.tgz",
-      "resolved": "https://registry.npmjs.org/cli-router/-/cli-router-0.3.6.tgz",
+      "version": "0.3.7",
+      "from": "cli-router@0.3.7",
+      "resolved": "https://registry.npmjs.org/cli-router/-/cli-router-0.3.7.tgz",
       "dependencies": {
         "docopt": {
           "version": "0.6.2",
-          "from": "git+https://github.com/gullitmiranda/docopt.coffee.git#45ed4031549a7b083cca3a9e6af149003e03878e",
+          "from": "git+https://github.com/gullitmiranda/docopt.coffee.git#stable",
           "resolved": "git+https://github.com/gullitmiranda/docopt.coffee.git#45ed4031549a7b083cca3a9e6af149003e03878e"
         },
         "ramda": {
           "version": "0.14.0",
-          "from": "https://registry.npmjs.org/ramda/-/ramda-0.14.0.tgz",
+          "from": "ramda@>=0.14.0 <0.15.0",
           "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.14.0.tgz"
         }
       }
@@ -6150,142 +6150,142 @@
     },
     "gulp-awspublish": {
       "version": "3.0.0",
-      "from": "gulp-awspublish@3.0.0",
+      "from": "https://registry.npmjs.org/gulp-awspublish/-/gulp-awspublish-3.0.0.tgz",
       "resolved": "https://registry.npmjs.org/gulp-awspublish/-/gulp-awspublish-3.0.0.tgz",
       "dependencies": {
         "aws-sdk": {
           "version": "2.2.0",
-          "from": "aws-sdk@>=2.1.16 <3.0.0",
+          "from": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.2.0.tgz",
           "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.2.0.tgz",
           "dependencies": {
             "sax": {
               "version": "0.5.3",
-              "from": "sax@0.5.3",
+              "from": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz",
               "resolved": "https://registry.npmjs.org/sax/-/sax-0.5.3.tgz"
             },
             "xml2js": {
               "version": "0.2.8",
-              "from": "xml2js@0.2.8",
+              "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz",
               "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.2.8.tgz"
             },
             "xmlbuilder": {
               "version": "0.4.2",
-              "from": "xmlbuilder@0.4.2",
+              "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz",
               "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.2.tgz"
             }
           }
         },
         "clone": {
           "version": "0.2.0",
-          "from": "clone@>=0.0.0 <1.0.0",
+          "from": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz",
           "resolved": "https://registry.npmjs.org/clone/-/clone-0.2.0.tgz"
         },
         "gulp-util": {
           "version": "2.2.20",
-          "from": "gulp-util@>=2.0.0 <3.0.0",
+          "from": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "resolved": "https://registry.npmjs.org/gulp-util/-/gulp-util-2.2.20.tgz",
           "dependencies": {
             "chalk": {
               "version": "0.5.1",
-              "from": "chalk@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-0.5.1.tgz",
               "dependencies": {
                 "ansi-styles": {
                   "version": "1.1.0",
-                  "from": "ansi-styles@>=1.1.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-1.1.0.tgz"
                 },
                 "escape-string-regexp": {
                   "version": "1.0.3",
-                  "from": "escape-string-regexp@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.3.tgz"
                 },
                 "has-ansi": {
                   "version": "0.1.0",
-                  "from": "has-ansi@>=0.1.0 <0.2.0",
+                  "from": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-0.1.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "strip-ansi": {
                   "version": "0.3.0",
-                  "from": "strip-ansi@>=0.3.0 <0.4.0",
+                  "from": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-0.3.0.tgz",
                   "dependencies": {
                     "ansi-regex": {
                       "version": "0.2.1",
-                      "from": "ansi-regex@>=0.2.1 <0.3.0",
+                      "from": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz",
                       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-0.2.1.tgz"
                     }
                   }
                 },
                 "supports-color": {
                   "version": "0.2.0",
-                  "from": "supports-color@>=0.2.0 <0.3.0",
+                  "from": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz",
                   "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-0.2.0.tgz"
                 }
               }
             },
             "dateformat": {
               "version": "1.0.11",
-              "from": "dateformat@>=1.0.7-1.2.3 <2.0.0",
+              "from": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
               "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.11.tgz",
               "dependencies": {
                 "get-stdin": {
                   "version": "5.0.0",
-                  "from": "get-stdin@*",
+                  "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-5.0.0.tgz"
                 },
                 "meow": {
                   "version": "3.3.0",
-                  "from": "meow@*",
+                  "from": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "resolved": "https://registry.npmjs.org/meow/-/meow-3.3.0.tgz",
                   "dependencies": {
                     "camelcase-keys": {
                       "version": "1.0.0",
-                      "from": "camelcase-keys@>=1.0.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-1.0.0.tgz",
                       "dependencies": {
                         "camelcase": {
                           "version": "1.2.1",
-                          "from": "camelcase@>=1.0.1 <2.0.0",
+                          "from": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
                           "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz"
                         },
                         "map-obj": {
                           "version": "1.0.1",
-                          "from": "map-obj@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
                         }
                       }
                     },
                     "indent-string": {
                       "version": "1.2.2",
-                      "from": "indent-string@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-1.2.2.tgz",
                       "dependencies": {
                         "get-stdin": {
                           "version": "4.0.1",
-                          "from": "get-stdin@>=4.0.1 <5.0.0",
+                          "from": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
                         },
                         "repeating": {
                           "version": "1.1.3",
-                          "from": "repeating@>=1.1.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-1.1.3.tgz",
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.1",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.1.tgz",
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.0",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
+                                  "from": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz",
                                   "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.0.tgz"
                                 }
                               }
@@ -6296,12 +6296,12 @@
                     },
                     "minimist": {
                       "version": "1.2.0",
-                      "from": "minimist@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
                     },
                     "object-assign": {
                       "version": "3.0.0",
-                      "from": "object-assign@>=3.0.0 <4.0.0",
+                      "from": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz"
                     }
                   }
@@ -6310,51 +6310,51 @@
             },
             "lodash._reinterpolate": {
               "version": "2.4.1",
-              "from": "lodash._reinterpolate@>=2.4.1 <3.0.0",
+              "from": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-2.4.1.tgz"
             },
             "lodash.template": {
               "version": "2.4.1",
-              "from": "lodash.template@>=2.4.1 <3.0.0",
+              "from": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
               "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-2.4.1.tgz",
               "dependencies": {
                 "lodash.defaults": {
                   "version": "2.4.1",
-                  "from": "lodash.defaults@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.defaults/-/lodash.defaults-2.4.1.tgz",
                   "dependencies": {
                     "lodash._objecttypes": {
                       "version": "2.4.1",
-                      "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                     }
                   }
                 },
                 "lodash.escape": {
                   "version": "2.4.1",
-                  "from": "lodash.escape@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.escape/-/lodash.escape-2.4.1.tgz",
                   "dependencies": {
                     "lodash._escapehtmlchar": {
                       "version": "2.4.1",
-                      "from": "lodash._escapehtmlchar@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._escapehtmlchar/-/lodash._escapehtmlchar-2.4.1.tgz",
                       "dependencies": {
                         "lodash._htmlescapes": {
                           "version": "2.4.1",
-                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash._reunescapedhtml": {
                       "version": "2.4.1",
-                      "from": "lodash._reunescapedhtml@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._reunescapedhtml/-/lodash._reunescapedhtml-2.4.1.tgz",
                       "dependencies": {
                         "lodash._htmlescapes": {
                           "version": "2.4.1",
-                          "from": "lodash._htmlescapes@>=2.4.1 <2.5.0",
+                          "from": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._htmlescapes/-/lodash._htmlescapes-2.4.1.tgz"
                         }
                       }
@@ -6363,39 +6363,39 @@
                 },
                 "lodash._escapestringchar": {
                   "version": "2.4.1",
-                  "from": "lodash._escapestringchar@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash._escapestringchar/-/lodash._escapestringchar-2.4.1.tgz"
                 },
                 "lodash.keys": {
                   "version": "2.4.1",
-                  "from": "lodash.keys@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.keys/-/lodash.keys-2.4.1.tgz",
                   "dependencies": {
                     "lodash._isnative": {
                       "version": "2.4.1",
-                      "from": "lodash._isnative@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._isnative/-/lodash._isnative-2.4.1.tgz"
                     },
                     "lodash.isobject": {
                       "version": "2.4.1",
-                      "from": "lodash.isobject@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-2.4.1.tgz",
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "2.4.1",
-                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                         }
                       }
                     },
                     "lodash._shimkeys": {
                       "version": "2.4.1",
-                      "from": "lodash._shimkeys@>=2.4.1 <2.5.0",
+                      "from": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
                       "resolved": "https://registry.npmjs.org/lodash._shimkeys/-/lodash._shimkeys-2.4.1.tgz",
                       "dependencies": {
                         "lodash._objecttypes": {
                           "version": "2.4.1",
-                          "from": "lodash._objecttypes@>=2.4.1 <2.5.0",
+                          "from": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash._objecttypes/-/lodash._objecttypes-2.4.1.tgz"
                         }
                       }
@@ -6404,54 +6404,54 @@
                 },
                 "lodash.templatesettings": {
                   "version": "2.4.1",
-                  "from": "lodash.templatesettings@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-2.4.1.tgz"
                 },
                 "lodash.values": {
                   "version": "2.4.1",
-                  "from": "lodash.values@>=2.4.1 <2.5.0",
+                  "from": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz",
                   "resolved": "https://registry.npmjs.org/lodash.values/-/lodash.values-2.4.1.tgz"
                 }
               }
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "multipipe": {
               "version": "0.1.2",
-              "from": "multipipe@>=0.1.0 <0.2.0",
+              "from": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
               "resolved": "https://registry.npmjs.org/multipipe/-/multipipe-0.1.2.tgz",
               "dependencies": {
                 "duplexer2": {
                   "version": "0.0.2",
-                  "from": "duplexer2@0.0.2",
+                  "from": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.0.2.tgz",
                   "dependencies": {
                     "readable-stream": {
                       "version": "1.1.13",
-                      "from": "readable-stream@>=1.1.9 <1.2.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         }
                       }
@@ -6462,51 +6462,51 @@
             },
             "through2": {
               "version": "0.5.1",
-              "from": "through2@>=0.5.0 <0.6.0",
+              "from": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "resolved": "https://registry.npmjs.org/through2/-/through2-0.5.1.tgz",
               "dependencies": {
                 "readable-stream": {
                   "version": "1.0.33",
-                  "from": "readable-stream@>=1.0.17 <1.1.0",
+                  "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
                   "dependencies": {
                     "core-util-is": {
                       "version": "1.0.1",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
+                      "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                     },
                     "isarray": {
                       "version": "0.0.1",
-                      "from": "isarray@0.0.1",
+                      "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                     },
                     "string_decoder": {
                       "version": "0.10.31",
-                      "from": "string_decoder@>=0.10.0 <0.11.0",
+                      "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                     },
                     "inherits": {
                       "version": "2.0.1",
-                      "from": "inherits@>=2.0.1 <2.1.0",
+                      "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                     }
                   }
                 },
                 "xtend": {
                   "version": "3.0.0",
-                  "from": "xtend@>=3.0.0 <3.1.0",
+                  "from": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/xtend/-/xtend-3.0.0.tgz"
                 }
               }
             },
             "vinyl": {
               "version": "0.2.3",
-              "from": "vinyl@>=0.2.1 <0.3.0",
+              "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
               "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.2.3.tgz",
               "dependencies": {
                 "clone-stats": {
                   "version": "0.0.1",
-                  "from": "clone-stats@>=0.0.1 <0.1.0",
+                  "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
                 }
               }
@@ -6515,51 +6515,51 @@
         },
         "mime": {
           "version": "1.3.4",
-          "from": "mime@>=1.0.0 <2.0.0",
+          "from": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
           "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz"
         },
         "pad-component": {
           "version": "0.0.1",
-          "from": "pad-component@>=0.0.0 <1.0.0",
+          "from": "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz",
           "resolved": "https://registry.npmjs.org/pad-component/-/pad-component-0.0.1.tgz"
         },
         "pascal-case": {
           "version": "1.1.1",
-          "from": "pascal-case@>=1.1.0 <2.0.0",
+          "from": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz",
           "resolved": "https://registry.npmjs.org/pascal-case/-/pascal-case-1.1.1.tgz",
           "dependencies": {
             "camel-case": {
               "version": "1.1.2",
-              "from": "camel-case@>=1.1.1 <2.0.0",
+              "from": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz",
               "resolved": "https://registry.npmjs.org/camel-case/-/camel-case-1.1.2.tgz",
               "dependencies": {
                 "sentence-case": {
                   "version": "1.1.2",
-                  "from": "sentence-case@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/sentence-case/-/sentence-case-1.1.2.tgz",
                   "dependencies": {
                     "lower-case": {
                       "version": "1.1.2",
-                      "from": "lower-case@>=1.1.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz",
                       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-1.1.2.tgz"
                     }
                   }
                 },
                 "upper-case": {
                   "version": "1.1.2",
-                  "from": "upper-case@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
                 }
               }
             },
             "upper-case-first": {
               "version": "1.1.1",
-              "from": "upper-case-first@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz",
               "resolved": "https://registry.npmjs.org/upper-case-first/-/upper-case-first-1.1.1.tgz",
               "dependencies": {
                 "upper-case": {
                   "version": "1.1.2",
-                  "from": "upper-case@>=1.1.1 <2.0.0",
+                  "from": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz",
                   "resolved": "https://registry.npmjs.org/upper-case/-/upper-case-1.1.2.tgz"
                 }
               }
@@ -6568,105 +6568,105 @@
         },
         "through2": {
           "version": "0.6.5",
-          "from": "through2@>=0.0.0 <1.0.0",
+          "from": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
           "dependencies": {
             "readable-stream": {
               "version": "1.0.33",
-              "from": "readable-stream@>=1.0.33-1 <1.1.0-0",
+              "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.33.tgz",
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.1",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
+                  "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
+                  "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
+                  "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                   "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                 },
                 "inherits": {
                   "version": "2.0.1",
-                  "from": "inherits@>=2.0.1 <2.1.0",
+                  "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                 }
               }
             },
             "xtend": {
               "version": "4.0.0",
-              "from": "xtend@>=4.0.0 <4.1.0-0",
+              "from": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz",
               "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.0.tgz"
             }
           }
         },
         "vinyl": {
           "version": "0.4.6",
-          "from": "vinyl@>=0.4.6 <0.5.0",
+          "from": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "resolved": "https://registry.npmjs.org/vinyl/-/vinyl-0.4.6.tgz",
           "dependencies": {
             "clone-stats": {
               "version": "0.0.1",
-              "from": "clone-stats@>=0.0.1 <0.0.2",
+              "from": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-0.0.1.tgz"
             }
           }
         },
         "xml-json": {
           "version": "2.0.2",
-          "from": "xml-json@>=2.0.2 <3.0.0",
+          "from": "https://registry.npmjs.org/xml-json/-/xml-json-2.0.2.tgz",
           "resolved": "https://registry.npmjs.org/xml-json/-/xml-json-2.0.2.tgz",
           "dependencies": {
             "extend": {
               "version": "1.3.0",
-              "from": "extend@>=1.3.0 <2.0.0",
+              "from": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz",
               "resolved": "https://registry.npmjs.org/extend/-/extend-1.3.0.tgz"
             },
             "ldjson-stream": {
               "version": "1.2.1",
-              "from": "ldjson-stream@>=1.1.0 <2.0.0",
+              "from": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
               "resolved": "https://registry.npmjs.org/ldjson-stream/-/ldjson-stream-1.2.1.tgz",
               "dependencies": {
                 "split2": {
                   "version": "0.2.1",
-                  "from": "split2@>=0.2.1 <0.3.0",
+                  "from": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz",
                   "resolved": "https://registry.npmjs.org/split2/-/split2-0.2.1.tgz"
                 }
               }
             },
             "minimist": {
               "version": "0.2.0",
-              "from": "minimist@>=0.2.0 <0.3.0",
+              "from": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz",
               "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.2.0.tgz"
             },
             "pumpify": {
               "version": "1.3.3",
-              "from": "pumpify@>=1.2.1 <2.0.0",
+              "from": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.3.tgz",
               "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.3.3.tgz",
               "dependencies": {
                 "duplexify": {
                   "version": "3.4.2",
-                  "from": "duplexify@>=3.1.2 <4.0.0",
+                  "from": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                   "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.4.2.tgz",
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.0.0",
-                      "from": "end-of-stream@1.0.0",
+                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.0.0.tgz",
                       "dependencies": {
                         "once": {
                           "version": "1.3.2",
-                          "from": "once@>=1.3.0 <1.4.0",
+                          "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.1",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
+                              "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                             }
                           }
@@ -6675,37 +6675,37 @@
                     },
                     "readable-stream": {
                       "version": "2.0.2",
-                      "from": "readable-stream@>=2.0.0 <3.0.0",
+                      "from": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.2.tgz",
                       "dependencies": {
                         "core-util-is": {
                           "version": "1.0.1",
-                          "from": "core-util-is@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.1.tgz"
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.1 <2.1.0",
+                          "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz"
                         },
                         "isarray": {
                           "version": "0.0.1",
-                          "from": "isarray@0.0.1",
+                          "from": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
                         },
                         "process-nextick-args": {
                           "version": "1.0.3",
-                          "from": "process-nextick-args@>=1.0.0 <1.1.0",
+                          "from": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz",
                           "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.3.tgz"
                         },
                         "string_decoder": {
                           "version": "0.10.31",
-                          "from": "string_decoder@>=0.10.0 <0.11.0",
+                          "from": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
                           "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
                         },
                         "util-deprecate": {
                           "version": "1.0.1",
-                          "from": "util-deprecate@>=1.0.1 <1.1.0",
+                          "from": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.1.tgz"
                         }
                       }
@@ -6714,22 +6714,22 @@
                 },
                 "pump": {
                   "version": "1.0.0",
-                  "from": "pump@>=1.0.0 <2.0.0",
+                  "from": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
                   "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.0.tgz",
                   "dependencies": {
                     "end-of-stream": {
                       "version": "1.1.0",
-                      "from": "end-of-stream@>=1.1.0 <2.0.0",
+                      "from": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz",
                       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.1.0.tgz"
                     },
                     "once": {
                       "version": "1.3.2",
-                      "from": "once@>=1.3.1 <2.0.0",
+                      "from": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "resolved": "https://registry.npmjs.org/once/-/once-1.3.2.tgz",
                       "dependencies": {
                         "wrappy": {
                           "version": "1.0.1",
-                          "from": "wrappy@>=1.0.0 <2.0.0",
+                          "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz",
                           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.1.tgz"
                         }
                       }
@@ -6740,32 +6740,32 @@
             },
             "xml-nodes": {
               "version": "0.1.4",
-              "from": "xml-nodes@>=0.1.2 <0.2.0",
+              "from": "https://registry.npmjs.org/xml-nodes/-/xml-nodes-0.1.4.tgz",
               "resolved": "https://registry.npmjs.org/xml-nodes/-/xml-nodes-0.1.4.tgz"
             },
             "xml-objects": {
               "version": "0.0.1",
-              "from": "xml-objects@0.0.1",
+              "from": "https://registry.npmjs.org/xml-objects/-/xml-objects-0.0.1.tgz",
               "resolved": "https://registry.npmjs.org/xml-objects/-/xml-objects-0.0.1.tgz",
               "dependencies": {
                 "xml2js": {
                   "version": "0.4.12",
-                  "from": "xml2js@>=0.4.0 <0.5.0",
+                  "from": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.12.tgz",
                   "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.12.tgz",
                   "dependencies": {
                     "sax": {
                       "version": "1.1.3",
-                      "from": "sax@>=0.6.0",
+                      "from": "https://registry.npmjs.org/sax/-/sax-1.1.3.tgz",
                       "resolved": "https://registry.npmjs.org/sax/-/sax-1.1.3.tgz"
                     },
                     "xmlbuilder": {
                       "version": "3.0.0",
-                      "from": "xmlbuilder@>=2.4.6",
+                      "from": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-3.0.0.tgz",
                       "dependencies": {
                         "lodash": {
                           "version": "3.10.1",
-                          "from": "lodash@>=3.5.0 <4.0.0",
+                          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
                           "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
                         }
                       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "babel-runtime": "^5.1.11",
     "bluebird": "^2.9.27",
     "chokidar": "^1.0.1",
-    "cli-router": "^0.3.6",
+    "cli-router": "^0.3.7",
     "cli-table": "git+https://github.com/gullitmiranda/cli-table#master",
     "colors": "^0.6.2",
     "connectivity": "^0.1.1",

--- a/shared/locales/usage-en-US.txt
+++ b/shared/locales/usage-en-US.txt
@@ -5,7 +5,8 @@ Usage:
   azk config (track-toggle|track-status) [-qh] [-l <level>] [-v]...
   azk doctor [--logo] [-qh] [-l <level>] [-v]...
   azk deploy (clear-cache|fast|full|restart|versions) [-vh]
-  azk deploy (shell|ssh) [-vh] [-- <args>...]
+  azk deploy shell [--command=<cmd>] [-vh] [-- <args>...]
+  azk deploy ssh [-vh] [-- <args>...]
   azk deploy rollback [<ref>] [-vh]
   azk deploy [-vh]
   azk docker [-qh] [-l <level>] [-v]... [-- <docker-args>...]

--- a/shared/locales/usage-en-US.txt
+++ b/shared/locales/usage-en-US.txt
@@ -4,7 +4,8 @@ Usage:
   azk agent (start|status|stop) [--no-daemon --child --no-reload-vm --configure-file=<file>] [-qh] [-l <level>] [-v]...
   azk config (track-toggle|track-status) [-qh] [-l <level>] [-v]...
   azk doctor [--logo] [-qh] [-l <level>] [-v]...
-  azk deploy (clear-cache|fast|full|restart|shell|ssh|versions) [-vh]
+  azk deploy (clear-cache|fast|full|restart|versions) [-vh]
+  azk deploy (shell|ssh) [-vh] [-- <args>...]
   azk deploy rollback [<ref>] [-vh]
   azk deploy [-vh]
   azk docker [-qh] [-l <level>] [-v]... [-- <docker-args>...]

--- a/shared/locales/usage-en-US.txt
+++ b/shared/locales/usage-en-US.txt
@@ -4,8 +4,8 @@ Usage:
   azk agent (start|status|stop) [--no-daemon --child --no-reload-vm --configure-file=<file>] [-qh] [-l <level>] [-v]...
   azk config (track-toggle|track-status) [-qh] [-l <level>] [-v]...
   azk doctor [--logo] [-qh] [-l <level>] [-v]...
-  azk deploy (fast|slow|restart|ssh|versions) [-vh]
-  azk deploy rollback [<git-ref>] [-vh]
+  azk deploy (clear-cache|fast|full|restart|shell|ssh|versions) [-vh]
+  azk deploy rollback [<ref>] [-vh]
   azk deploy [-vh]
   azk docker [-qh] [-l <level>] [-v]... [-- <docker-args>...]
   azk info [--no-colored] [-qh] [-l <level>] [-v]...
@@ -43,23 +43,27 @@ Commands:
   vm       Controls the Virtual Machine.
 
 Actions:
+  clear-cache               Clear deploy cached configuration.
   installed                 Checks if the virtual machine is installed.
-  fast                      Fast deploy.
+  fast                      Deploy without configuring the remote server (default for every run after the first one).
+  full                      Configure the remote server and deploy the app (default for the first run).
   remove                    Removes the virtual machine.
-  restart                   Restart systems in deploy.
-  slow                      Slow deploy.
+  restart                   Restart systems local or in remote server.
+  rollback                  Revert the app to a specified reference (Default is previous version).
   start                     Starts azk agent or virtual machine.
   stop                      Stops azk agent or virtual machine.
   status                    Shows azk agent or virtual machine status.
-  ssh                       Gets access to the machine (vm or deploy) via SSH protocol.
+  shell                     Start a shell inside the deploy system.
+  ssh                       Gets access to the machine (vm or remote server) via SSH protocol.
   track-status              Shows tracking status (on or off).
   track-toggle              Toggles tracking behavior on/off.
-  versions                  List deployed versions.
+  versions                  List all app versions deployed on the remote server.
 
 Arguments:
   docker-args               Options and arguments to be passed to Docker.
   instances                 Number of instances.
   path                      Path where manifest file can be found.
+  ref                       Version or git reference -- commit, branch etc.
   ssh-args                  Options and arguments to be passed to VM over ssh.
   shell-args                Options and arguments to be passed to the system.
   system                    System name where the action will take place.
@@ -120,8 +124,9 @@ Examples:
   azk start azukiapp/azkdemo --ref 0.0.1               # tag 0.0.1
   azk start azukiapp/azkdemo --ref 880d01a             # commit 880d01a
   azk deploy                                           # run `deploy fast`
+  azk deploy shell
+  azk deploy full
   azk deploy fast
-  azk deploy slow
   azk deploy versions
   azk deploy rollback                                  # rollback to previous version
   azk deploy rollback v2                               # rollback to tag v2

--- a/shared/locales/usage-en-US.txt
+++ b/shared/locales/usage-en-US.txt
@@ -130,7 +130,7 @@ Examples:
   azk deploy fast
   azk deploy versions
   azk deploy rollback                                  # rollback to previous version
-  azk deploy rollback v2                               # rollback to tag v2
+  azk deploy rollback v2                               # rollback to version v2
   azk deploy rollback feature/add                      # rollback to branch feature/add
   azk deploy rollback 880d01a                          # rollback to commit 880d01a
   azk deploy restart

--- a/shared/locales/usage-en-US.txt
+++ b/shared/locales/usage-en-US.txt
@@ -26,7 +26,7 @@ Usage:
 Commands:
   agent    Controls azk agent.
   config   Controls azk configuration options.
-  deploy   Run deploy system.
+  deploy   Deploy this project to a remote server.
   docker   Alias for calling docker in azk configuration scope.
   doctor   Shows an analysis of azk's health.
   help     Shows help about a specific command.

--- a/shared/locales/usage-en-US.txt
+++ b/shared/locales/usage-en-US.txt
@@ -4,6 +4,9 @@ Usage:
   azk agent (start|status|stop) [--no-daemon --child --no-reload-vm --configure-file=<file>] [-qh] [-l <level>] [-v]...
   azk config (track-toggle|track-status) [-qh] [-l <level>] [-v]...
   azk doctor [--logo] [-qh] [-l <level>] [-v]...
+  azk deploy (fast|slow|restart|ssh|versions) [-vh]
+  azk deploy rollback [<git-ref>] [-vh]
+  azk deploy [-vh]
   azk docker [-qh] [-l <level>] [-v]... [-- <docker-args>...]
   azk info [--no-colored] [-qh] [-l <level>] [-v]...
   azk init [<path>] [--filename --force] [-qh] [-l <level>] [-v]...
@@ -23,6 +26,7 @@ Usage:
 Commands:
   agent    Controls azk agent.
   config   Controls azk configuration options.
+  deploy   Run deploy system.
   docker   Alias for calling docker in azk configuration scope.
   doctor   Shows an analysis of azk's health.
   help     Shows help about a specific command.
@@ -40,13 +44,17 @@ Commands:
 
 Actions:
   installed                 Checks if the virtual machine is installed.
+  fast                      Fast deploy.
   remove                    Removes the virtual machine.
+  restart                   Restart systems in deploy.
+  slow                      Slow deploy.
   start                     Starts azk agent or virtual machine.
   stop                      Stops azk agent or virtual machine.
   status                    Shows azk agent or virtual machine status.
-  ssh                       Gets access to the virtual machine via SSH protocol.
+  ssh                       Gets access to the machine (vm or deploy) via SSH protocol.
   track-status              Shows tracking status (on or off).
   track-toggle              Toggles tracking behavior on/off.
+  versions                  List deployed versions.
 
 Arguments:
   docker-args               Options and arguments to be passed to Docker.
@@ -111,3 +119,12 @@ Examples:
   azk start azukiapp/azkdemo --ref master              # branch master
   azk start azukiapp/azkdemo --ref 0.0.1               # tag 0.0.1
   azk start azukiapp/azkdemo --ref 880d01a             # commit 880d01a
+  azk deploy                                           # run `deploy fast`
+  azk deploy fast
+  azk deploy slow
+  azk deploy versions
+  azk deploy rollback                                  # rollback to previous version
+  azk deploy rollback v2                               # rollback to tag v2
+  azk deploy rollback feature/add                      # rollback to branch feature/add
+  azk deploy rollback 880d01a                          # rollback to commit 880d01a
+  azk deploy restart

--- a/shared/locales/usage-en-US.txt
+++ b/shared/locales/usage-en-US.txt
@@ -44,21 +44,21 @@ Commands:
   vm       Controls the Virtual Machine.
 
 Actions:
-  clear-cache               Clear deploy cached configuration.
+  clear-cache               Clears deployment cached configuration.
   installed                 Checks if the virtual machine is installed.
-  fast                      Deploy without configuring the remote server (default for every run after the first one).
-  full                      Configure the remote server and deploy the app (default for the first run).
+  fast                      Deploys without configuring the remote server (default for every run after the first deployment).
+  full                      Configures the remote server and deploy the app (default for the first deployment).
   remove                    Removes the virtual machine.
-  restart                   Restart systems local or in remote server.
-  rollback                  Revert the app to a specified reference (Default is previous version).
+  restart                   Restarts local systems or the app on the remote server.
+  rollback                  Reverts the app to a specified reference (default is the previous version).
   start                     Starts azk agent or virtual machine.
   stop                      Stops azk agent or virtual machine.
   status                    Shows azk agent or virtual machine status.
-  shell                     Start a shell inside the deploy system.
-  ssh                       Gets access to the machine (vm or remote server) via SSH protocol.
+  shell                     Starts a shell from inside the deploy system container.
+  ssh                       Connects to the VM or remote server (when used with deploy) via SSH protocol.
   track-status              Shows tracking status (on or off).
   track-toggle              Toggles tracking behavior on/off.
-  versions                  List all app versions deployed on the remote server.
+  versions                  Lists all versions of the app deployed on the remote server.
 
 Arguments:
   docker-args               Options and arguments to be passed to Docker.

--- a/spec/cmds/deploy_spec.js
+++ b/spec/cmds/deploy_spec.js
@@ -12,13 +12,93 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
   var doc_opts    = { exit: false };
   var run_options = { ui: ui, cwd: __dirname };
 
-  it("should run a `deploy` command", function() {
-    doc_opts.argv = ['deploy'];
-    var options = cli.router.cleanParams(cli.docopt(doc_opts));
+  describe('run command', function () {
+    it("`deploy`", function() {
+      doc_opts.argv = ['deploy'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
 
-    return cli.run(doc_opts, run_options).then((code) => {
-      h.expect(code).to.equal(0);
-      h.expect(options).to.have.property('deploy', true);
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+      });
+    });
+
+    it("`deploy fast`", function() {
+      doc_opts.argv = ['deploy', 'fast'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('fast', true);
+      });
+    });
+
+    it("`deploy slow`", function() {
+      doc_opts.argv = ['deploy', 'slow'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('slow', true);
+      });
+    });
+
+    it("`deploy restart`", function() {
+      doc_opts.argv = ['deploy', 'restart'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('restart', true);
+      });
+    });
+
+    it("`deploy ssh`", function() {
+      doc_opts.argv = ['deploy', 'ssh'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('ssh', true);
+      });
+    });
+
+    it("`deploy versions`", function() {
+      doc_opts.argv = ['deploy', 'versions'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('versions', true);
+      });
+    });
+
+    it("`deploy rollback`", function() {
+      doc_opts.argv = ['deploy', 'rollback'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('rollback', true);
+      });
+    });
+
+    it("`deploy rollback <git-ref>`", function() {
+      doc_opts.argv = ['deploy', 'rollback', 'v2'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('rollback', true);
+        h.expect(options).to.have.property('git-ref', "v2");
+      });
     });
   });
 });

--- a/spec/cmds/deploy_spec.js
+++ b/spec/cmds/deploy_spec.js
@@ -96,7 +96,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
     });
 
     it("`deploy ssh -- echo data`", function() {
-      doc_opts.argv = ['deploy', 'ssh', '--', 'echo data'];
+      doc_opts.argv = ['deploy', 'ssh', '--', "-c 'echo data'"];
       var options = cli.router.cleanParams(cli.docopt(doc_opts));
 
       return cli.run(doc_opts, run_options).then((code) => {
@@ -104,8 +104,8 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('ssh', true);
         h.expect(options).to.have.property('__doubledash', true);
-        h.expect(options.args).to.deep.eql(['echo data']);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- ssh echo data')));
+        h.expect(options.args).to.deep.eql(["-c 'echo data'"]);
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp("azk shell deploy -- ssh -c 'echo data'")));
       });
     });
 

--- a/spec/cmds/deploy_spec.js
+++ b/spec/cmds/deploy_spec.js
@@ -4,8 +4,8 @@ import { SystemNotFoundError, InvalidCommandError } from 'azk/utils/errors';
 import Deploy from 'azk/cmds/deploy';
 
 class DeployTest extends Deploy {
-  _run(cmd) {
-    this.ui.output(`${cmd}`);
+  runShell(cmd) {
+    this.ui.output(cmd.join(" "));
     return 0;
   }
 }
@@ -31,7 +31,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
       return cli.run(doc_opts, run_options).then((code) => {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy')));
       });
     });
 
@@ -43,7 +43,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('clear-cache', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- clear-cache')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy -- clear-cache')));
       });
     });
 
@@ -55,7 +55,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('fast', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- fast')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy -- fast')));
       });
     });
 
@@ -67,7 +67,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('full', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- full')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy -- full')));
       });
     });
 
@@ -79,7 +79,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('restart', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- restart')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy -- restart')));
       });
     });
 
@@ -91,7 +91,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('ssh', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy --tty -- ssh')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy --tty -- ssh')));
       });
     });
 
@@ -105,7 +105,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(options).to.have.property('ssh', true);
         h.expect(options).to.have.property('__doubledash', true);
         h.expect(options.args).to.deep.eql(["-c 'echo data'"]);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp("azk shell deploy -- ssh -c 'echo data'")));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp("shell deploy -- ssh -c 'echo data'")));
       });
     });
 
@@ -117,7 +117,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('shell', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy --tty -- shell')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy --tty -- shell')));
       });
     });
 
@@ -131,7 +131,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(options).to.have.property('shell', true);
         h.expect(options).to.have.property('__doubledash', true);
         h.expect(options.args).to.deep.eql(['echo data']);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- shell echo data')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy -- shell echo data')));
       });
     });
 
@@ -143,7 +143,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('versions', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- versions')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy -- versions')));
       });
     });
 
@@ -155,7 +155,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('rollback', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- rollback')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy -- rollback')));
       });
     });
 
@@ -168,7 +168,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('rollback', true);
         h.expect(options).to.have.property('ref', "v2");
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- rollback v2')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('shell deploy -- rollback v2')));
       });
     });
 

--- a/spec/cmds/deploy_spec.js
+++ b/spec/cmds/deploy_spec.js
@@ -1,0 +1,24 @@
+import h from 'spec/spec_helper';
+import { Cli } from 'azk/cli';
+
+h.describeRequireVm('Azk cli, deploy controller', function() {
+  var outputs = [];
+  var ui      = h.mockUI(beforeEach, outputs);
+
+  var cli_options = {};
+  var cli = new Cli(cli_options)
+    .route('deploy');
+
+  var doc_opts    = { exit: false };
+  var run_options = { ui: ui, cwd: __dirname };
+
+  it("should run a `deploy` command", function() {
+    doc_opts.argv = ['deploy'];
+    var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+    return cli.run(doc_opts, run_options).then((code) => {
+      h.expect(code).to.equal(0);
+      h.expect(options).to.have.property('deploy', true);
+    });
+  });
+});

--- a/spec/cmds/deploy_spec.js
+++ b/spec/cmds/deploy_spec.js
@@ -20,7 +20,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
   describe('run command', function () {
     var run_options = { ui: ui, cwd: h.fixture_path('slim-app'), just_parse: true };
     var cli = new Cli(cli_options)
-      .route('deploy', null, function(p) {
+      .route('deploy', null, function() {
         return (new (DeployTest)(this)).index();
       });
 
@@ -91,7 +91,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('ssh', true);
-        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- ssh')));
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy --tty -- ssh')));
       });
     });
 

--- a/spec/cmds/deploy_spec.js
+++ b/spec/cmds/deploy_spec.js
@@ -24,6 +24,17 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
       });
     });
 
+    it("`deploy clear-cache`", function() {
+      doc_opts.argv = ['deploy', 'clear-cache'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('clear-cache', true);
+      });
+    });
+
     it("`deploy fast`", function() {
       doc_opts.argv = ['deploy', 'fast'];
       var options = cli.router.cleanParams(cli.docopt(doc_opts));
@@ -35,14 +46,14 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
       });
     });
 
-    it("`deploy slow`", function() {
-      doc_opts.argv = ['deploy', 'slow'];
+    it("`deploy full`", function() {
+      doc_opts.argv = ['deploy', 'full'];
       var options = cli.router.cleanParams(cli.docopt(doc_opts));
 
       return cli.run(doc_opts, run_options).then((code) => {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
-        h.expect(options).to.have.property('slow', true);
+        h.expect(options).to.have.property('full', true);
       });
     });
 
@@ -68,6 +79,17 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
       });
     });
 
+    it("`deploy shell`", function() {
+      doc_opts.argv = ['deploy', 'shell'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('shell', true);
+      });
+    });
+
     it("`deploy versions`", function() {
       doc_opts.argv = ['deploy', 'versions'];
       var options = cli.router.cleanParams(cli.docopt(doc_opts));
@@ -90,7 +112,7 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
       });
     });
 
-    it("`deploy rollback <git-ref>`", function() {
+    it("`deploy rollback <ref>`", function() {
       doc_opts.argv = ['deploy', 'rollback', 'v2'];
       var options = cli.router.cleanParams(cli.docopt(doc_opts));
 
@@ -98,8 +120,15 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('rollback', true);
-        h.expect(options).to.have.property('git-ref', "v2");
+        h.expect(options).to.have.property('ref', "v2");
       });
+    });
+
+    it("`invalid` and should error", function() {
+      doc_opts.argv = ['deploy', 'invalid'];
+
+      var func = () => cli.docopt(doc_opts);
+      h.expect(func).to.throw(InvalidCommandError, /deploy invalid/);
     });
   });
 

--- a/spec/cmds/deploy_spec.js
+++ b/spec/cmds/deploy_spec.js
@@ -95,6 +95,20 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
       });
     });
 
+    it("`deploy ssh -- echo data`", function() {
+      doc_opts.argv = ['deploy', 'ssh', '--', 'echo data'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('ssh', true);
+        h.expect(options).to.have.property('__doubledash', true);
+        h.expect(options.args).to.deep.eql(['echo data']);
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- ssh echo data')));
+      });
+    });
+
     it("`deploy shell`", function() {
       doc_opts.argv = ['deploy', 'shell'];
       var options = cli.router.cleanParams(cli.docopt(doc_opts));
@@ -104,6 +118,20 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('shell', true);
         h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy --tty -- shell')));
+      });
+    });
+
+    it("`deploy shell -- echo data`", function() {
+      doc_opts.argv = ['deploy', 'shell', '--', 'echo data'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+        h.expect(options).to.have.property('shell', true);
+        h.expect(options).to.have.property('__doubledash', true);
+        h.expect(options.args).to.deep.eql(['echo data']);
+        h.expect(outputs[0]).to.match(RegExp(h.escapeRegExp('azk shell deploy -- shell echo data')));
       });
     });
 

--- a/spec/cmds/deploy_spec.js
+++ b/spec/cmds/deploy_spec.js
@@ -1,5 +1,6 @@
 import h from 'spec/spec_helper';
 import { Cli } from 'azk/cli';
+import { SystemNotFoundError } from 'azk/utils/errors';
 
 h.describeRequireVm('Azk cli, deploy controller', function() {
   var outputs = [];
@@ -98,6 +99,48 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
         h.expect(options).to.have.property('deploy', true);
         h.expect(options).to.have.property('rollback', true);
         h.expect(options).to.have.property('git-ref', "v2");
+      });
+    });
+  });
+
+  describe("without deploy system", function() {
+    var manifest;
+
+    before(() => {
+      var data = { };
+      return h.mockManifest(data).then((mf) => {
+        manifest = mf;
+      });
+    });
+
+    it("should raise error if no get deploy system", function() {
+      var func = () => manifest.getSystemsByName("deploy");
+      h.expect(func).to.throw(SystemNotFoundError, /deploy/);
+    });
+
+    it("should no deploy system", function() {
+      doc_opts.argv = ['deploy'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+      var run_options = { ui: ui, cwd: manifest.cwd, just_parse: true };
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(1);
+        h.expect(options).to.have.property('deploy', true);
+      });
+    });
+  });
+
+  describe("with deploy system", function() {
+    var run_options = { ui: ui, cwd: h.fixture_path('slim-app'), just_parse: true };
+
+    doc_opts.argv = ['deploy'];
+
+    it("should run a `deploy` command", function() {
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
       });
     });
   });

--- a/spec/cmds/deploy_spec.js
+++ b/spec/cmds/deploy_spec.js
@@ -133,9 +133,18 @@ h.describeRequireVm('Azk cli, deploy controller', function() {
   describe("with deploy system", function() {
     var run_options = { ui: ui, cwd: h.fixture_path('slim-app'), just_parse: true };
 
-    doc_opts.argv = ['deploy'];
-
     it("should run a `deploy` command", function() {
+      doc_opts.argv = ['deploy'];
+      var options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+      return cli.run(doc_opts, run_options).then((code) => {
+        h.expect(code).to.equal(0);
+        h.expect(options).to.have.property('deploy', true);
+      });
+    });
+
+    it("should run a `deploy fast` command", function() {
+      doc_opts.argv = ['deploy', 'fast'];
       var options = cli.router.cleanParams(cli.docopt(doc_opts));
 
       return cli.run(doc_opts, run_options).then((code) => {

--- a/spec/docker/pull_spec.js
+++ b/spec/docker/pull_spec.js
@@ -1,4 +1,4 @@
-import { _, config } from 'azk';
+import { config } from 'azk';
 import { subscribe } from 'azk/utils/postal';
 import { Image } from 'azk/docker';
 import h from 'spec/spec_helper';
@@ -21,21 +21,8 @@ describe("Azk docker module, image pull @slow", function() {
     return h.docker.pull(image.repository, image.tag)
       .then(() => {
         _subscription.unsubscribe();
-
-        var status_list = [
-          'pulling_repository',
-          'pulling_layers',
-          'pulling_metadata',
-          'pulling_fs_layer',
-          'pulling_image',
-          'download',
-          'download_complete',
-        ];
-
-        _.each(status_list, (status) => {
-          h.expect(events)
-          .to.contain.an.item.with.deep.property('statusParsed.type', status);
-        });
+        h.expect(events).to.contain.an.item.with.deep.property('statusParsed.type', "pulling_finished");
+        h.expect(events).to.contain.an.item.with.deep.property('end').and.to.ok;
       })
       .catch(function (err) {
         _subscription.unsubscribe();

--- a/spec/fixtures/slim-app/.env.sample
+++ b/spec/fixtures/slim-app/.env.sample
@@ -1,0 +1,2 @@
+FROM_DOT_ENV=azk is beautiful
+DEPLOY_API_TOKEN="<get in https://cloud.digitalocean.com/settings/applications>"

--- a/spec/fixtures/slim-app/Azkfile.js
+++ b/spec/fixtures/slim-app/Azkfile.js
@@ -31,4 +31,7 @@ systems({
       EXAMPLE: "value",
     },
   },
+  deploy: {
+    image: { docker: "azukiapp/alpine" },
+  }
 });

--- a/spec/fixtures/slim-app/Azkfile.js
+++ b/spec/fixtures/slim-app/Azkfile.js
@@ -17,6 +17,13 @@ systems({
     shell: "/bin/bash",
     command: socat('80') + " &0>/dev/null ; " + socat('53') + " &0>/dev/null ; " + socat('53'),
     wait: {"retry": 20, "timeout": 1000},
+    http: {
+      domains: [
+        "#{process.env.HOST_DOMAIN}",
+        "#{process.env.HOST_IP}",
+        "#{system.name}.#{azk.default_domain}",
+      ]
+    },
     provision: [
       "ls -l ./src",
       "./src/bashttpd",

--- a/spec/manifest/index_spec.js
+++ b/spec/manifest/index_spec.js
@@ -66,7 +66,7 @@ describe("Azk manifest class, main set", function() {
         var systems = manifest.getSystemsByName();
         h.expect(systems).to.length(_.keys(manifest.systems).length);
         h.expect(systems[0]).to.equal(manifest.system("expand-test"));
-        h.expect(systems[systems.length-1]).to.equal(manifest.system("example"));
+        h.expect(systems[systems.length - 1]).to.equal(manifest.system("example"));
       });
 
       it("should raise error if get a not set system", function() {

--- a/spec/system/index_spec.js
+++ b/spec/system/index_spec.js
@@ -22,7 +22,7 @@ describe("Azk system class, main set", function() {
     h.expect(system).to.have.property("command").and.match(regex);
     h.expect(system).to.have.property("depends").and.eql([]);
     h.expect(system).to.have.property("envs").and.eql({});
-    h.expect(system).to.have.property("shell", "/bin/sh");
+    h.expect(system).to.have.property("shell", null);
     h.expect(system).to.have.property("workdir", "/");
     h.expect(system).to.have.property("scalable").and.eql({ default: 1, limit: 1 });
     h.expect(system).to.have.property("default_options").to.fail;

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -33,10 +33,10 @@ export function cli(args, cwd, ui = UI) {
       .route('shell')
       .route('status')
       .route('start', (p) => {
-          var is_start_url_system = /.*[/].*/g.test(p["<system>"]);
-          var has_git_repo_option = p["<git-repo>"] !== null;
-          return is_start_url_system || has_git_repo_option;
-        }, 'start.getProject')
+        var is_start_url_system = /.*[/].*/g.test(p["<system>"]);
+        var has_git_repo_option = p["<git-repo>"] !== null;
+        return is_start_url_system || has_git_repo_option;
+      }, 'start.getProject')
       .route('start')
       .route('restart', (p) => p.restart          , 'start.index')
       .route('stop'   , (p) => p.stop             , 'start.index')

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -38,8 +38,8 @@ export function cli(args, cwd, ui = UI) {
         return is_start_url_system || has_git_repo_option;
       }, 'start.getProject')
       .route('start')
-      .route('restart', (p) => p.restart          , 'start.index')
-      .route('stop'   , (p) => p.stop             , 'start.index')
+      .route('restart', (p) => p.restart , 'start.index')
+      .route('stop'   , (p) => p.stop    , 'start.index')
       .route('logs')
       .route('help'); // If you do not fall in any other route, the help is called.
 

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -12,44 +12,51 @@ export class Cli extends AzkCli {
   }
 }
 
-export function cli(args, cwd, ui = UI) {
-  var result;
-  try {
-    var azk_cli = new Cli();
-    azk_cli
-      // Options
-      .route('help', (p, args) => p.help || p['--help'] || _.isEmpty(args))
-      .route('version', (p) => p.version || p['--version'])
-      // Commands
-      .route('agent', (p, args) => p.agent && /(start|status|stop|configure)/.test(args))
-      .route('vm', (p, args) => p.vm && /(ssh|start|status|installed|stop|remove)/.test(args))
-      .route('config', (p, args) => p.config && /(track-toggle|track-status)/.test(args))
-      .route('deploy')
-      .route('docker')
-      .route('doctor')
-      .route('info')
-      .route('init')
-      .route('scale')
-      .route('shell')
-      .route('status')
-      .route('start', (p) => {
-        var is_start_url_system = /.*[/].*/g.test(p["<system>"]);
-        var has_git_repo_option = p["<git-repo>"] !== null;
-        return is_start_url_system || has_git_repo_option;
-      }, 'start.getProject')
-      .route('start')
-      .route('restart', (p) => p.restart , 'start.index')
-      .route('stop'   , (p) => p.stop    , 'start.index')
-      .route('logs')
-      .route('help'); // If you do not fall in any other route, the help is called.
+function make_cli() {
+  return new Cli()
+    // Options
+    .route('help', (p, args) => p.help || p['--help'] || _.isEmpty(args))
+    .route('version', (p) => p.version || p['--version'])
+    // Commands
+    .route('agent', (p, args) => p.agent && /(start|status|stop|configure)/.test(args))
+    .route('vm', (p, args) => p.vm && /(ssh|start|status|installed|stop|remove)/.test(args))
+    .route('config', (p, args) => p.config && /(track-toggle|track-status)/.test(args))
+    .route('deploy')
+    .route('docker')
+    .route('doctor')
+    .route('info')
+    .route('init')
+    .route('scale')
+    .route('shell')
+    .route('status')
+    .route('start', (p) => {
+      var is_start_url_system = /.*[/].*/g.test(p["<system>"]);
+      var has_git_repo_option = p["<git-repo>"] !== null;
+      return is_start_url_system || has_git_repo_option;
+    }, 'start.getProject')
+    .route('start')
+    .route('restart', (p) => p.restart , 'start.index')
+    .route('stop'   , (p) => p.stop    , 'start.index')
+    .route('logs')
+    .route('help'); // If you do not fall in any other route, the help is called.
+}
 
-    result = azk_cli.run({
-      argv: args.slice(2)
-    }, {
-      args: args.slice(2),
-      ui  : ui,
-      cwd : process.cwd()
-    });
+export function run(args, cwd, ui) {
+  var cli = make_cli();
+  return [cli, cli.run({
+    argv: args
+  }, {
+    args: args,
+    ui  : ui,
+    cwd : process.cwd()
+  })];
+}
+
+export function cli(args, cwd, ui = UI) {
+  var result, azk_cli;
+  try {
+    args = args.slice(2);
+    [azk_cli, result] = run(args, cwd, ui = UI);
   } catch (e) {
     result = (e instanceof InvalidCommandError) ?
       azk_cli.invalidCmd(e) : promiseReject(e);

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -24,6 +24,7 @@ export function cli(args, cwd, ui = UI) {
       .route('agent', (p, args) => p.agent && /(start|status|stop|configure)/.test(args))
       .route('vm', (p, args) => p.vm && /(ssh|start|status|installed|stop|remove)/.test(args))
       .route('config', (p, args) => p.config && /(track-toggle|track-status)/.test(args))
+      .route('deploy')
       .route('docker')
       .route('doctor')
       .route('info')

--- a/src/cmds/deploy.js
+++ b/src/cmds/deploy.js
@@ -3,6 +3,7 @@ import { lazy_require, _ } from 'azk';
 import { async } from 'azk/utils/promises';
 import { AzkError } from 'azk/utils/errors';
 import { Helpers } from 'azk/cli/helpers';
+import { run as cli_run } from 'azk/cli';
 
 var lazy = lazy_require({
   Manifest: ['azk/manifest']
@@ -13,23 +14,40 @@ class Deploy extends CliTrackerController {
     return async(this, function* () {
       yield Helpers.requireAgent(this.ui);
 
-      var system = this._getDeploySystem(this.cwd);
-      var suffix = this.args.slice(1);
-      var cmd = [`azk shell ${system.name}`];
-      if (suffix) {
-        if (_.contains(suffix, "shell") || _.contains(suffix, "ssh")) {
-          if (_.contains(suffix, "--"))
-            suffix = _.filter(suffix, (s) => s != '--')
-          else {
-            cmd.push("--tty");
-          }
-        }
-        cmd.push('--');
-        cmd.push(suffix.join(' '));
-      }
-      cmd = cmd.join(" ");
+      // Get deploy [commands] avaible
+      var output  = [];
+      var mock_ui = { output: (line) => output.push(line) };
+      cli_run(["deploy", "--help"], this.cwd, mock_ui);
+      var args = output.join("").match(/Actions:([^]*)Arguments/)[0]
+      args = _.map(args.match(/^\s{2}([\w|-]*)/mg), (arg) => arg.trim());
 
-      return this._run(cmd);
+      var params   = this.normalized_params;
+      var system   = this._getDeploySystem(this.cwd);
+      var command  = _.find(args, (cmd) => params.commands[cmd]);
+      var cmd_head = ["shell", system.name];
+      var cmd_tail = [];
+
+      // Rollback to version
+      if (!_.isEmpty(params.arguments.ref)) {
+        cmd_tail.push(params.arguments.ref);
+      }
+
+      // Forwarding shell and ssh commands
+      if (params.commands.shell || params.commands.ssh) {
+        if (!_.isEmpty(params.options.command)) {
+          cmd_tail.push("-c", this._escape_quotes(params.options.command));
+        } else if (!_.isEmpty(params.arguments.args)) {
+          var escape_args = _.map(params.arguments.args, (arg) => this._escape_quotes(arg));
+          cmd_tail.push(...escape_args);
+        } else {
+          cmd_head.push("--tty");
+        }
+      }
+
+      var cmd = cmd_head.concat(["--", command, ...cmd_tail]);
+      var result;
+      [, result] = cli_run(cmd, this.cwd, this.ui);
+      return result;
     })
     .catch((err) => {
       if (err instanceof AzkError) {
@@ -39,6 +57,10 @@ class Deploy extends CliTrackerController {
       }
       return 1;
     });
+  }
+
+  _escape_quotes(cmd) {
+    return cmd.replace(/"/g, `\\"`);
   }
 
   _run(cmd) {

--- a/src/cmds/deploy.js
+++ b/src/cmds/deploy.js
@@ -17,8 +17,8 @@ class Deploy extends CliTrackerController {
       var suffix = this.args.slice(1).join(' ');
       var cmd = [`azk shell ${system.name}`];
       if (suffix) {
-        if (suffix == "shell") {
-          cmd.push("--tty")
+        if (suffix == "shell" || suffix == "ssh") {
+          cmd.push("--tty");
         }
         cmd.push('--');
         cmd.push(suffix);

--- a/src/cmds/deploy.js
+++ b/src/cmds/deploy.js
@@ -1,5 +1,5 @@
 import { CliTrackerController } from 'azk/cli/cli_tracker_controller.js';
-import { lazy_require } from 'azk';
+import { lazy_require, _ } from 'azk';
 import { async } from 'azk/utils/promises';
 import { AzkError } from 'azk/utils/errors';
 import { Helpers } from 'azk/cli/helpers';
@@ -14,14 +14,18 @@ class Deploy extends CliTrackerController {
       yield Helpers.requireAgent(this.ui);
 
       var system = this._getDeploySystem(this.cwd);
-      var suffix = this.args.slice(1).join(' ');
+      var suffix = this.args.slice(1);
       var cmd = [`azk shell ${system.name}`];
       if (suffix) {
-        if (suffix == "shell" || suffix == "ssh") {
-          cmd.push("--tty");
+        if (_.contains(suffix, "shell") || _.contains(suffix, "ssh")) {
+          if (_.contains(suffix, "--"))
+            suffix = _.filter(suffix, (s) => s != '--')
+          else {
+            cmd.push("--tty");
+          }
         }
         cmd.push('--');
-        cmd.push(suffix);
+        cmd.push(suffix.join(' '));
       }
       cmd = cmd.join(" ");
 

--- a/src/cmds/deploy.js
+++ b/src/cmds/deploy.js
@@ -1,0 +1,9 @@
+import { CliTrackerController } from 'azk/cli/cli_tracker_controller.js';
+
+class Deploy extends CliTrackerController {
+  index(opts) {
+    return 0;
+  }
+}
+
+module.exports = Deploy;

--- a/src/cmds/deploy.js
+++ b/src/cmds/deploy.js
@@ -1,6 +1,6 @@
 import { CliTrackerController } from 'azk/cli/cli_tracker_controller.js';
 import { lazy_require } from 'azk';
-import { defer, async } from 'azk/utils/promises';
+import { async } from 'azk/utils/promises';
 import { AzkError } from 'azk/utils/errors';
 import { Helpers } from 'azk/cli/helpers';
 
@@ -13,27 +13,25 @@ class Deploy extends CliTrackerController {
     return async(this, function* () {
       yield Helpers.requireAgent(this.ui);
 
-      return this
-        ._getDeploySystem()
-        .then(() => {
-          return 0;
-        })
-        .catch((err) => {
-          if (err instanceof AzkError) {
-            this.ui.fail(err.toString());
-          } else {
-            this.ui.fail(err.stack);
-          }
-          return 1;
-        });
+      var system = this._getDeploySystem(this.cwd);
+      // TODO: append `this.args` and run `system`
+      // console.log('this.args:', this.args);
+
+      return 0;
+    })
+    .catch((err) => {
+      if (err instanceof AzkError) {
+        this.ui.fail(err.toString());
+      } else {
+        this.ui.fail(err.stack);
+      }
+      return 1;
     });
   }
 
-  _getDeploySystem() {
-    return defer((resolve) => {
-      var manifest = new lazy.Manifest(this.cwd, true);
-      resolve(manifest.getSystemsByName("deploy"));
-    });
+  _getDeploySystem(cwd) {
+    var manifest = new lazy.Manifest(cwd, true);
+    return manifest.system("deploy", true);
   }
 }
 

--- a/src/cmds/deploy.js
+++ b/src/cmds/deploy.js
@@ -14,10 +14,18 @@ class Deploy extends CliTrackerController {
       yield Helpers.requireAgent(this.ui);
 
       var system = this._getDeploySystem(this.cwd);
-      // TODO: append `this.args` and run `system`
-      // console.log('this.args:', this.args);
+      var suffix = this.args.slice(1).join(' ');
+      var cmd = [`azk shell ${system.name}`];
+      if (suffix) {
+        if (suffix == "shell") {
+          cmd.push("--tty")
+        }
+        cmd.push('--');
+        cmd.push(suffix);
+      }
+      cmd = cmd.join(" ");
 
-      return 0;
+      return this._run(cmd);
     })
     .catch((err) => {
       if (err instanceof AzkError) {
@@ -27,6 +35,10 @@ class Deploy extends CliTrackerController {
       }
       return 1;
     });
+  }
+
+  _run(cmd) {
+    return this.ui.execSh(cmd);
   }
 
   _getDeploySystem(cwd) {

--- a/src/cmds/deploy.js
+++ b/src/cmds/deploy.js
@@ -18,7 +18,7 @@ class Deploy extends CliTrackerController {
       var output  = [];
       var mock_ui = { output: (line) => output.push(line) };
       cli_run(["deploy", "--help"], this.cwd, mock_ui);
-      var args = output.join("").match(/Actions:([^]*)Arguments/)[0]
+      var args = output.join("").match(/Actions:([^]*)Arguments/)[0];
       args = _.map(args.match(/^\s{2}([\w|-]*)/mg), (arg) => arg.trim());
 
       var params   = this.normalized_params;
@@ -44,10 +44,8 @@ class Deploy extends CliTrackerController {
         }
       }
 
-      var cmd = cmd_head.concat(["--", command, ...cmd_tail]);
-      var result;
-      [, result] = cli_run(cmd, this.cwd, this.ui);
-      return result;
+      // Call internaly cli and return result
+      return this.runShell(cmd_head.concat(["--", command, ...cmd_tail]));
     })
     .catch((err) => {
       if (err instanceof AzkError) {
@@ -59,12 +57,13 @@ class Deploy extends CliTrackerController {
     });
   }
 
-  _escape_quotes(cmd) {
-    return cmd.replace(/"/g, `\\"`);
+  runShell(cmd) {
+    var [, result] = cli_run(cmd, this.cwd, this.ui);
+    return result;
   }
 
-  _run(cmd) {
-    return this.ui.execSh(cmd);
+  _escape_quotes(cmd) {
+    return cmd.replace(/"/g, `\\"`);
   }
 
   _getDeploySystem(cwd) {

--- a/src/cmds/deploy.js
+++ b/src/cmds/deploy.js
@@ -1,8 +1,39 @@
 import { CliTrackerController } from 'azk/cli/cli_tracker_controller.js';
+import { lazy_require } from 'azk';
+import { defer, async } from 'azk/utils/promises';
+import { AzkError } from 'azk/utils/errors';
+import { Helpers } from 'azk/cli/helpers';
+
+var lazy = lazy_require({
+  Manifest: ['azk/manifest']
+});
 
 class Deploy extends CliTrackerController {
-  index(opts) {
-    return 0;
+  index() {
+    return async(this, function* () {
+      yield Helpers.requireAgent(this.ui);
+
+      return this
+        ._getDeploySystem()
+        .then(() => {
+          return 0;
+        })
+        .catch((err) => {
+          if (err instanceof AzkError) {
+            this.ui.fail(err.toString());
+          } else {
+            this.ui.fail(err.stack);
+          }
+          return 1;
+        });
+    });
+  }
+
+  _getDeploySystem() {
+    return defer((resolve) => {
+      var manifest = new lazy.Manifest(this.cwd, true);
+      resolve(manifest.getSystemsByName("deploy"));
+    });
   }
 }
 

--- a/src/cmds/info.js
+++ b/src/cmds/info.js
@@ -62,7 +62,7 @@ class Info extends CliTrackerController {
 
   _format_command(commands) {
     commands = _.map(commands, (cmd) => {
-      return (cmd.match(/\s/)) ? `"${cmd.replace(/\"/g, '\\"')}"` : cmd;
+      return _.isString(cmd) && (cmd.match(/\s/)) ? `"${cmd.replace(/\"/g, '\\"')}"` : cmd;
     });
     return commands.join(" ");
   }

--- a/src/cmds/shell.js
+++ b/src/cmds/shell.js
@@ -38,11 +38,9 @@ class Shell extends CliTrackerController {
         }
       }
 
-      if (_.isString(options.command)) {
-        options.command = `${options.command};`;
-      }
-      var commands = _.compact([ options.command, ...args['shell-args']]);
-      var tty_default = options.tty || _.isEmpty(commands);
+      // Use or not tty?
+      var shell_args = args['shell-args'];
+      var tty_default = options.tty || _.isEmpty(options.command) || _.isEmpty(shell_args);
       var tty = (options['no-tty']) ? (options.tty || false) : tty_default;
 
       var stdin = this.ui.stdin();
@@ -63,11 +61,11 @@ class Shell extends CliTrackerController {
         return { type: (opts[2] ? opts[1] : 'path'), value: (opts[2] ? opts[2] : opts[0]) };
       });
 
-      // TODO add support to `-- [shell-args]`
-      var cmd = [options.shell || system.shell];
-      if (!_.isEmpty(commands)) {
-        cmd.push("-c");
-        cmd.push(commands.join(' '));
+      var cmd = [];
+      if (!_.isEmpty(options.command)) {
+        cmd.push("-c", options.command);
+      } else if (!_.isEmpty(shell_args)) {
+        cmd = cmd.concat(shell_args);
       }
       cmd = _.compact(cmd);
 
@@ -77,6 +75,7 @@ class Shell extends CliTrackerController {
         build_force    : options.rebuild || false,
         provision_force: (options.rebuild ? true : options.reprovision) || false,
         remove         : is_remove,
+        shell          : options.shell,
       });
 
       var result = defer((resolver, reject) => {

--- a/src/cmds/start.js
+++ b/src/cmds/start.js
@@ -136,7 +136,7 @@ class Start extends Scale {
             git_destination_path: command_parse_result.git_destination_path
           });
         });
-      })
+      });
     }
   }
 }

--- a/src/manifest/get_project.js
+++ b/src/manifest/get_project.js
@@ -285,8 +285,6 @@ export class GetProject extends UIProxy {
       } else {
         return promiseResolve(gitCallError);
       }
-
-
     };
   }
 
@@ -299,7 +297,7 @@ export class GetProject extends UIProxy {
     return filtered.length > 0;
   }
 
-  _checkDestinationFolder(git_destination_path, verbose_level) {
+  _checkDestinationFolder(git_destination_path/*, verbose_level*/) {
     this.ok('commands.start.get_project.checking_destination', {
       git_destination_path,
     });

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -48,7 +48,7 @@ export class System {
 
   get default_options() {
     return {
-      shell    : "/bin/sh",
+      shell    : null,
       depends  : [],
       envs     : {},
       scalable : false,

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -172,7 +172,7 @@ export class System {
       hostnames = [this.http.hostname];
     }
 
-    hostnames = _.filter(hostnames, (hostname) => { return ! _.isEmpty(hostname) })
+    hostnames = _.filter(hostnames, (hostname) => { return !_.isEmpty(hostname); })
       .map((hostname) => hostname.toLowerCase());
 
     return hostnames;

--- a/src/system/run.js
+++ b/src/system/run.js
@@ -16,6 +16,7 @@ var Run = {
     return async(this, function* () {
       var steps = system.provision_steps;
 
+      options = _.clone(options);
       options = _.defaults(options, {
         provision_force: false,
         build_force: false,
@@ -31,7 +32,7 @@ var Run = {
       log.debug('provision steps', steps);
 
       // provision command (require /bin/sh)
-      var cmd  = ["/bin/sh", "-c", "( " + steps.join('; ') + " )"];
+      options.command = ["/bin/sh", "-c", "( " + steps.join('; ') + " )"];
 
       // Capture outputs
       var output = "";
@@ -49,16 +50,16 @@ var Run = {
       }
 
       publish("system.run.provision.status", { type: "provision", system: system.name });
-      var exitResult = yield system.runShell(cmd, options);
+      var exitResult = yield system.runShell(options);
       if (exitResult.code !== 0) {
-        throw new RunCommandError(system.name, cmd.join(' '), output);
+        throw new RunCommandError(system.name, options.command.join(' '), output);
       }
       // save the date provisioning
       system.provisioned = new Date();
     });
   },
 
-  runShell(system, command, options = {}) {
+  runShell(system, options = {}) {
     return async(this, function* () {
       options = _.defaults(options, {
         remove: false,
@@ -75,23 +76,9 @@ var Run = {
       var image = yield this._check_image(system, options);
       var docker_opt = system.shellOptions(options);
 
-      if (_.isEmpty(options.shell)) {
-        options.shell = system.shell;
-        // Cmd from image
-        if (_.isEmpty(options.shell) && !_.isEmpty(image.Config.Cmd)) {
-          options.shell = image.Config.Cmd;
-        } else if(_.isEmpty(options.shell)) {
-          options.shell = "/bin/sh"
-        }
-      }
-
-      if (!_.isArray(options.shell)) {
-        options.shell = [options.shell];
-      }
-      command = options.shell.concat(command);
-
-      var container  = yield lazy.docker.run(system.image.name, command, docker_opt);
-      var data       = yield container.inspect();
+      var command   = this._normalizeCommand(options.command, image, system.shell);
+      var container = yield lazy.docker.run(system.image.name, command, docker_opt);
+      var data      = yield container.inspect();
 
       log.debug("[system] container shell ended: %s", container.id);
 
@@ -133,7 +120,7 @@ var Run = {
       });
 
       var docker_opt = system.daemonOptions(options);
-      var command    = docker_opt.command;
+      var command    = this._normalizeCommand(docker_opt.command, image, system.shell);
       var container  = yield lazy.docker.run(system.image.name, command, docker_opt);
 
       if (options.wait) {
@@ -264,6 +251,24 @@ var Run = {
 
       return true;
     });
+  },
+
+  _normalizeCommand(command, image, system_shell = null) {
+    command = _.clone(command);
+    var shell = command.shift();
+
+    if (_.isEmpty(shell)) {
+      shell = system_shell;
+      // Cmd from image
+      if (_.isEmpty(shell) && !_.isEmpty(image.Config) && !_.isEmpty(image.Config.Cmd)) {
+        shell = image.Config.Cmd;
+      } else if (_.isEmpty(shell)) {
+        shell = "/bin/sh";
+      }
+    }
+
+    shell = _.isArray(shell) ? shell : [shell];
+    return shell.concat(command);
   },
 
   // Wait for container/system available


### PR DESCRIPTION
But this change required some changes on how the container run command is get. Until now, `azk` used `/bin/sh -c` by default in order to run any command inside a container. However, in cases which the Docker image set a custom `CMD[...]`, this custom command was ignored and the behavior was different from the expected.
The consequences of this change is:
- For systems run on `azk start`, `/bin/sh -c` is not used (forced) anymore. Instead, the priority is: "property `command` defined in `Azkfile.js`" > "command defined by `CMD[...]` in the Docker image";
- For the command `azk shell`, the priority is: "option `--shell` passed to `azk shell`" > "property `shell` defined in `Azkfile.js`" > "command defined in `CMD [...]` in the Docker image" > "`/bin/sh`";
- The command `azk shell` offers two options to run commands:
```sh
azk shell --shell=SHELL -c CMD # => SHELL -c "CMD"
azk shell -- CMD               # => CMD
```