### PR TITLE
[Package] Removing bashisms from azk installation script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Suggestions] Adding `php artisan migrate` to php_laravel;
   * [Suggestions] Changing postgres version to 9.4 and env prefix to `POSTGRES`;
   * [Docs] Adding instructions about "Expandable Properties";
+  * [Package] Installation script (`install.sh`) now supports other shells besides `bash` #583;
 
 ## v0.16.3 - (2015-12-08)
 

--- a/docs/content/en/installation/express.md
+++ b/docs/content/en/installation/express.md
@@ -2,10 +2,10 @@ The easiest way to install `azk` is to use the script below. It will identify yo
 ​
 ```bash
 # recommended for Mac users
-$ curl -sSL http://azk.io/install.sh | bash
+$ curl -sSL http://azk.io/install.sh | sh
 
 # or
 
 # recommended for Linux users
-$ wget -nv http://azk.io/install.sh -O- -t 2 -T 10 | bash
+$ wget -nv http://azk.io/install.sh -O- -t 2 -T 10 | sh
 ```

--- a/docs/content/pt-BR/installation/express.md
+++ b/docs/content/pt-BR/installation/express.md
@@ -2,10 +2,10 @@ A forma mais fácil de instalar o `azk` é utilizar o script abaixo. Ele vai ide
 
 ```bash
 # Recomendado para usuários de Mac
-$ curl -sSL http://azk.io/install.sh | bash
+$ curl -sSL http://azk.io/install.sh | sh
 
 # ou
 
 # Recomendado para usuários de Linux
-$ wget -nv http://azk.io/install.sh -O- -t 2 -T 10 | bash
+$ wget -nv http://azk.io/install.sh -O- -t 2 -T 10 | sh
 ```


### PR DESCRIPTION
This PR closes #578.

This changes allow installing azk using another shell besides `bash`:

```
curl -sSL http://azk.io/install.sh | sh
```

**Tested shells:**

- [x] Bash
- [x] Dash
- [x] Zsh
- [x] Ksh
- [x] Fish