### PR TITLE
[generators] Fixing replace evidences in `Court`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Bug
+  * [Generators] Fixing replace evidences in `Court`;
+
 ## v0.16.1 - (2015-11-08)
 
 * Enhancements

--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -111,6 +111,7 @@ var Helpers = {
 
       var context = event.context || "agent";
       var keys    = ["status", context];
+      var tKey;
 
       switch (event.type) {
         case "status":
@@ -137,13 +138,13 @@ var Helpers = {
           }
           break;
         case "wait_port":
-          var tKey = ["status", event.system, "wait"];
+          tKey = ["status", event.system, "wait"];
           log.info_t(tKey, event);
           cmd.ok(tKey, event);
           break;
         case "try_connect":
           if (context === "balancer") {
-            var tKey = [...keys].concat("progress");
+            tKey = [...keys].concat("progress");
             log.info_t(tKey, event);
             cmd.ok(tKey, event);
           }

--- a/src/generator/court.js
+++ b/src/generator/court.js
@@ -192,22 +192,33 @@ export class Court extends UIProxy {
     var groupedByDir = this._getEvidencesByFolder();
 
     _.forEach(groupedByDir, function(evidences) {
+      // var result = [];
+      var filter_by_name = [];
+
       _.forEach(evidences, function(evidence) {
-        // this evidence can replace
-        if (_.has(evidence, 'replaces')) {
-          // try find dependency to remove
-          _.remove(evidences, function(dirItem) {
-            var willRemove = _.contains(evidence.replaces, dirItem.name);
-            if (willRemove) {
-              log.debug('Court._replacesEvidences', {
-                name             : evidence.ruleName,
-                relevantFile     : evidence.fullpath,
-                evidenceReplaces : evidence.replaces,
-                willReplaces     : dirItem.ruleName });
-            }
-            return willRemove;
+        _.forEach(evidences, function(item) {
+          // checks that this evidence should be replaced
+          if (_.has(item, 'replaces') && _.contains(item.replaces, evidence.name)) {
+            filter_by_name.push(evidence.name);
+          }
+        });
+      });
+
+      filter_by_name = _.uniq(filter_by_name);
+
+      // remove evidences to be replaced
+      _.remove(evidences, function(evidence) {
+        var willRemove = _.contains(filter_by_name, evidence.name);
+
+        if (willRemove) {
+          log.debug('Court._replacesEvidences', {
+            name             : evidence.ruleName,
+            relevantFile     : evidence.fullpath,
+            evidenceReplaces : evidence.replaces,
+            willReplaces     : filter_by_name,
           });
         }
+        return willRemove;
       });
     });
 


### PR DESCRIPTION
At the time of checking, some evidence is not removed as it should, thus generating, invalid `Azkfile`.