### PR TITLE
[Package] Improving install.sh: installing Docker before azk if it's not present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Enhancements
+  * [Installation] Installation script (`install.sh`) now installs Docker automatically;
+
 ## v0.16.2 - (2015-11-17)
 
 * Enhancements

--- a/docs/content/en/installation/express.md
+++ b/docs/content/en/installation/express.md
@@ -7,5 +7,5 @@ $ curl -sSL http://azk.io/install.sh | bash
 # or
 
 # recommended for Linux users
-$ wget -nv -O- -t 2 -T 10 http://azk.io/install.sh | bash
+$ wget -nv http://azk.io/install.sh -O- -t 2 -T 10 | bash
 ```

--- a/docs/content/en/installation/express.md
+++ b/docs/content/en/installation/express.md
@@ -2,10 +2,10 @@ The easiest way to install `azk` is to use the script below. It will identify yo
 ​
 ```bash
 # recommended for Mac users
-$ curl -Ls http://azk.io/install.sh | bash
+$ curl -sSL http://azk.io/install.sh | bash
 
 # or
 
 # recommended for Linux users
-$ wget -qO- http://azk.io/install.sh | bash
+$ wget -nv -O- -t 2 -T 10 http://azk.io/install.sh | bash
 ```

--- a/docs/content/en/installation/linux.md
+++ b/docs/content/en/installation/linux.md
@@ -20,7 +20,7 @@ There are two ways to install Docker:
   ```bash
   $ curl -sSL https://get.docker.com/ | sh
   # or
-  $ wget -nv -O- -t 2 -T 10 https://get.docker.com/ | sh
+  $ wget -nv https://get.docker.com/ -O- -t 2 -T 10 | sh
   ```
 
 2. Manual installation:

--- a/docs/content/en/installation/linux.md
+++ b/docs/content/en/installation/linux.md
@@ -20,7 +20,7 @@ There are two ways to install Docker:
   ```bash
   $ curl -sSL https://get.docker.com/ | sh
   # or
-  $ wget -qO- https://get.docker.com/ | sh
+  $ wget -nv -O- -t 2 -T 10 https://get.docker.com/ | sh
   ```
 
 2. Manual installation:

--- a/docs/content/pt-BR/installation/express.md
+++ b/docs/content/pt-BR/installation/express.md
@@ -2,10 +2,10 @@ A forma mais fácil de instalar o `azk` é utilizar o script abaixo. Ele vai ide
 
 ```bash
 # Recomendado para usuários de Mac
-$ curl -Ls http://azk.io/install.sh | bash
+$ curl -sSL http://azk.io/install.sh | bash
 
 # ou
 
 # Recomendado para usuários de Linux
-$ wget -qO- http://azk.io/install.sh | bash
+$ wget -nv -O- -t 2 -T 10 http://azk.io/install.sh | bash
 ```

--- a/docs/content/pt-BR/installation/express.md
+++ b/docs/content/pt-BR/installation/express.md
@@ -7,5 +7,5 @@ $ curl -sSL http://azk.io/install.sh | bash
 # ou
 
 # Recomendado para usuários de Linux
-$ wget -nv -O- -t 2 -T 10 http://azk.io/install.sh | bash
+$ wget -nv http://azk.io/install.sh -O- -t 2 -T 10 | bash
 ```

--- a/docs/content/pt-BR/installation/linux.md
+++ b/docs/content/pt-BR/installation/linux.md
@@ -20,7 +20,7 @@ Existem duas formas de instalação do Docker:
   ```bash
   $ curl -sSL https://get.docker.com/ | sh
   # ou
-  $ wget -qO- https://get.docker.com/ | sh
+  $ wget -nv -O- -t 2 -T 10 https://get.docker.com/ | sh
   ```
 
 2. Instalação manual:

