### PR TITLE
[Spec] Fixing error when tests were run without a running agent

### DIFF
--- a/spec/spec_helpers/dustman.js
+++ b/spec/spec_helpers/dustman.js
@@ -68,7 +68,9 @@ export function extend(Helpers) {
 
     after((done) => {
       process.nextTick(() => {
-        _subscription.unsubscribe();
+        if (_subscription) {
+          _subscription.unsubscribe();
+        }
         done();
       });
     });


### PR DESCRIPTION
This PR reverts the changes made by [this commit] (https://github.com/azukiapp/azk/blob/5c2eeb003ad02f8f1bf3df89c6af3e3855bd3b9d/spec/spec_helpers/dustman.js#L69-L74) in the file `spec/spec_helpers/dustman.js`.

This was causing the following error when the test suite was run without a running agent:

```
Before all tasks:
  1) "before all" hook

events.js:72
        throw er; // Unhandled 'error' event
              ^
TypeError: Cannot call method 'unsubscribe' of undefined
    at azk-0.17.0 - spec/spec_helpers/dustman.js:71:23
    at process._tickDomainCallback (node.js:492:13)
```