### PR TITLE
[Package] Updating azk on `install.sh` script

### DIFF
--- a/docs/content/en/installation/README.md
+++ b/docs/content/en/installation/README.md
@@ -11,6 +11,8 @@ The installation process will add the `azk` command to your system path, making 
 
 ## azk express installation
 
+The easiest way to install `azk` is to use the script below. It will identify your operating system, and if it is compatible perform all installation tasks.
+
 !INCLUDE "express.md"
 
 ## Mininum requirements

--- a/docs/content/en/installation/express.md
+++ b/docs/content/en/installation/express.md
@@ -1,5 +1,3 @@
-The easiest way to install `azk` is to use the script below. It will identify your operating system, and if it is compatible perform all installation tasks.
-​
 ```bash
 # recommended for Mac users
 $ curl -sSL http://azk.io/install.sh | sh

--- a/docs/content/en/installation/linux.md
+++ b/docs/content/en/installation/linux.md
@@ -81,6 +81,8 @@ To do this, run:
 
 ### Express installation
 
+The easiest way to install `azk` is to use the script below. It will identify your operating system, and if it is compatible perform all installation tasks.
+
 !INCLUDE "express.md"
 
 ### Ubuntu

--- a/docs/content/en/installation/upgrading.md
+++ b/docs/content/en/installation/upgrading.md
@@ -22,7 +22,7 @@ $ brew upgrade azukiapp/azk/azk
 ```bash
 $ azk agent stop
 $ sudo apt-get update
-$ sudo apt-get upgrade azk
+$ sudo apt-get install azk
 ```
 
 #### Fedora:

--- a/docs/content/en/installation/upgrading.md
+++ b/docs/content/en/installation/upgrading.md
@@ -7,6 +7,10 @@
 
 Once `azk` has been installed via packages the upgrade process becomes really simple:
 
+### Express upgrade
+
+!INCLUDE "express.md"
+
 ### Mac OS X
 
 ```bash

--- a/docs/content/pt-BR/installation/README.md
+++ b/docs/content/pt-BR/installation/README.md
@@ -11,6 +11,8 @@ A instalação vai adicionar o comando `azk` ao path do sistema. Isso torna o co
 
 ## Instalação expressa do azk
 
+A forma mais fácil de instalar o `azk` é utilizar o script abaixo. Ele vai identificar o sistema operacional que está usando e, se for compatível, realizar todos os processos de instalação.
+
 !INCLUDE "express.md"
 
 ## Requisitos mínimos de instalação

--- a/docs/content/pt-BR/installation/express.md
+++ b/docs/content/pt-BR/installation/express.md
@@ -1,5 +1,3 @@
-A forma mais fácil de instalar o `azk` é utilizar o script abaixo. Ele vai identificar o sistema operacional que está usando e, se for compatível, realizar todos os processos de instalação.
-
 ```bash
 # Recomendado para usuários de Mac
 $ curl -sSL http://azk.io/install.sh | sh

--- a/docs/content/pt-BR/installation/linux.md
+++ b/docs/content/pt-BR/installation/linux.md
@@ -81,6 +81,8 @@ será executado automaticamente no próximo login. Para isso execute os comandos
 
 ### Instalação expressa
 
+A forma mais fácil de instalar o `azk` é utilizar o script abaixo. Ele vai identificar o sistema operacional que está usando e, se for compatível, realizar todos os processos de instalação.
+
 !INCLUDE "express.md"
 
 ### Ubuntu

--- a/docs/content/pt-BR/installation/upgrading.md
+++ b/docs/content/pt-BR/installation/upgrading.md
@@ -22,7 +22,7 @@ Ubuntu:
 ```bash
 $ azk agent stop
 $ sudo apt-get update
-$ sudo apt-get upgrade azk
+$ sudo apt-get install azk
 ```
 
 Fedora:

--- a/docs/content/pt-BR/installation/upgrading.md
+++ b/docs/content/pt-BR/installation/upgrading.md
@@ -7,6 +7,10 @@
 
 Uma vez que o `azk` tenha sido instalado por pacotes o processo de atualização se torna realmente simples:
 
+### Atualização expressa
+
+!INCLUDE "express.md"
+
 ### Mac OS X
 
 ```bash

--- a/shared/scripts/install.sh
+++ b/shared/scripts/install.sh
@@ -517,7 +517,7 @@ log() {
 }
 
 step() {
-  printf "$( log info -n $@ | sed -e :a -e 's/^.\{1,72\}$/&./;ta' )"
+  printf "$( log info $@ | sed -e :a -e 's/^.\{1,72\}$/&./;ta' )"
 }
 
 step_wait() {

--- a/shared/scripts/install.sh
+++ b/shared/scripts/install.sh
@@ -323,8 +323,10 @@ install_azk_mac_osx() {
   check_homebrew_installation
 
   step_wait "${INSTALL_STEP_LABEL}"
-  if [ "${UPDATE_AZK}" = "true" ]  && brew update && brew upgrade azukiapp/azk/azk || \
-     [ "${UPDATE_AZK}" != "true" ] && brew install azukiapp/azk/azk; then
+  if [ "${UPDATE_AZK}" = "true" ]  && \
+     brew untap azukiapp/azk && brew tap azukiapp/azk && brew upgrade azukiapp/azk/azk || \
+     [ "${UPDATE_AZK}" != "true" ] && \
+     brew install azukiapp/azk/azk; then
     step_done
   else
     step_fail


### PR DESCRIPTION
Now, the `install.sh` script can also update `azk` to its latest version.

It's just follow the instructions from [here](http://docs.azk.io/en/installation/#azk-express-installation).