--- a/docs/content/pt-BR/installation/linux.md
+++ b/docs/content/pt-BR/installation/linux.md
@@ -20,7 +20,7 @@ Existem duas formas de instalação do Docker:
   ```bash
   $ curl -sSL https://get.docker.com/ | sh
   # ou
-  $ wget -nv -O- -t 2 -T 10 https://get.docker.com/ | sh
+  $ wget -nv https://get.docker.com/ -O- -t 2 -T 10 | sh
   ```
 
 2. Instalação manual:

--- a/shared/scripts/install.sh
+++ b/shared/scripts/install.sh
@@ -87,7 +87,10 @@ log() {
   fi
 }
 
-step() { log info -n $@ | sed -e :a -e 's/^.\{1,72\}$/&./;ta'; }
+step() {
+  local title=$( log info -n $@ | sed -e :a -e 's/^.\{1,72\}$/&./;ta' )
+  echo -n $title
+}
 
 step_wait() {
   if [[ ! -z ${@} ]]; then
@@ -365,17 +368,24 @@ install_azk_mac_osx() {
     fail
   fi
 
+
+  step "Checking for Homebrew installation"
   if command_exists brew; then
     step_done
-    step "Installing azk"
-    brew install azukiapp/azk/azk
-    step_done
+    debug "Homebrew detected"
   else
     step_fail
     add_report "Homebrew not found"
     add_report "  In order to install azk you must have Homebrew on Mac OS X systems."
     add_report "  Refer to: http://docs.azk.io/en/installation/mac_os_x.html"
     fail
+  fi
+
+  step_wait "Installing azk"
+  if brew install azukiapp/azk/azk; then
+    step_done
+  else
+    step_fail
   fi
 }
 

--- a/shared/scripts/install.sh
+++ b/shared/scripts/install.sh
@@ -3,12 +3,30 @@
 ROOT_UID=0
 NEWLINE=$'\n'
 
-super() {
-  debug "${@}"
+command_exists() {
+  command -v "${@}" > /dev/null 2>&1
+}
+
+run_super() {
   if [[ $UID != $ROOT_UID ]]; then
     sudo "${@}"
   else
     $@
+  fi
+}
+
+super() {
+  if [[ "$1" == "-v" ]]; then
+    shift
+    debug "${@}"
+    run_super "${@}" > /dev/null
+  elif echo "$1" | grep -P "\-v+"; then
+    shift
+    debug "${@}"
+    run_super "${@}"
+  else
+    debug "${@}"
+    run_super "${@}" > /dev/null 2>&1
   fi
 }
 
@@ -37,6 +55,7 @@ log() {
   debug)
     local color="%{blue}"
     local stderr=true
+    local identation="  "
     ;;
   info)
     local color="%{green}"
@@ -62,17 +81,32 @@ log() {
   fi
 
   if [[ -z ${stderr} ]]; then
-    echo $opts "$(escape "${color}[azk]${tag}%{reset} $@")"
+    echo $opts "$(escape "${color}[azk]${tag}%{reset} ${identation}$@")"
   else
-    echo $opts "$(escape "${color}[azk]${tag}%{reset} $@")" 1>&2
+    echo $opts "$(escape "${color}[azk]${tag}%{reset} ${identation}$@")" 1>&2
   fi
 }
 
 step() { log info -n $@ | sed -e :a -e 's/^.\{1,72\}$/&./;ta'; }
 
-step_done() { echo "[ DONE ]"; }
+step_wait() {
+  if [[ ! -z ${@} ]]; then
+    STEP_WAIT="${@}"
+    step "${STEP_WAIT}"
+  fi
+  echo "$(escape "%{blue}[ WAIT ]%{reset}")"
+}
 
-step_fail() { echo "[ FAIL ]"; }
+check_wait() {
+  if [[ ! -z ${STEP_WAIT} ]]; then
+    step "${STEP_WAIT}"
+    STEP_WAIT=
+  fi
+}
+
+step_done() { check_wait && echo "$(escape "%{green}[ DONE ]%{reset}")"; }
+
+step_fail() { check_wait && echo "$(escape "%{red}[ FAIL ]%{reset}")"; }
 
 debug() { log debug $@; }
 
@@ -113,7 +147,7 @@ main(){
   fi
 
   step_done
-  debug "  Detected platform: $PLATFORM, $ARCH"
+  debug "Detected platform: $PLATFORM, $ARCH"
 
   if [[ $PLATFORM == "darwin" ]]; then
     OS="mac"
@@ -134,7 +168,7 @@ main(){
     OS=$ID
     OS_VERSION=$VERSION_ID
 
-    debug "  Detected Linux: $OS, $OS_VERSION"
+    debug "Detected distribution: $OS, $OS_VERSION"
 
     # Check if linux distribution is compatible?
     if [[ $ID != "ubuntu" && $ID != "fedora" ]]; then
@@ -144,7 +178,9 @@ main(){
 
     # Check if is SUDO
     if [[ $UID != $ROOT_UID ]]; then
-      super echo "sudo enabled" > /dev/null
+      step_wait "Enabling sudo"
+      super echo "sudo enabled"
+      step_done
     fi
 
     if [[ $ID == "ubuntu" ]]; then
@@ -175,11 +211,17 @@ main(){
 
     if [[ $ID == "fedora" ]]; then
       case $OS_VERSION in
-        "20"|"21"|"22" )
-          FEDORA_VERSION="20"
+        "20"|"21" )
+          FEDORA_PKG_VERSION="20"
+          FEDORA_PKG_MANAGER="yum"
+          ;;
+        "22" )
+          FEDORA_PKG_VERSION="20"
+          FEDORA_PKG_MANAGER="dnf"
           ;;
         "23" )
-          FEDORA_VERSION="23"
+          FEDORA_PKG_VERSION="23"
+          FEDORA_PKG_MANAGER="dnf"
           ;;
         * )
           add_report "  Unsupported Fedora version."
