### PR TITLE
[Cli] Fixing test suite calls

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,13 +92,13 @@ ${VM_DISKS_DIR}/azk-agent.vmdk.gz:
 ${AZK_LIB_PATH}/bats:
 	@git clone -b ${BATS_VERSION} https://github.com/sstephenson/bats ${AZK_LIB_PATH}/bats
 
-slow_test: TEST_SLOW=:slow
-slow_test: test
+fast_test: TEST_FAST=:fast
+fast_test: test
 	@echo "task: $@"
 
 test: bootstrap
 	@echo "task: $@"
-	${AZK_BIN} nvm npm run test${TEST_SLOW} $(if $(filter undefined,$(origin TEST_GREP)),,-- --grep "${TEST_GREP}")
+	${AZK_BIN} nvm npm run test${TEST_FAST} $(if $(filter undefined,$(origin TEST_GREP)),,-- --grep "${TEST_GREP}")
 
 ###### Package session ######
 

--- a/Makefile
+++ b/Makefile
@@ -92,12 +92,13 @@ ${VM_DISKS_DIR}/azk-agent.vmdk.gz:
 ${AZK_LIB_PATH}/bats:
 	@git clone -b ${BATS_VERSION} https://github.com/sstephenson/bats ${AZK_LIB_PATH}/bats
 
+slow_test: TEST_SLOW=:slow
 slow_test: test
 	@echo "task: $@"
 
 test: bootstrap
 	@echo "task: $@"
-	${AZK_BIN} nvm gulp test $(if $(filter undefined,$(origin TEST_GREP)),"",--grep "${TEST_GREP}")
+	${AZK_BIN} nvm npm run test${TEST_SLOW} $(if $(filter undefined,$(origin TEST_GREP)),,-- --grep "${TEST_GREP}")
 
 ###### Package session ######
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "gulp test",
-    "test:slow": "gulp test --slow",
+    "test:fast": "gulp test --skip-slow",
     "azk:package": "./src/libexec/package-tools/build.sh",
     "azk:package:publish": "gulp publish"
   },

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Orchestrate development environments with agility and automation",
   "main": "index.js",
   "scripts": {
-    "test": "make test",
+    "test": "gulp test",
+    "test:slow": "gulp test --slow",
     "azk:package": "./src/libexec/package-tools/build.sh",
     "azk:package:publish": "gulp publish"
   },

--- a/shared/scripts/ci-tests.sh
+++ b/shared/scripts/ci-tests.sh
@@ -66,7 +66,8 @@ setup() {
 }
 
 run_tests() {
-  make slow_test
+  unset TEST_GREP
+  make test
 }
 
 teardown() {

--- a/shared/scripts/ci-tests.sh
+++ b/shared/scripts/ci-tests.sh
@@ -66,7 +66,7 @@ setup() {
 }
 
 run_tests() {
-  azk nvm gulp test --slow
+  make slow_test
 }
 
 teardown() {


### PR DESCRIPTION
This PR intends to fix the chain of the test suite calls:

*Before:*
`npm` -> `make` -> `gulp`

*After:*
`make` -> `npm` -> `gulp`

Since running `make` is a requirement for `azk nvm npm` to be available, `make` should be called first.

Also, in `ci-tests.sh`, the used test command is `make test` to run the whole test suite.