### PR TITLE
[Crash] Adding errors on agent startup and completion to the bug report.

### DIFF
--- a/spec/cmds/info_spec.js
+++ b/spec/cmds/info_spec.js
@@ -43,7 +43,7 @@ describe('Azk cli, info controller, run in an', function() {
       return cli.run(doc_opts, run_options).then((code) => {
         h.expect(code).to.equal(0);
         h.expect(options).to.have.property('info', true);
-        h.expect(options).to.have.property('no-color', 1);
+        h.expect(options).to.have.property('no-color', true);
         h.expect(outputs[0]).to.match(/^manifest/);
       });
     });

--- a/src/agent/index.js
+++ b/src/agent/index.js
@@ -2,10 +2,11 @@ import { _, config, log, lazy_require, set_config, fsAsync } from 'azk';
 import { defer, async, promiseResolve } from 'azk/utils/promises';
 import { publish } from 'azk/utils/postal';
 import { Pid } from 'azk/utils/pid';
-import { AzkError, AgentStopError } from 'azk/utils/errors';
+import { AgentStopError } from 'azk/utils/errors';
 
 var lazy = lazy_require({
   Server : ['azk/agent/server'],
+  error_handler: ['azk/cli/error_handler', 'handler'],
 });
 
 var blank_observer = {
@@ -35,15 +36,15 @@ var Agent = {
         this.change_status('starting');
         this
           .processWrapper(options.configs || {} )
-          .catch((err) => {
-            if (!(err instanceof AzkError)) {
-              err = err.stack ? err.stack : err.toString();
-            }
-            this.change_status("error", err);
-            if (!this.stopping) {
+          .catch((error) => {
+            return lazy.error_handler(error).then(() => false);
+          })
+          .then((result) => {
+            if (!result && !this.stopping) {
               this.stopping = true;
-              this.gracefullyStop();
+              return this.gracefullyStop();
             }
+            return 0;
           });
       }
     });
@@ -76,9 +77,7 @@ var Agent = {
       })
       .catch((error) => {
         try { pid.unlink(); } catch (e) {}
-        error = error.stack || error;
-        log.error('[agent] agent stop error: ' + error);
-        return 1;
+        return lazy.error_handler(error).then(() => 1);
       })
       .then(this.observer.resolve);
   },
@@ -139,6 +138,7 @@ var Agent = {
         publish("agent.agent.started.event", {});
         log.info("[azk] agent start with pid: " + process.pid);
       }
+      return true;
     });
   },
 };

--- a/src/cli/cli_controller.js
+++ b/src/cli/cli_controller.js
@@ -26,7 +26,7 @@ export class CliController extends RouterController {
     }
 
     // Force no colors in output
-    if (opts['no-color'] === 1) {
+    if (opts['no-color']) {
       this.ui.useColours(false);
     }
 

--- a/src/cli/error_handler.js
+++ b/src/cli/error_handler.js
@@ -3,6 +3,7 @@ import { AzkError, MustAcceptTermsOfUse } from 'azk/utils/errors';
 import { async } from 'azk/utils/promises';
 
 var lazy = lazy_require({
+  UI              : ['azk/cli/ui'],
   CrashReport     : ['azk/utils/crash_report'],
   tracker         : ['azk/utils/tracker', 'default'],
   AskSendErrorView: ['azk/cli/views/ask_send_error_view'],
@@ -10,7 +11,7 @@ var lazy = lazy_require({
 
 function init_options(options) {
   if (isBlank(options.view)) {
-    options.view = new lazy.AskSendErrorView(options.ui);
+    options.view = new lazy.AskSendErrorView(options.ui || lazy.UI);
   }
 
   return [options.view, options.tracker || lazy.tracker];

--- a/src/config.js
+++ b/src/config.js
@@ -181,15 +181,18 @@ var options = mergeConfig({
     },
   },
   development: {
+    flags: {
+      require_accept_use_terms: envs('AZK_REQUIRE_TERMS', false),
+    },
     logs_level: {
       console: (envs('AZK_DEBUG') ? 'debug' : envs('AZK_OUTPUT_LOG_LEVEL', 'warn')),
       file: envs('AZK_LOG_LEVEL', 'debug'),
     },
     tracker: {
       // jscs:disable maximumLineLength
-      disable           : envs('AZK_DISABLE_TRACKER', false),
-      projectId         : envs('AZK_KEEN_PROJECT_ID', '5526968d672e6c5a0d0ebec6'),
-      writeKey          : envs('AZK_KEEN_WRITE_KEY', '5dbce13e376070e36eec0c7dd1e7f42e49f39b4db041f208054617863832309c14a797409e12d976630c3a4b479004f26b362506e82a46dd54df0c977a7378da280c05ae733c97abb445f58abb56ae15f561ac9ad774cea12c3ad8628d896c39f6e702f6b035541fc1a562997cb05768'),
+      disable  : envs('AZK_DISABLE_TRACKER', false),
+      projectId: envs('AZK_KEEN_PROJECT_ID', '5526968d672e6c5a0d0ebec6'),
+      writeKey : envs('AZK_KEEN_WRITE_KEY', '5dbce13e376070e36eec0c7dd1e7f42e49f39b4db041f208054617863832309c14a797409e12d976630c3a4b479004f26b362506e82a46dd54df0c977a7378da280c05ae733c97abb445f58abb56ae15f561ac9ad774cea12c3ad8628d896c39f6e702f6b035541fc1a562997cb05768'),
       // jscs:enable maximumLineLength
     },
     report: {
@@ -220,16 +223,16 @@ var options = mergeConfig({
       namespace: 'test',
     },
     docker: {
-      namespace   : 'azk.test',
-      repository  : 'azk_test',
-      build_name  : 'azkbuildtest',
-      image_empty : 'cevich/empty_base_image:latest',
+      namespace  : 'azk.test',
+      repository : 'azk_test',
+      build_name : 'azkbuildtest',
+      image_empty: 'cevich/empty_base_image:latest',
     },
     tracker: {
       disable: true,
       // jscs:disable maximumLineLength
-      projectId : envs('AZK_KEEN_PROJECT_ID', '5526968d672e6c5a0d0ebec6'),
-      writeKey  : envs('AZK_KEEN_WRITE_KEY', '5dbce13e376070e36eec0c7dd1e7f42e49f39b4db041f208054617863832309c14a797409e12d976630c3a4b479004f26b362506e82a46dd54df0c977a7378da280c05ae733c97abb445f58abb56ae15f561ac9ad774cea12c3ad8628d896c39f6e702f6b035541fc1a562997cb05768'),
+      projectId: envs('AZK_KEEN_PROJECT_ID', '5526968d672e6c5a0d0ebec6'),
+      writeKey : envs('AZK_KEEN_WRITE_KEY', '5dbce13e376070e36eec0c7dd1e7f42e49f39b4db041f208054617863832309c14a797409e12d976630c3a4b479004f26b362506e82a46dd54df0c977a7378da280c05ae733c97abb445f58abb56ae15f561ac9ad774cea12c3ad8628d896c39f6e702f6b035541fc1a562997cb05768'),
       // jscs:enabled maximumLineLength
     },
     report: {


### PR DESCRIPTION
Those errors weren't sent due to the agent startup process, that was designed to catch any error and make `azk` gracefully stop. So that, those errors didn't reach `src/cli/index.js` and, consequently, the error handler.