@@ -199,11 +241,11 @@ main(){
 check_docker_installation() {
   step "Checking Docker installation"
 
-  if hash docker 2>/dev/null; then
+  if command_exists docker; then
     step_done
-    debug '  Docker is installed, skipping Docker installation.'
-    debug '    To update Docker, run the command bellow:'
-    debug '    $ curl -sSL https://get.docker.com/ | sh'
+    debug "Docker is installed, skipping Docker installation."
+    debug "  To update Docker, run the command bellow:"
+    debug "  $ curl -sSL https://get.docker.com/ | sh"
   else
     step_fail
     add_report 'azk needs Docker to be installed.'
@@ -216,54 +258,51 @@ check_docker_installation() {
 install_azk_ubuntu() {
   check_docker_installation
 
-  step "Installing azk"
+  step_wait "Installing azk"
 
-  echo "" 1>&2
-  super apt-key adv --keyserver keys.gnupg.net --recv-keys 022856F6D78159DF43B487D5C82CF0628592D2C9 1>/dev/null 2>&1
-  echo "deb [arch=amd64] ${AZUKIAPP_REPO_URL} ${UBUNTU_CODENAME} main" | super tee /etc/apt/sources.list.d/azuki.list 1>/dev/null 2>&1
-  super apt-get update 1>/dev/null
-  super apt-get install azk -y 1>/dev/null
-
-  step_done
+  if super apt-key adv --keyserver keys.gnupg.net --recv-keys 022856F6D78159DF43B487D5C82CF0628592D2C9 && \
+     echo "deb [arch=amd64] ${AZUKIAPP_REPO_URL} ${UBUNTU_CODENAME} main" | super tee /etc/apt/sources.list.d/azuki.list && \
+     super -v apt-get update && \
+     super -v apt-get install -y azk; then
+    step_done
+  else
+    step_fail
+    add_report 'Failed to install azk. Try again later.'
+    fail
+  fi
 }
 
 install_azk_fedora() {
   check_docker_installation
 
-  step "Installing azk"
+  step_wait "Installing azk"
 
-  echo "" 1>&2
-  super rpm --import "${AZUKIAPP_REPO_URL}/keys/azuki.asc" 1>/dev/null
-
-  echo "[azuki]
+  if super -v rpm --import "${AZUKIAPP_REPO_URL}/keys/azuki.asc" && \
+     echo "[azuki]
 name=azk
-baseurl=${AZUKIAPP_REPO_URL}/fedora${FEDORA_VERSION}
+baseurl=${AZUKIAPP_REPO_URL}/fedora${FEDORA_PKG_VERSION}
 enabled=1
 gpgcheck=1
-" | super tee /etc/yum.repos.d/azuki.repo 1>/dev/null 2>&1
-
-  if [[ "${FEDORA_VERSION}" == "20" ]]; then
-    FEDORA_PKG_MANAGER="yum"
+" | super tee /etc/yum.repos.d/azuki.repo && \
+     super -v ${FEDORA_PKG_MANAGER} install -y azk; then
+    step_done
   else
-    FEDORA_PKG_MANAGER="dnf"
+    step_fail
+    add_report 'Failed to install azk. Try again later.'
+    fail
   fi
-
-  super ${FEDORA_PKG_MANAGER} install azk -y 1>/dev/null
-
-  step_done
 }
 
 add_user_to_docker_group() {
-  if groups `whoami` | grep &>/dev/null '\docker\b'; then
+  if groups `whoami` | grep -q '\docker\b'; then
     return 0;
   fi
 
-  step "Adding current user to Docker user group"
+  step_wait "Adding current user to Docker user group"
 
-  echo "" 1>&2
-  super groupadd docker 1>/dev/null
-  super gpasswd -a `whoami` docker 1>/dev/null
-  super service docker restart 1>/dev/null
+  super groupadd docker
+  super gpasswd -a `whoami` docker
+  super service docker restart
 
   step_done
 
@@ -273,10 +312,10 @@ add_user_to_docker_group() {
 }
 
 disable_dnsmasq() {
-  step "Disabling dnsmasq"
+  step_wait "Disabling dnsmasq"
 
-  super service dnsmasq stop 1>/dev/null 2>&1
-  super update-rc.d -f dnsmasq remove 1>/dev/null 2>&1
+  super service dnsmasq stop
+  super update-rc.d -f dnsmasq remove
 
   add_report "Note: dnsmasq service was disabled."
   step_done
@@ -284,7 +323,7 @@ disable_dnsmasq() {
 
 install_azk_mac_osx() {
   step "Checking for VirtualBox installation"
-  if hash VBoxManage 2>/dev/null; then
+  if command_exists VBoxManage; then
     step_done
     debug "Virtual Box detected"
   else
@@ -295,7 +334,7 @@ install_azk_mac_osx() {
     fail
   fi
 
-  if hash brew 2>/dev/null; then
+  if command_exists brew; then
     step_done
     step "Installing azk"
     brew install azukiapp/azk/azk

--- a/shared/scripts/install.sh
+++ b/shared/scripts/install.sh
@@ -11,7 +11,7 @@ run_super() {
   if [[ $UID != $ROOT_UID ]]; then
     sudo "${@}"
   else
-    $@
+    "${@}"
   fi
 }
 
@@ -265,7 +265,7 @@ install_docker() {
   sleep 10
 
   step_wait "Installing Docker"
-  if super bash -c "${fetch_cmd} 'https://get.docker.com/' | sh"; then
+  if super bash -c "${fetch_cmd} https://get.docker.com/ | sh"; then
     step_done
   else
     step_fail

--- a/shared/scripts/install.sh
+++ b/shared/scripts/install.sh
@@ -244,9 +244,9 @@ main(){
 curl_or_wget() {
   CURL_BIN="curl"; WGET_BIN="wget"
   if command_exists ${CURL_BIN}; then
-    echo "${CURL_BIN} -sL"
+    echo "${CURL_BIN} -sSL"
   elif command_exists ${WGET_BIN}; then
-    echo "${WGET_BIN} -qO-"
+    echo "${WGET_BIN} -nv -O- -t 2 -T 10"
   fi
 }
 


### PR DESCRIPTION
When running `install.sh` (from http://www.azk.io/install.sh), it now will check for Docker. If it's not present, now it runs the script from https://get.docker.com/ in order to get it installed.