### PR TITLE
[Suggestions] Updating MySQL 5.6 suggestion

### DIFF
--- a/src/generator/suggestions/mysql-5.6.js
+++ b/src/generator/suggestions/mysql-5.6.js
@@ -29,17 +29,16 @@ export class Suggestion extends DefaultSuggestion {
       wait: 25,
       envs: {
         // set instances variables
-        MYSQL_ROOT_PASSWORD: "mysecretpassword",
-        MYSQL_USER         : "azk",
-        MYSQL_PASS         : "azk",
-        MYSQL_DATABASE     : "#{manifest.dir}_development",
+        MYSQL_USER          : "azk",
+        MYSQL_PASSWORD      : "azk",
+        MYSQL_DATABASE      : "#{manifest.dir}_development",
       },
       export_envs_comment: [
         'check this gist to configure your database',
         'https://gist.github.com/gullitmiranda/62082f2e47c364ef9617'
       ],
       export_envs: {
-        DATABASE_URL: "mysql2://#{envs.MYSQL_USER}:#{envs.MYSQL_PASS}@#{net.host}" +
+        DATABASE_URL: "mysql2://#{envs.MYSQL_USER}:#{envs.MYSQL_PASSWORD}@#{net.host}" +
                       ":#{net.port.data}/${envs.MYSQL_DATABASE}",
       },
     });


### PR DESCRIPTION
Updating MySQL 5.6 suggestion: `MYSQL_PASSWORD` should be used instead of `MYSQL_PASS` ([reference](https://github.com/docker-library/mysql/blob/e892e8c52485535cce5dbadaba2c579fcc805f21/5.6/docker-entrypoint.sh#L68)).

