### PR TITLE
[Cli] Fixing `ui.isInteractive()` not using option `--quiet`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Bug
+  * [Cli] Fixing `ui.isInteractive()` not using option `--quiet`;
+
 ## v0.16.3 - (2015-12-08)
 
 * Enhancements

--- a/src/cli/cli_controller.js
+++ b/src/cli/cli_controller.js
@@ -4,20 +4,23 @@ import { _, log } from 'azk';
 export class CliController extends RouterController {
   constructor(...args) {
     super(...args);
-    this._verbose_nivel = 0;
+    this._verbose_level = 0;
   }
 
-  configure(opts) {
-    opts = _.merge({}, opts, (this.normalized_params && this.normalized_params.options))
+  _configure(opts) {
+    opts = _.merge({}, opts, (this.normalized_params && this.normalized_params.options));
 
-    // Set log level
+    // Set verbose level
     if (opts.verbose) {
-      this._verbose_nivel = opts.verbose;
+      this._verbose_level = opts.verbose;
     }
+
+    // Set console log level
     if (opts.log) {
       log.setConsoleLevel(opts.log);
     }
 
+    // Save quiet mode in ui
     if (opts.quiet && this.ui) {
       this.ui.setInteractive(false);
     }
@@ -32,7 +35,7 @@ export class CliController extends RouterController {
   }
 
   verbose_msg(nivel, func, ...args) {
-    if (nivel <= this._verbose_nivel) {
+    if (nivel <= this._verbose_level) {
       if (typeof(func) == "function") {
         return func(...args);
       } else {
@@ -41,16 +44,10 @@ export class CliController extends RouterController {
     }
   }
 
-  /*
-    Callbacks
-   */
-  before_action(action_name, opts, ...args) {
-    return super.before_action(action_name, opts, ...args);
-  }
-
+  // Callbacks
   run_action(action_name, opts, ...args) {
-    var options = _.isObject(action_name) ? action_name : opts;
-    this.configure(_.isObject(action_name) ? action_name : opts);
+    let options = _.isObject(action_name) ? action_name : opts;
+    this._configure(options);
     return super.run_action(action_name, opts, ...args);
   }
 }

--- a/src/cli/cli_tracker_controller.js
+++ b/src/cli/cli_tracker_controller.js
@@ -1,6 +1,6 @@
+import { _ } from 'azk';
 import { CliController } from 'azk/cli/cli_controller';
 import { Helpers } from 'azk/cli/helpers';
-import { _ } from 'azk';
 import { promiseResolve } from 'azk/utils/promises';
 import { default as tracker } from 'azk/utils/tracker';
 
@@ -11,8 +11,9 @@ export class CliTrackerController extends CliController {
     this.ui.tracker = tracker;
   }
 
+  // callbacks
   before_action(...args) {
-    return this.before_action_tracker(...args).then(() => {
+    return this._action_tracker(...args).then(() => {
       return super.before_action(...args);
     });
   }
@@ -23,7 +24,7 @@ export class CliTrackerController extends CliController {
     });
   }
 
-  before_action_tracker(action_name, params) {
+  _action_tracker(action_name, params) {
     return Helpers
       .askPermissionToTrack(this.ui)
       .then((shouldTrack) => {

--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -13,7 +13,7 @@ var Helpers = {
     return lazy.AgentClient
       .status()
       .then((status) => {
-        if (!status.agent && !cli.non_interactive) {
+        if (!status.agent && !cli.isInteractive()) {
           var question = {
             type    : 'confirm',
             name    : 'start',
@@ -33,14 +33,14 @@ var Helpers = {
       });
   },
 
-  askPermissionToTrack(cli, force = false) {
+  askPermissionToTrack(ui, force = false) {
     return async(this, function* () {
       // check if user already answered
-      var trackerPermission = cli.tracker.loadTrackerPermission(); // Boolean
+      var trackerPermission = ui.tracker.loadTrackerPermission(); // Boolean
 
       var should_ask_permission = (force || typeof trackerPermission === 'undefined');
       if (should_ask_permission) {
-        if (!cli.isInteractive()) { return false; }
+        if (!ui.isInteractive()) { return false; }
 
         var question = {
           type    : 'confirm',
@@ -49,14 +49,14 @@ var Helpers = {
           default : 'Y'
         };
 
-        var answers = yield cli.prompt(question);
-        cli.tracker.saveTrackerPermission(answers.track_ask);
+        var answers = yield ui.prompt(question);
+        ui.tracker.saveTrackerPermission(answers.track_ask);
 
         if (answers.track_ask) {
-          cli.ok('analytics.message_optIn');
-          yield cli.tracker.sendEvent("tracker", { event_type: "accepted" });
+          ui.ok('analytics.message_optIn');
+          yield ui.tracker.sendEvent("tracker", { event_type: "accepted" });
         } else {
-          cli.ok('analytics.message_optOut', {command: 'azk config track-toggle'});
+          ui.ok('analytics.message_optOut', {command: 'azk config track-toggle'});
         }
 
         return answers.track_ask;

--- a/src/cli/helpers.js
+++ b/src/cli/helpers.js
@@ -13,7 +13,7 @@ var Helpers = {
     return lazy.AgentClient
       .status()
       .then((status) => {
-        if (!status.agent && !cli.isInteractive()) {
+        if (!status.agent && cli.isInteractive()) {
           var question = {
             type    : 'confirm',
             name    : 'start',

--- a/src/cli/ui.js
+++ b/src/cli/ui.js
@@ -24,7 +24,7 @@ var azk_deprecate = 'azk'.cyan;
 var UI = {
   isUI: true,
   t: t,
-  non_interactive: false,
+  _interactive: true,
 
   dir(...args) {
     console.dir(...args);
@@ -169,11 +169,11 @@ var UI = {
   },
 
   setInteractive(value) {
-    this.non_interactive = value;
+    this._interactive = value;
   },
 
   isInteractive() {
-    return this.non_interactive === false && this.stdout().isTTY === true;
+    return this._interactive === true && this.stdout().isTTY === true;
   },
 
   outputColumns() {

--- a/src/cli/ui.js
+++ b/src/cli/ui.js
@@ -24,6 +24,7 @@ var azk_deprecate = 'azk'.cyan;
 var UI = {
   isUI: true,
   t: t,
+  non_interactive: false,
 
   dir(...args) {
     console.dir(...args);
@@ -167,8 +168,12 @@ var UI = {
     });
   },
 
+  setInteractive(value) {
+    this.non_interactive = value;
+  },
+
   isInteractive() {
-    return this.stdout().isTTY === true;
+    return this.non_interactive === false && this.stdout().isTTY === true;
   },
 
   outputColumns() {


### PR DESCRIPTION
The `UI` was not taking into consideration the `--quiet` sent as argument in the cli.

eg:
```shell
$ azk agent stop
$ azk status --quiet
azk: azk agent is required but is not running (try `azk agent status`)
```
