### PR TITLE
[suggestions] Adding `node_modules` and `vendor` to laravel suggestion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## v0.16.0-rc1 - (2015-10-20)
 
+* Bug
+  * [Suggestion] Fixed high CPU usage by sync for the Laravel suggestion.
+
 * Enhancements
   * [VM] Adding configuration key `AZK_DOCKER_MONITOR` to enable or disable docker monitor. By default is `true` for Linux and `false` if is not Linux;
   * [Cli] Send env TERM if is interactive terminal;

--- a/src/generator/suggestions/php_laravel.js
+++ b/src/generator/suggestions/php_laravel.js
@@ -18,6 +18,10 @@ export class Suggestion extends DefaultSuggestion {
         'composer install',
         'npm install',
       ],
+      mounts: this.extend(this.suggestion.mounts, {
+        "/azk/#{app.dir}/node_modules": {type: 'persistent', value: "#{app.relative}/node_modules"},
+        "/azk/#{app.dir}/vendor"      : {type: 'persistent', value: "#{app.relative}/vendor"},
+      }),
     });
   }
 }


### PR DESCRIPTION
Rodrigo Rigoni was facing problems with high CPU usage by `azk sync`. The problem of the reason was that the Azkfile.js suggested to Laravel applications did not have mounts for the folders `node_modules` and `vendor`, as they are in `.gitignore`.

Just add the following lines to the application of `mounts` that the problem should be solved.:
```js
      mounts: {
        // ...
        '/azk/#{manifest.dir}/node_modules': persistent("./node_modules"),
        '/azk/#{manifest.dir}/vendor'      : persistent("./vendor"),
      },
```