### PR TITLE
[package] Improving installation script for Ubuntu and Fedora

### DIFF
--- a/docs/content/en/installation/README.md
+++ b/docs/content/en/installation/README.md
@@ -11,19 +11,7 @@ The installation process will add the `azk` command to your system path, making 
 
 ## azk express installation
 
-The easiest way to install `azk` is to use the script below. It will identify your operating system, and if it is compatible perform all installation tasks.
-
-#### via curl
-
-```sh
-curl -Ls http://azk.io/install.sh | bash
-```
-
-#### via wget
-
-```sh
-wget -qO- http://azk.io/install.sh | bash
-```
+!INCLUDE "express.md"
 
 ## Mininum requirements
 

--- a/docs/content/en/installation/linux.md
+++ b/docs/content/en/installation/linux.md
@@ -1,40 +1,98 @@
 # Linux
 
-> The easiest way to install azk is following [azk express installation](./README.html#azk-express-installation) section.
-
 !INCLUDE "warning.md"
 
 ## Requirements
 
-* Distributions (tested): Ubuntu 12.04/14.04/15.04 and Fedora 20/21/22/23
-* Architecture: 64-bits
+* **Distributions (tested)**: Ubuntu 12.04/14.04/15.04 and Fedora 20/21/22
+* **Architecture**: 64-bits
 * [Docker][docker] 1.8.1
 * Not running any services on ports `80` and `53`
 
 **Important**: If you are running any service on port `80` and/or `53` you must customize the configuration of `azk` setting the following variables `AZK_BALANCER_PORT` and `AZK_DNS_PORT` respectively, before running `azk agent start`.
 
-## Ubuntu Precise (12.04), Trusty (14.04) and Wily (15.04) (all 64-bit)
+## Installing the newest Docker version
 
-1. Install Docker:
+There are two ways to install Docker:
 
-  - Install **Docker's latest version** [docker-engine][docker_ubuntu_installation] - Docker has a `curl script` for easy installation;
-  - Include your local user in the [docker group][docker_ubuntu_root_access]; Logoff for user group settings to take effect;
-  - [Disable the use of dnsmasq][docker_ubuntu_dns];
-  - Stop dnsmasq and ensure it won't start at login:
+1. Express installation:
 
-    ``` bash
-    $ sudo service dnsmasq stop
-    $ sudo update-rc.d -f dnsmasq remove
-    ```
+  ```bash
+  $ curl -sSL https://get.docker.com/ | sh
+  # or
+  $ wget -qO- https://get.docker.com/ | sh
+  ```
 
-2. Add the Azuki keys to your local keychain:
+2. Manual installation:
+
+  - [Ubuntu][docker_ubuntu_installation]
+  - [Fedora][docker_fedora_installation]
+
+## Granting access to Docker service to your user
+
+The docker daemon binds to a Unix socket instead of a TCP port. By default that Unix socket is owned by the user root and other users can access it with sudo. For this reason, docker daemon always runs as the root user.
+
+To avoid having to use sudo when you use the docker command, create a Unix group called docker and add users to it. When the docker daemon starts, it makes the ownership of the Unix socket read/writable by the docker group.
+
+> **Warning**: The docker group is equivalent to the root user; For details on how this impacts security in your system, see [Docker Daemon Attack Surface][docker_daemon_attack_surface] for details.
+
+To create the docker group and add your user:
+
+1. Log into Ubuntu as a user with sudo privileges;
+
+2. Create the docker group and add your user
+
+  ```bash
+  $ sudo usermod -aG docker $(id -un)
+  ```
+
+3. Log out and log back in
+
+  This ensures your user is running with the correct permissions.
+
+4. Verify your work by running docker without sudo
+
+  ```bash
+  $ docker run hello-world
+  ```
+
+  If this fails with a message similar to this:
+
+  ```bash
+  Cannot connect to the Docker daemon. Is 'docker daemon' running on this host?
+  ```
+
+  Check that the `DOCKER_HOST` environment variable is not set for your shell. If it is, unset it.
+
+## Disabling dnsmasq service (Ubuntu-only)
+
+In desktop systems running Ubuntu or one of its derivatives, there is a default dns service (dnsmasq)
+that conflicts with azk built-in dns service.
+
+To solve this, it's needed to stop dnsmasq and ensure it won't be auto started after the next login.
+To do this, run:
+
+  ```bash
+  $ sudo service dnsmasq stop
+  $ sudo update-rc.d -f dnsmasq remove
+  ```
+
+## Installing azk
+
+### Express installation
+
+!INCLUDE "express.md"
+
+### Ubuntu
+
+1. Add the Azuki keys to your local keychain:
 
   ```bash
   $ sudo apt-key adv --keyserver keys.gnupg.net \
     --recv-keys 022856F6D78159DF43B487D5C82CF0628592D2C9
   ```
 
-3. Add the Azuki repository to the apt sources list:
+2. Add the Azuki repository to the apt sources list:
 
   ```bash
   # Ubuntu Precise (12.04)
@@ -50,16 +108,16 @@
     sudo tee /etc/apt/sources.list.d/azuki.list
   ```
 
-4. Update the list of packages and install azk:
+3. Update the list of packages and install azk:
 
   ```bash
   $ sudo apt-get update
   $ sudo apt-get install azk
   ```
 
-5. You can [start the azk agent](../getting-started/starting-agent.md) now, but, **make sure that the Docker service is running**;
+4. You can [start the azk agent](../getting-started/starting-agent.md) now, but, **make sure that the Docker service is running**;
 
-## Fedora 20, 21, 22 e 23
+### Fedora
 
 1. Add the Azuki keys to your local keychain:
 
@@ -71,18 +129,9 @@
 2. Add the Azuki repository:
 
   ```bash
-  # Fedora 20, 21 e 22
   $ echo "[azuki]
   name=azk
   baseurl=http://repo.azukiapp.com/fedora20
-  enabled=1
-  gpgcheck=1
-  " > /etc/yum.repos.d/azuki.repo
-
-  # Fedora 23
-  $ echo "[azuki]
-  name=azk
-  baseurl=http://repo.azukiapp.com/fedora23
   enabled=1
   gpgcheck=1
   " > /etc/yum.repos.d/azuki.repo
@@ -94,12 +143,10 @@
   $ sudo yum install azk
   ```
 
-4. Include your local user in the [docker group][docker_fedora_root_access]; Logoff for user group settings to take effect;
-
-5. You can [start the azk agent](../getting-started/starting-agent.md) now, but, **make sure that the Docker service is running**;
+4. You can [start the azk agent](../getting-started/starting-agent.md) now, but, **make sure that the Docker service is running**;
 
 
-## Other distributions
+### Other distributions
 
 Coming soon...
 

--- a/docs/content/en/installation/warning.md
+++ b/docs/content/en/installation/warning.md
@@ -1,1 +1,1 @@
-_Upgrade notice_: If you already have `azk` installed, prior to the `0.6.0` release, follow [these steps](upgrading.md#upgrading-from-azk--051) before moving forward. If you do not have `azk` installed ignore this warning and continue the installation normally.
+**Upgrade notice**: If you already have `azk` installed, prior to the `0.6.0` release, follow [these steps](upgrading.md#upgrading-from-azk--051) before moving forward. If you do not have `azk` installed ignore this warning and continue the installation normally.

--- a/docs/content/links.md
+++ b/docs/content/links.md
@@ -5,10 +5,9 @@
 [docker_remote_api]: https://docs.docker.com/reference/api/docker_remote_api/
 [docker_remote_api_create]: https://docs.docker.com/reference/api/docker_remote_api_v1.20/#create-a-container
 [docker_install]: https://docs.docker.com/installation/#installation
-[docker_ubuntu_installation]: http://docs.docker.com/engine/installation/ubuntulinux/#installation
-[docker_ubuntu_dns]: https://docs.docker.com/installation/ubuntulinux/#configure-a-dns-server-for-use-by-docker
-[docker_ubuntu_root_access]: https://docs.docker.com/engine/installation/ubuntulinux/#create-a-docker-group
-[docker_fedora_root_access]: http://docs.docker.com/engine/installation/fedora/#create-a-docker-group
+[docker_ubuntu_installation]: http://docs.docker.com/engine/installation/ubuntulinux/
+[docker_fedora_installation]: http://docs.docker.com/engine/installation/fedora/
+[docker_daemon_attack_surface]: https://docs.docker.com/engine/articles/security/#docker-daemon-attack-surface
 
 [postgres]: http://www.postgresql.org/
 [redis]: http://redis.io/

--- a/docs/content/pt-BR/installation/README.md
+++ b/docs/content/pt-BR/installation/README.md
@@ -11,19 +11,7 @@ A instalação vai adicionar o comando `azk` ao path do sistema. Isso torna o co
 
 ## Instalação expressa do azk
 
-A forma mais fácil de instalar o `azk` é utilizar o script abaixo. Ele vai identificar o sistema operacional que está usando e, se for compatível, realizar todos os processos de instalação.
-
-#### via curl
-
-```sh
-curl -Ls http://azk.io/install.sh | bash
-```
-
-#### via wget
-
-```sh
-wget -qO- http://azk.io/install.sh | bash
-```
+!INCLUDE "express.md"
 
 ## Requisitos mínimos de instalação
 

--- a/docs/content/pt-BR/installation/warning.md
+++ b/docs/content/pt-BR/installation/warning.md
@@ -1,1 +1,1 @@
-_Aviso sobre upgrade_: Se você já tem o `azk` nas versões anteriores a `0.6.0` instalado, siga [estes passos](upgrading.md#atualizando-a-partir-azk--051) antes de continuar. Se você não tem o `azk` instalado ignore este aviso e continue a instalação normalmente.
+**Aviso sobre upgrade**: Se você já tem o `azk` nas versões anteriores a `0.6.0` instalado, siga [estes passos](upgrading.md#atualizando-a-partir-azk--051) antes de continuar. Se você não tem o `azk` instalado ignore este aviso e continue a instalação normalmente.

--- a/shared/scripts/install.sh
+++ b/shared/scripts/install.sh
@@ -84,6 +84,12 @@ err() { log err $@; }
 
 main(){
 
+  if [[ "$1" == "stage" ]]; then
+    AZUKIAPP_REPO_URL="http://repo-stage.azukiapp.com"
+  else
+    AZUKIAPP_REPO_URL="http://repo.azukiapp.com"
+  fi
+
   step "Checking platform"
 
   # Detecting PLATFORM and ARCH
@@ -213,7 +219,7 @@ install_azk_ubuntu() {
 
   echo "" 1>&2
   super apt-key adv --keyserver keys.gnupg.net --recv-keys 022856F6D78159DF43B487D5C82CF0628592D2C9 1>/dev/null 2>&1
-  echo "deb [arch=amd64] http://repo.azukiapp.com ${UBUNTU_CODENAME} main" | super tee /etc/apt/sources.list.d/azuki.list 1>/dev/null 2>&1
+  echo "deb [arch=amd64] ${AZUKIAPP_REPO_URL} ${UBUNTU_CODENAME} main" | super tee /etc/apt/sources.list.d/azuki.list 1>/dev/null 2>&1
   super apt-get update 1>/dev/null
   super apt-get install azk -y 1>/dev/null
 
@@ -226,11 +232,11 @@ install_azk_fedora() {
   step "Installing azk"
 
   echo "" 1>&2
-  super rpm --import 'http://repo.azukiapp.com/keys/azuki.asc' 1>/dev/null
+  super rpm --import "${AZUKIAPP_REPO_URL}/keys/azuki.asc" 1>/dev/null
 
   echo "[azuki]
 name=azk
-baseurl=http://repo.azukiapp.com/fedora${FEDORA_VERSION}
+baseurl=${AZUKIAPP_REPO_URL}/fedora${FEDORA_VERSION}
 enabled=1
 gpgcheck=1
 " | super tee /etc/yum.repos.d/azuki.repo 1>/dev/null 2>&1
@@ -329,4 +335,4 @@ success() {
   exit 0
 }
 
-main
+main "${@}"


### PR DESCRIPTION
This PR improves the `install.sh` script:

- Checking Docker installation before adding Azuki apt repo in Ubuntu;
- Using 'dnf' package manager for Fedora 23;
- Replacing 'docker' with 'Docker';
- Adding 'stage' repo as an option;