### PR TITLE
[Cli] Include git commit on azk version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /node_modules
 /build
 npm-debug.log
+.package-envs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## dev
 
 * Enhancements
+  * [Cli] `azk version` changes to display the first 7 digits of the commit hash and the date of the corresponding commite version;
   * [Cli] Updating `i18n-cli`: now, it supports color syntax highlight;
   * [Cli] Replacing `colors` for `chalk` and adding `--no-color` option that outputs in only one color;
   * [Cli] Improving `ui.isInteractive()`: now, not only the existence of a `tty` is checked but also the parameter `--quiet`;

--- a/Makefile
+++ b/Makefile
@@ -160,10 +160,10 @@ package_clean:
 	@echo "task: $@"
 	@rm -Rf ${AZK_PACKAGE_PREFIX}/..?* ${AZK_PACKAGE_PREFIX}/.[!.]* ${AZK_PACKAGE_PREFIX}/*
 
-check_version: NEW_AZK_VERSION=$(shell ${PATH_USR_LIB_AZK}/bin/azk version)
+check_version: NEW_AZK_VERSION=$(shell ${PATH_USR_LIB_AZK}/bin/azk version | sed -e 's/^azk version\ //; s/,.*//')
 check_version:
 	@echo "task: $@"
-	@if [ ! "azk ${AZK_VERSION}" = "${NEW_AZK_VERSION}" ] ; then \
+	@if [ ! "${AZK_VERSION}" = "${NEW_AZK_VERSION}" ] ; then \
 		echo 'Error to run: ${PATH_USR_LIB_AZK}/bin/azk version'; \
 		echo 'Expect: azk ${AZK_VERSION}'; \
 		echo 'Output: ${NEW_AZK_VERSION}'; \

--- a/Makefile
+++ b/Makefile
@@ -208,7 +208,7 @@ $(abspath $(2)/$(3)): $(abspath $(1)/$(3))
 endef
 
 # copy regular files
-FILES_FILTER  = package.json bin shared .nvmrc CHANGELOG.md LICENSE README.md .dependencies
+FILES_FILTER  = package.json bin shared .nvmrc CHANGELOG.md LICENSE README.md .dependencies .package-envs
 FILES_ALL     = $(shell cd ${AZK_ROOT_PATH} && find $(FILES_FILTER) -print 2>/dev/null | grep -v shared/completions)
 FILES_TARGETS = $(foreach file,$(addprefix $(PATH_USR_LIB_AZK)/, $(FILES_ALL)),$(abspath $(file)))
 $(foreach file,$(FILES_ALL),$(eval $(call COPY_FILES,$(AZK_ROOT_PATH),$(PATH_USR_LIB_AZK),$(file))))

--- a/bin/azk
+++ b/bin/azk
@@ -49,6 +49,9 @@ export PATH=$AZK_NPM_PATH/.bin:$PATH
 
 # Load dependencies versions
 . ${AZK_ROOT_PATH}/.dependencies
+if [ -e ${AZK_ROOT_PATH}/.package-envs ]; then
+  . ${AZK_ROOT_PATH}/.package-envs
+fi
 export AZK_DOCKER_MIN_VERSION=${AZK_DOCKER_MIN_VERSION}
 export AZK_DOCKER_API_VERSION=${AZK_DOCKER_API_VERSION}
 export AZK_ISO_VERSION=${AZK_ISO_VERSION}

--- a/shared/scripts/install.sh
+++ b/shared/scripts/install.sh
@@ -424,7 +424,7 @@ check_azk_installation() {
 azk_is_up_to_date() {
   AZK_TAGS_URL="https://api.github.com/repos/azukiapp/azk/tags"
   AZK_VERSIONS=$(curl -sSL ${AZK_TAGS_URL} | grep name)
-  AZK_CURRENT_VERSION=$(azk version | cut -d ' ' -f2)
+  AZK_CURRENT_VERSION=$(azk version | sed -e 's/^azk version\ //; s/,.*//')
   AZK_LATEST_VERSION=$( curl -sSL ${AZK_TAGS_URL} | \
                         grep name | \
                         head -1 | \

--- a/spec/cmds/version_spec.js
+++ b/spec/cmds/version_spec.js
@@ -11,7 +11,7 @@ describe('Azk cli, version controller', function() {
 
   var doc_opts    = { exit: false };
   var run_options = { ui: ui };
-  var version_regex = /azk version \d+\.\d+\.\d+, build \w+/;
+  var version_regex = /azk version \d+\.\d+\.\d+, build \w+, date \d+-\d+-\d+/;
 
   it('should run a version command', function() {
     doc_opts.argv = 'version';

--- a/spec/cmds/version_spec.js
+++ b/spec/cmds/version_spec.js
@@ -1,6 +1,5 @@
 import h from 'spec/spec_helper';
 import { Cli } from 'azk/cli';
-import Azk from 'azk';
 
 describe('Azk cli, version controller', function() {
   var outputs = [];
@@ -12,7 +11,7 @@ describe('Azk cli, version controller', function() {
 
   var doc_opts    = { exit: false };
   var run_options = { ui: ui };
-  var version     = `azk ${Azk.version}`;
+  var version_regex = /azk version \d+\.\d+\.\d+, build \w+/;
 
   it('should run a version command', function() {
     doc_opts.argv = 'version';
@@ -20,7 +19,7 @@ describe('Azk cli, version controller', function() {
     return cli.run(doc_opts, run_options).then((code) => {
       h.expect(code).to.eql(0);
       h.expect(options).to.have.property('version', true);
-      h.expect(outputs[0]).to.eql(version);
+      h.expect(outputs[0]).to.match(version_regex);
     });
   });
 
@@ -28,7 +27,7 @@ describe('Azk cli, version controller', function() {
     doc_opts.argv = '--version';
     return cli.run(doc_opts, run_options).then((code) => {
       h.expect(code).to.eql(0);
-      h.expect(outputs[0]).to.eql(version);
+      h.expect(outputs[0]).to.match(version_regex);
     });
   });
 });

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -1,0 +1,14 @@
+import h from 'spec/spec_helper';
+import Azk from 'azk';
+
+describe('azk main module', function() {
+
+  it('should `version` get azk current version', function() {
+    h.expect(Azk.version).to.match(/\d+\.\d+\.\d+/);
+  });
+
+  it('should `isDev` check if current azk is a dev version', function() {
+    h.expect(Azk.isDev).to.equal(true);
+  });
+
+});

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -7,8 +7,8 @@ describe('azk main module', function() {
     h.expect(Azk.version).to.match(/\d+\.\d+\.\d+/);
   });
 
-  it('should `isDev` check if current azk is a dev version', function() {
-    h.expect(Azk.isDev).to.equal(true);
+  it('should `gitCommitId` check if current azk is a dev version', function() {
+    return h.expect(Azk.gitCommitId).to.eventually.not.be.undefined;
   });
 
 });

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -7,8 +7,14 @@ describe('azk main module', function() {
     h.expect(Azk.version).to.match(/\d+\.\d+\.\d+/);
   });
 
-  it('should `gitCommitId` check if current azk is a dev version', function() {
-    return h.expect(Azk.gitCommitId).to.eventually.not.be.undefined;
+  it('should `gitCommitIdAsync` get current commit id from ENV', function() {
+    const last_commit_id = '123';
+    return h.expect(Azk.gitCommitIdAsync(last_commit_id))
+      .to.eventually.to.equal(last_commit_id);
+  });
+
+  it('should `gitCommitIdAsync` get current commit id from dev project', function() {
+    return h.expect(Azk.gitCommitIdAsync()).to.eventually.not.be.undefined;
   });
 
 });

--- a/spec/index_spec.js
+++ b/spec/index_spec.js
@@ -7,14 +7,18 @@ describe('azk main module', function() {
     h.expect(Azk.version).to.match(/\d+\.\d+\.\d+/);
   });
 
-  it('should `gitCommitIdAsync` get current commit id from ENV', function() {
+  it('should commitId() get current commit id from ENV', function() {
     const last_commit_id = '123';
-    return h.expect(Azk.gitCommitIdAsync(last_commit_id))
+    return h.expect(Azk.commitId(last_commit_id))
       .to.eventually.to.equal(last_commit_id);
   });
 
-  it('should `gitCommitIdAsync` get current commit id from dev project', function() {
-    return h.expect(Azk.gitCommitIdAsync()).to.eventually.not.be.undefined;
+  it('should commitId() get current commit id from dev project', function() {
+    return h.expect(Azk.commitId()).to.eventually.not.be.undefined;
+  });
+
+  it('should commitDate get current commit date from dev project', function() {
+    return h.expect(Azk.commitDate()).to.eventually.not.be.undefined;
   });
 
 });

--- a/spec/manifest/get_project_spec.js
+++ b/spec/manifest/get_project_spec.js
@@ -5,22 +5,23 @@ import { promiseResolve } from 'azk/utils/promises';
 
 describe('GetProject:', function() {
 
+  // cli-router to parse arguments
+  const cli_options = {};
+  const cli = new Cli(cli_options);
+
+  // parse arguments with parseCommandOptions
+  const cliRouterCleanParams = function (command_args) {
+    const doc_opts    = { exit: false };
+    doc_opts.argv = command_args.split(' ').splice(1);
+
+    // parsed arguments
+    const cli_options = cli.router.cleanParams(cli.docopt(doc_opts));
+
+    // azk start git repo parsed arguments
+    return GetProject.parseCommandOptions(cli_options);
+  };
+
   describe('parseCommandOptions:', function () {
-    // cli-router to parse arguments
-    var cli_options = {};
-    var cli = new Cli(cli_options);
-
-    // parse arguments with parseCommandOptions
-    var cliRouterCleanParams = function (command_args) {
-      var doc_opts    = { exit: false };
-      doc_opts.argv = command_args.split(' ').splice(1);
-
-      // parsed arguments
-      var cli_options = cli.router.cleanParams(cli.docopt(doc_opts));
-
-      // azk start git repo parsed arguments
-      return GetProject.parseCommandOptions(cli_options);
-    };
 
     it('should git-ref=master with git-repo argument only', function() {
       var parsed_options = cliRouterCleanParams([
@@ -137,6 +138,19 @@ describe('GetProject:', function() {
       return getProject._checkGitVersion(0)
       .then(function() {
         h.expect(getProject.is_new_git).to.be.true;
+      });
+    });
+
+    it('should _gitspawn_VersionAsync get real current git version', function() {
+      var parsed_options = cliRouterCleanParams([
+        'azk start git@github.com:azukiapp/azkdemo.git',
+        '--git-ref master',
+        '-vv',
+      ].join(' '));
+      getProject = new GetProject(ui, parsed_options);
+      return getProject._gitspawn_VersionAsync(2)
+      .then(function(result) {
+        h.expect(result.message).to.match(/git version/);
       });
     });
 

--- a/spec/manifest/get_project_spec.js
+++ b/spec/manifest/get_project_spec.js
@@ -126,31 +126,31 @@ describe('GetProject:', function() {
     });
 
     it('should be an old git version when <  1.7.10', function() {
-      getProject._gitspawn_VersionAsync = () => promiseResolve({code: 0, message: '1.7.9'});
-      return getProject._checkGitVersion(0)
+      getProject._gitHelper.version = () => promiseResolve('1.7.9');
+      return getProject._checkGitVersion()
       .then(function() {
         h.expect(getProject.is_new_git).to.be.false;
       });
     });
 
-    it('should be a  new git version when >= 1.7.10', function() {
-      getProject._gitspawn_VersionAsync = () => promiseResolve({code: 0, message: '1.7.10'});
-      return getProject._checkGitVersion(0)
+    it('should be a new git version when >= 1.7.10', function() {
+      getProject._gitHelper.version = () => promiseResolve('1.7.10');
+      return getProject._checkGitVersion()
       .then(function() {
         h.expect(getProject.is_new_git).to.be.true;
       });
     });
 
-    it('should _gitspawn_VersionAsync get real current git version', function() {
+    it('should _gitHelper.version get real current git version', function() {
       var parsed_options = cliRouterCleanParams([
         'azk start git@github.com:azukiapp/azkdemo.git',
         '--git-ref master',
         '-vv',
       ].join(' '));
       getProject = new GetProject(ui, parsed_options);
-      return getProject._gitspawn_VersionAsync(2)
-      .then(function(result) {
-        h.expect(result.message).to.match(/git version/);
+      return getProject._gitHelper.version(getProject.gitOutput)
+      .then(function(git_version) {
+        h.expect(git_version).to.match(/\d+\.\d+\.\d+/);
       });
     });
 

--- a/spec/manifest/get_project_spec.js
+++ b/spec/manifest/get_project_spec.js
@@ -1,7 +1,6 @@
 import h from 'spec/spec_helper';
 import { GetProject } from 'azk/manifest/get_project';
 import { Cli } from 'azk/cli';
-import { promiseResolve } from 'azk/utils/promises';
 
 describe('GetProject:', function() {
 
@@ -126,19 +125,13 @@ describe('GetProject:', function() {
     });
 
     it('should be an old git version when <  1.7.10', function() {
-      getProject._gitHelper.version = () => promiseResolve('1.7.9');
-      return getProject._checkGitVersion()
-      .then(function() {
-        h.expect(getProject.is_new_git).to.be.false;
-      });
+      getProject._checkGitVersion('1.7.9');
+      h.expect(getProject.is_new_git).to.be.false;
     });
 
     it('should be a new git version when >= 1.7.10', function() {
-      getProject._gitHelper.version = () => promiseResolve('1.7.10');
-      return getProject._checkGitVersion()
-      .then(function() {
-        h.expect(getProject.is_new_git).to.be.true;
-      });
+      getProject._checkGitVersion('1.7.10');
+      h.expect(getProject.is_new_git).to.be.true;
     });
 
     it('should _gitHelper.version get real current git version', function() {

--- a/spec/utils/git_helper_spec.js
+++ b/spec/utils/git_helper_spec.js
@@ -1,5 +1,6 @@
 import h from 'spec/spec_helper';
 import { default as gitHelper } from 'azk/utils/git_helper';
+import { config, path, fsAsync } from 'azk';
 
 describe("Git Helper", function() {
   let outputs = [];
@@ -16,10 +17,15 @@ describe("Git Helper", function() {
   });
 
   it("should run git rev-parse HEAD", function() {
-    const azkDevPathMatch = __dirname.match(process.env.AZK_ROOT_PATH);
-    /**/console.log('\n>>---------\n azkDevPathMatch:\n', azkDevPathMatch, '\n>>---------\n');/*-debug-*/
-    const isAzkDev = azkDevPathMatch !== null;
-    /**/console.log('\n>>---------\n isAzkDev:\n', isAzkDev, '\n>>---------\n');/*-debug-*/
+    const azkRootPath = config('paths:azk_root');
+    const git_path = path.join(azkRootPath, '.git');
+    return fsAsync.exists(git_path)
+    .then((exists) => {
+      h.expect(exists).to.be.equal(true);
+      return gitHelper.revParse('HEAD', git_path, ui.stdout().write)
+      .then((commit_id) => {
+        h.expect(commit_id).to.not.be.undefined;
+      });
+    });
   });
-
 });

--- a/spec/utils/git_helper_spec.js
+++ b/spec/utils/git_helper_spec.js
@@ -28,4 +28,5 @@ describe("Git Helper", function() {
       });
     });
   });
+
 });

--- a/spec/utils/git_helper_spec.js
+++ b/spec/utils/git_helper_spec.js
@@ -1,12 +1,14 @@
 import h from 'spec/spec_helper';
 import { default as gitHelper } from 'azk/utils/git_helper';
-import { config, path, fsAsync } from 'azk';
+import { config, path } from 'azk';
 
 describe("Git Helper", function() {
   let outputs = [];
-  let ui = h.mockUI(beforeEach, outputs);
+  const ui = h.mockUI(beforeEach, outputs);
+  const azkRootPath = config('paths:azk_root');
+  const git_path = path.join(azkRootPath, '.git');
 
-  it("should run git --version", function() {
+  it("should run scan `git --version` to stdout", function() {
     const command = gitHelper.version(ui.stdout().write);
     return h.expect(command)
       .to.eventually.not.be.undefined
@@ -16,16 +18,23 @@ describe("Git Helper", function() {
       });
   });
 
+  it("should return version on `git --version`", function() {
+    const command = gitHelper.version(null);
+    return h.expect(command)
+      .to.eventually.to.match(/\d+\.\d+\.\d+/);
+  });
+
   it("should run git rev-parse HEAD", function() {
-    const azkRootPath = config('paths:azk_root');
-    const git_path = path.join(azkRootPath, '.git');
-    return fsAsync.exists(git_path)
-    .then((exists) => {
-      h.expect(exists).to.be.equal(true);
-      return gitHelper.revParse('HEAD', git_path, ui.stdout().write)
-      .then((commit_id) => {
-        h.expect(commit_id).to.not.be.undefined;
-      });
+    return gitHelper.revParse('HEAD', git_path)
+    .then((commit_id) => {
+      h.expect(commit_id).to.not.be.undefined;
+    });
+  });
+
+  it("should lsRemote get remote data @slow", function() {
+    return gitHelper.lsRemote('https://github.com/azukiapp/azk.git')
+    .then((result) => {
+      h.expect(result).to.match(/HEAD/g);
     });
   });
 

--- a/spec/utils/git_helper_spec.js
+++ b/spec/utils/git_helper_spec.js
@@ -6,16 +6,20 @@ describe("Git Helper", function() {
   let ui = h.mockUI(beforeEach, outputs);
 
   it("should run git --version", function() {
-    const command = gitHelper.version({verbose_level: 1, ui});
+    const command = gitHelper.version(ui.stdout().write);
     return h.expect(command)
       .to.eventually.not.be.undefined
       .then(() => {
-        /**/console.log('\n>>---------\n outputs:\n', outputs, '\n>>---------\n');/*-debug-*/
+        h.expect(outputs[0]).to.equal('$> git --version');
+        h.expect(outputs[1]).to.match(/git version/);
       });
   });
 
   it("should run git rev-parse HEAD", function() {
-    /**/console.log('\n>>---------\n __dirname:\n', __dirname, '\n>>---------\n');/*-debug-*/
+    const azkDevPathMatch = __dirname.match(process.env.AZK_ROOT_PATH);
+    /**/console.log('\n>>---------\n azkDevPathMatch:\n', azkDevPathMatch, '\n>>---------\n');/*-debug-*/
+    const isAzkDev = azkDevPathMatch !== null;
+    /**/console.log('\n>>---------\n isAzkDev:\n', isAzkDev, '\n>>---------\n');/*-debug-*/
   });
 
 });

--- a/spec/utils/git_helper_spec.js
+++ b/spec/utils/git_helper_spec.js
@@ -2,40 +2,79 @@ import h from 'spec/spec_helper';
 import { default as gitHelper } from 'azk/utils/git_helper';
 import { config, path } from 'azk';
 
-describe("Git Helper", function() {
-  let outputs = [];
-  const ui = h.mockUI(beforeEach, outputs);
+describe('Git Helper', function() {
   const azkRootPath = config('paths:azk_root');
   const git_path = path.join(azkRootPath, '.git');
 
-  it("should run scan `git --version` to stdout", function() {
-    const command = gitHelper.version(ui.stdout().write);
-    return h.expect(command)
-      .to.eventually.not.be.undefined
-      .then(() => {
-        h.expect(outputs[0]).to.equal('$> git --version');
-        h.expect(outputs[1]).to.match(/git version/);
-      });
+  it('should run scan `git --version` to stdout', function() {
+    let outputs = [];
+    const writeToOutput = (data) => {
+      outputs.push(data.toString());
+    };
+    return gitHelper.version(writeToOutput)
+    .then(() => {
+      h.expect(outputs).to.containSubset(['$> git --version']);
+    });
   });
 
-  it("should return version on `git --version`", function() {
+  it('should return version on `git --version`', function() {
     const command = gitHelper.version(null);
     return h.expect(command)
       .to.eventually.to.match(/\d+\.\d+\.\d+/);
   });
 
-  it("should run git rev-parse HEAD", function() {
-    return gitHelper.revParse('HEAD', git_path)
-    .then((commit_id) => {
-      h.expect(commit_id).to.not.be.undefined;
-    });
+  it('should run git rev-parse HEAD', function() {
+    const command = gitHelper.revParse('HEAD', git_path, null);
+    return h.expect(command)
+      .to.eventually.to.not.be.undefined;
   });
 
-  it("should lsRemote get remote data @slow", function() {
-    return gitHelper.lsRemote('https://github.com/azukiapp/azk.git')
-    .then((result) => {
-      h.expect(result).to.match(/HEAD/g);
+  it('should lsRemote get remote data @slow', function() {
+    const GIT_URL = 'https://github.com/azukiapp/azkdemo';
+    const command = gitHelper.lsRemote(GIT_URL, null);
+    return h.expect(command)
+      .to.eventually.to.match(/HEAD/g);
+  });
+
+  it('should clone, pull and checkout @slow', function() {
+    return h.tmp_dir().then((tmp_path) => {
+      const GIT_URL = 'https://github.com/azukiapp/azkdemo';
+      const GIT_BRANCH_TAG_COMMIT = 'master';
+      const DEST_FOLDER = tmp_path;
+
+      return gitHelper.clone(
+        GIT_URL,
+        GIT_BRANCH_TAG_COMMIT,
+        DEST_FOLDER,
+        false,
+        null
+      )
+      .then((result) => {
+        h.expect(result).to.match(/Cloning into/g);
+      })
+      .then(() => {
+        return gitHelper.pull(
+          GIT_URL,
+          'final',
+          DEST_FOLDER,
+          null
+        );
+      })
+      .then((result) => {
+        h.expect(result).to.match(/final/g);
+      })
+      .then(() => {
+        return gitHelper.checkout(
+          '77284eb',
+          DEST_FOLDER,
+          null
+        );
+      })
+      .then((result) => {
+        h.expect(result).to.match(/77284eb/);
+      });
     });
+
   });
 
 });

--- a/spec/utils/git_helper_spec.js
+++ b/spec/utils/git_helper_spec.js
@@ -1,0 +1,21 @@
+import h from 'spec/spec_helper';
+import { default as gitHelper } from 'azk/utils/git_helper';
+
+describe("Git Helper", function() {
+  let outputs = [];
+  let ui = h.mockUI(beforeEach, outputs);
+
+  it("should run git --version", function() {
+    const command = gitHelper.version({verbose_level: 1, ui});
+    return h.expect(command)
+      .to.eventually.not.be.undefined
+      .then(() => {
+        /**/console.log('\n>>---------\n outputs:\n', outputs, '\n>>---------\n');/*-debug-*/
+      });
+  });
+
+  it("should run git rev-parse HEAD", function() {
+    /**/console.log('\n>>---------\n __dirname:\n', __dirname, '\n>>---------\n');/*-debug-*/
+  });
+
+});

--- a/spec/utils/git_helper_spec.js
+++ b/spec/utils/git_helper_spec.js
@@ -29,6 +29,12 @@ describe('Git Helper', function() {
       .to.eventually.to.not.be.undefined;
   });
 
+  it('should run git show', function() {
+    const command = gitHelper.show('HEAD', '%ci', git_path, null);
+    return h.expect(command)
+      .to.eventually.to.match(/\d+-\d+-\d+.*/);
+  });
+
   it('should lsRemote get remote data @slow', function() {
     const GIT_URL = 'https://github.com/azukiapp/azkdemo';
     const command = gitHelper.lsRemote(GIT_URL, null);

--- a/spec/utils/spawn_helper_spec.js
+++ b/spec/utils/spawn_helper_spec.js
@@ -1,0 +1,19 @@
+import h from 'spec/spec_helper';
+import { lazy_require } from 'azk';
+
+var lazy = lazy_require({
+  spawnHelper: ['azk/utils/spawn_helper'],
+  printOutput: ['azk/utils/spawn_helper'],
+});
+
+describe("Spawn Helper", function() {
+  let outputs = [];
+  let ui = h.mockUI(beforeEach, outputs);
+
+  it("should printOutput do not print if verbose_level = 0", function() {
+    const result = lazy.printOutput(ui.ok, 0, '[azk]', 'DATA');
+    h.expect(result).to.be.undefined;
+    h.expect(outputs.length).to.equal(0);
+  });
+
+});

--- a/spec/utils/spawn_helper_spec.js
+++ b/spec/utils/spawn_helper_spec.js
@@ -2,18 +2,45 @@ import h from 'spec/spec_helper';
 import { lazy_require } from 'azk';
 
 var lazy = lazy_require({
-  spawnHelper: ['azk/utils/spawn_helper'],
+  spawnAsync: ['azk/utils/spawn_helper'],
   printOutput: ['azk/utils/spawn_helper'],
 });
 
 describe("Spawn Helper", function() {
   let outputs = [];
   let ui = h.mockUI(beforeEach, outputs);
+  let stdOut = ui.stdout().write.bind(ui);
 
   it("should printOutput do not print if verbose_level = 0", function() {
-    const result = lazy.printOutput(ui.ok, 0, '[azk]', 'DATA');
-    h.expect(result).to.be.undefined;
+    lazy.printOutput(stdOut, 0, '[azk]', 'DATA');
     h.expect(outputs.length).to.equal(0);
+  });
+
+  it("should printOutput print if verbose_level = 1", function() {
+    lazy.printOutput(stdOut, 1, '[azk]', 'DATA');
+    h.expect(outputs[0]).to.match(/\[azk\] DATA/);
+  });
+
+  it("should spawnAsync should return result and call scanFunction", function() {
+    const scanFunction = stdOut;
+    const spawnAsync_promise = lazy.spawnAsync('git', ['--version'], scanFunction);
+
+    return spawnAsync_promise.then((result) => {
+      h.expect(result.error_code).to.equal(0);
+      h.expect(result.message).to.match(/git version/);
+      h.expect(outputs[0]).to.equal('$> git --version');
+      h.expect(outputs[1]).to.match(/git version/);
+    });
+  });
+
+  it("should spawnAsync should return result even without scanFunction", function() {
+    const spawnAsync_promise = lazy.spawnAsync('git', ['--version'], undefined);
+
+    return spawnAsync_promise.then((result) => {
+      h.expect(result.error_code).to.equal(0);
+      h.expect(result.message).to.match(/git version/);
+      h.expect(outputs.length).to.equal(0);
+    });
   });
 
 });

--- a/spec/utils/spawn_helper_spec.js
+++ b/spec/utils/spawn_helper_spec.js
@@ -21,6 +21,16 @@ describe("Spawn Helper", function() {
     h.expect(outputs[0]).to.match(/\[azk\] DATA/);
   });
 
+  it("should spawnAsync should return result even without scanFunction", function() {
+    const spawnAsync_promise = lazy.spawnAsync('git', ['--version'], undefined);
+
+    return spawnAsync_promise.then((result) => {
+      h.expect(result.error_code).to.equal(0);
+      h.expect(result.message).to.match(/git version/);
+      h.expect(outputs.length).to.equal(0);
+    });
+  });
+
   it("should spawnAsync should return result and call scanFunction", function() {
     const scanFunction = stdOut;
     const spawnAsync_promise = lazy.spawnAsync('git', ['--version'], scanFunction);
@@ -30,16 +40,6 @@ describe("Spawn Helper", function() {
       h.expect(result.message).to.match(/git version/);
       h.expect(outputs[0]).to.equal('$> git --version');
       h.expect(outputs[1]).to.match(/git version/);
-    });
-  });
-
-  it("should spawnAsync should return result even without scanFunction", function() {
-    const spawnAsync_promise = lazy.spawnAsync('git', ['--version'], undefined);
-
-    return spawnAsync_promise.then((result) => {
-      h.expect(result.error_code).to.equal(0);
-      h.expect(result.message).to.match(/git version/);
-      h.expect(outputs.length).to.equal(0);
     });
   });
 

--- a/src/cmds/version.js
+++ b/src/cmds/version.js
@@ -8,11 +8,19 @@ export default class Version extends CliTrackerController {
     this.require_terms = false;
   }
 
+  // get version, commit id and commit date to create output
   index() {
-    const azk_last_commit = config('azk_last_commit');
-    return Azk.gitCommitIdAsync(azk_last_commit)
+    let versionOutput = `azk version ${Azk.version}, build `;
+    const azk_last_commit_id = config('azk_last_commit_id');
+    return Azk.commitId(azk_last_commit_id)
     .then((commitId) => {
-      this.ui.output(`azk version ${Azk.version}, build ${commitId}`);
+      versionOutput = versionOutput + commitId + ', date ';
+      const azk_last_commit_date = config('azk_last_commit_date');
+      return Azk.commitDate(azk_last_commit_date);
+    })
+    .then((commitDate) => {
+      versionOutput = versionOutput + commitDate;
+      this.ui.output(versionOutput);
       return 0;
     });
   }

--- a/src/cmds/version.js
+++ b/src/cmds/version.js
@@ -8,7 +8,9 @@ export default class Version extends CliTrackerController {
   }
 
   index() {
-    this.ui.output("azk %s", Azk.version);
-    return 0;
+    return Azk.gitCommitId.then((commitId) => {
+      this.ui.output(`azk version ${Azk.version}, build ${commitId}`);
+      return 0;
+    });
   }
 }

--- a/src/cmds/version.js
+++ b/src/cmds/version.js
@@ -1,5 +1,6 @@
 import { CliTrackerController } from 'azk/cli/cli_tracker_controller.js';
 import Azk from 'azk';
+import { config } from 'azk';
 
 export default class Version extends CliTrackerController {
   constructor(...args) {
@@ -8,7 +9,9 @@ export default class Version extends CliTrackerController {
   }
 
   index() {
-    return Azk.gitCommitId.then((commitId) => {
+    const azk_last_commit = config('azk_last_commit');
+    return Azk.gitCommitIdAsync(azk_last_commit)
+    .then((commitId) => {
       this.ui.output(`azk version ${Azk.version}, build ${commitId}`);
       return 0;
     });

--- a/src/config.js
+++ b/src/config.js
@@ -52,6 +52,7 @@ var options = mergeConfig({
     manifest : "Azkfile.js",
     locale   : 'en-US',
     azk_dir  : azk_dir,
+    azk_last_commit: envs("AZK_LAST_COMMIT"),
     flags    : {
       show_deprecate: envs('AZK_HIDE_DEPRECATE', false),
       require_accept_use_terms: envs('AZK_REQUIRE_TERMS', true),
@@ -79,7 +80,7 @@ var options = mergeConfig({
       data_mnt_path     : data_mnt_path,
       persistent_folders: path.join(data_mnt_path, 'persistent_folders'),
       sync_folders      : path.join(data_mnt_path, 'sync_folders'),
-      analytics         : path.join(data_path, azk_dir, "analytics"),
+      analytics         : path.join(data_path, azk_dir, "analytics")
     },
     logs_level: {
       console: (envs('AZK_DEBUG') ? 'debug' : envs('AZK_OUTPUT_LOG_LEVEL', 'error')),

--- a/src/config.js
+++ b/src/config.js
@@ -52,7 +52,8 @@ var options = mergeConfig({
     manifest : "Azkfile.js",
     locale   : 'en-US',
     azk_dir  : azk_dir,
-    azk_last_commit: envs("AZK_LAST_COMMIT"),
+    azk_last_commit_id: envs("AZK_LAST_COMMIT_ID"),
+    azk_last_commit_date: envs("AZK_LAST_COMMIT_DATE"),
     flags    : {
       show_deprecate: envs('AZK_HIDE_DEPRECATE', false),
       require_accept_use_terms: envs('AZK_REQUIRE_TERMS', true),

--- a/src/index.js
+++ b/src/index.js
@@ -11,12 +11,12 @@ class Azk {
     return require('package.json').version;
   }
 
-  static gitCommitIdAsync(azk_last_commit) {
+  static gitCommitIdAsync(azk_last_commit_id) {
     const path = GeralLib.path;
     const config = GeralLib.config;
 
     // git commit id from ENV
-    const commit_id = azk_last_commit;
+    const commit_id = azk_last_commit_id;
     if (commit_id) {
       return promiseResolve(commit_id);
     }
@@ -27,6 +27,27 @@ class Azk {
     const gitHelper = require('azk/utils/git_helper');
     return gitHelper.revParse('HEAD', git_path);
   }
+
+  static gitCommitDateAsync(azk_last_commit_date) {
+    const path = GeralLib.path;
+    const config = GeralLib.config;
+
+    // git commit id from ENV
+    const commit_date = azk_last_commit_date;
+    if (commit_date) {
+      return promiseResolve(commit_date);
+    }
+
+    // git commit date from git_helper
+    const azkRootPath = config('paths:azk_root');
+    const git_path = path.join(azkRootPath, '.git');
+    const gitHelper = require('azk/utils/git_helper');
+    return gitHelper.show('HEAD', '%ci', git_path, null)
+    .then((commit_date) => {
+      return commit_date.substring(0, 10);
+    });
+  }
+
 }
 
 // Default i18n method
@@ -67,7 +88,8 @@ var GeralLib = {
   get fsAsync    () { return require('file-async'); },
   get utils      () { return require('azk/utils'); },
   get version    () { return Azk.version; },
-  get gitCommitIdAsync() { return Azk.gitCommitIdAsync; },
+  get commitId   () { return Azk.gitCommitIdAsync; },
+  get commitDate () { return Azk.gitCommitDateAsync; },
   get isBlank    () { return isBlank; },
 
   get lazy_require() {

--- a/src/index.js
+++ b/src/index.js
@@ -1,21 +1,24 @@
 import { _, isBlank } from 'azk/utils';
+import { promiseResolve } from 'azk/utils/promises';
 
 try {
   require("babel-polyfill");
 } catch (e) {}
 
 class Azk {
+
   static get version() {
     return require('package.json').version;
   }
-  static get gitCommitId() {
-    const config = GeralLib.config;
+
+  static gitCommitIdAsync(azk_last_commit) {
     const path = GeralLib.path;
+    const config = GeralLib.config;
 
     // git commit id from ENV
-    const azk_last_commit = config('azk_last_commit');
-    if (azk_last_commit) {
-      return azk_last_commit;
+    const commit_id = azk_last_commit;
+    if (commit_id) {
+      return promiseResolve(commit_id);
     }
 
     // git commit id from git_helper
@@ -64,7 +67,7 @@ var GeralLib = {
   get fsAsync    () { return require('file-async'); },
   get utils      () { return require('azk/utils'); },
   get version    () { return Azk.version; },
-  get gitCommitId() { return Azk.gitCommitId; },
+  get gitCommitIdAsync() { return Azk.gitCommitIdAsync; },
   get isBlank    () { return isBlank; },
 
   get lazy_require() {

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,13 @@ class Azk {
   static get version() {
     return require('package.json').version;
   }
+  static get isDev() {
+    const currentDir = __dirname;
+    const azkRootPath = process.env.AZK_ROOT_PATH;
+    const azkDevPathMatch = currentDir.match(azkRootPath);
+    const isAzkDev = azkDevPathMatch !== null;
+    return isAzkDev;
+  }
 }
 
 // Default i18n method
@@ -48,6 +55,7 @@ var GeralLib = {
   get fsAsync() { return require('file-async'); },
   get utils  () { return require('azk/utils'); },
   get version() { return Azk.version; },
+  get isDev()   { return Azk.isDev; },
   get isBlank() { return isBlank; },
 
   get lazy_require() {

--- a/src/index.js
+++ b/src/index.js
@@ -8,12 +8,21 @@ class Azk {
   static get version() {
     return require('package.json').version;
   }
-  static get isDev() {
-    const currentDir = __dirname;
-    const azkRootPath = process.env.AZK_ROOT_PATH;
-    const azkDevPathMatch = currentDir.match(azkRootPath);
-    const isAzkDev = azkDevPathMatch !== null;
-    return isAzkDev;
+  static get gitCommitId() {
+    const config = GeralLib.config;
+    const path = GeralLib.path;
+
+    // git commit id from ENV
+    const azk_last_commit = config('azk_last_commit');
+    if (azk_last_commit) {
+      return azk_last_commit;
+    }
+
+    // git commit id from git_helper
+    const azkRootPath = config('paths:azk_root');
+    const git_path = path.join(azkRootPath, '.git');
+    const gitHelper = require('azk/utils/git_helper');
+    return gitHelper.revParse('HEAD', git_path);
   }
 }
 
@@ -49,14 +58,14 @@ var GeralLib = {
   },
 
   // Internals alias
-  get os     () { return require('os'); },
-  get path   () { return require('path'); },
-  get fs     () { return require('fs'); },
-  get fsAsync() { return require('file-async'); },
-  get utils  () { return require('azk/utils'); },
-  get version() { return Azk.version; },
-  get isDev()   { return Azk.isDev; },
-  get isBlank() { return isBlank; },
+  get os         () { return require('os'); },
+  get path       () { return require('path'); },
+  get fs         () { return require('fs'); },
+  get fsAsync    () { return require('file-async'); },
+  get utils      () { return require('azk/utils'); },
+  get version    () { return Azk.version; },
+  get gitCommitId() { return Azk.gitCommitId; },
+  get isBlank    () { return isBlank; },
 
   get lazy_require() {
     return require('azk/utils').lazy_require;

--- a/src/libexec/package-tools/arch/generate.sh
+++ b/src/libexec/package-tools/arch/generate.sh
@@ -21,7 +21,7 @@ abs_dir() {
 export AZK_ROOT_PATH=`cd \`abs_dir ${BASH_SOURCE:-$0}\`/../../..; pwd`
 export PATH=${AZK_ROOT_PATH}/bin:$PATH
 
-export VERSION=${1:-$( azk version | awk '{ print $2 }' )}
+export VERSION=${1:-$( azk version | sed -e 's/^azk version\ //; s/,.*//' )}
 export AUR_REPO_DIR=${2:-"/tmp/aur-azk"}
 
 RELEASE_CHANNEL=$( echo "${VERSION}" | sed s/[^\\-]*// | sed s/^\\-// | sed s/\\..*// )

--- a/src/libexec/package-tools/mac/generate.sh
+++ b/src/libexec/package-tools/mac/generate.sh
@@ -56,6 +56,7 @@ class ${CLASS_NAME} < Formula
     prefix.install Dir['*']
     prefix.install Dir['.nvmrc']
     prefix.install Dir['.dependencies']
+    prefix.install Dir['.package-envs']
   end
 end
 

--- a/src/libexec/package-tools/mac/generate.sh
+++ b/src/libexec/package-tools/mac/generate.sh
@@ -12,7 +12,7 @@ if [[ -z "${MAC_REPO_STAGE_BRANCH}" ]]; then
   exit 2
 fi
 
-export VERSION=$( azk version | awk '{ print $2 }' )
+export VERSION=$( azk version | sed -e 's/^azk version\ //; s/,.*//' )
 
 SHA256=$(shasum -a 256 shasum -a 256 "package/brew/azk_${VERSION}.tar.gz" | awk '{print $1}')
 

--- a/src/libexec/package-tools/mac/test.sh
+++ b/src/libexec/package-tools/mac/test.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-export VERSION=$( azk version | awk '{ print $2 }' )
+export VERSION=$( azk version | sed -e 's/^azk version\ //; s/,.*//' )
 
 BASE_DIR=$( pwd )
 SHA256=$(shasum -a 256 shasum -a 256 "package/brew/azk_${VERSION}.tar.gz" | awk '{print $1}')
@@ -77,7 +77,8 @@ brew install azukiapp/azk/azk${CHANNEL_SUFFIX}
 cd $FORMULA_DIR
 git checkout $FORMULA_FILE
 
-if [[ "$( bazk version )" == "azk ${VERSION}" ]]; then
+BAZK_VERSION=$(bazk version | sed -e 's/^azk version\ //; s/,.*//')
+if [[ "${BAZK_VERSION}" == "${VERSION}" ]]; then
   echo "azk ${VERSION} has been successfully installed."
 else
   echo "Failed to install azk ${VERSION}."

--- a/src/libexec/package-tools/pack.sh
+++ b/src/libexec/package-tools/pack.sh
@@ -117,6 +117,15 @@ if [[ ! -z "${BUILD_DEB}" ]] || [[ ! -z "${BUILD_RPM}" ]]; then
   [[ ! -e $SECRET_KEY ]] && echo >&2 "Please inform an valid GPG key." && exit 3
 fi
 
+create_package_envs() {
+  AZK_LAST_COMMIT_ID=$(git rev-parse HEAD | cut -c 1-7)
+  AZK_LAST_COMMIT_DATE=$(git log -1 --format=%cd --date=short)
+  (
+    echo "export AZK_LAST_COMMIT_ID=${AZK_LAST_COMMIT_ID}"
+    echo "export AZK_LAST_COMMIT_DATE=${AZK_LAST_COMMIT_DATE}"
+  ) > .package-envs
+}
+
 bump_version() {
   VERSION_NUMBER=$( cat package.json | grep -e "version" | cut -d' ' -f4 | sed -n 's/\"//p' | sed -n 's/\"//p' | sed -n 's/,//p' | sed s/-.*// )
 
@@ -234,6 +243,8 @@ cd $AZK_ROOT_PATH
 source .dependencies
 
 LINUX_BUILD_WAS_EXECUTED=false
+
+step_run "Creating .package-env file" --exit create_package_envs
 
 step_run "Bumping version" --exit bump_version
 

--- a/src/libexec/package-tools/pack.sh
+++ b/src/libexec/package-tools/pack.sh
@@ -279,7 +279,7 @@ if [[ $BUILD_DEB == true ]]; then
       EXTRA_FLAGS="LINUX_CLEAN="
     fi
 
-    step_run "Creating deb packages" make package_deb ${EXTRA_FLAGS}
+    step_run "Creating deb packages" --exit make package_deb ${EXTRA_FLAGS}
 
     UBUNTU_VERSIONS=( "ubuntu12:precise" "ubuntu14:trusty" "ubuntu15:wily" )
     for UBUNTU_VERSION in "${UBUNTU_VERSIONS[@]}"; do
@@ -325,7 +325,7 @@ if [[ $BUILD_RPM == true ]]; then
       EXTRA_FLAGS="LINUX_CLEAN="
     fi
 
-    step_run "Creating rpm packages" make package_rpm ${EXTRA_FLAGS}
+    step_run "Creating rpm packages" --exit make package_rpm ${EXTRA_FLAGS}
 
     FEDORA_VERSIONS=( "fedora20" "fedora23" )
     for FEDORA_VERSION in "${FEDORA_VERSIONS[@]}"; do
@@ -355,7 +355,7 @@ if [[ $BUILD_MAC == true ]]; then
   (
     set -e
     step_run "Cleaning environment" rm -Rf package/brew
-    step_run "Creating Mac packages" make package_mac
+    step_run "Creating Mac packages" --exit make package_mac
     step_run "Generating Mac repository" ${AZK_BUILD_TOOLS_PATH}/mac/generate.sh
     if [[ $NO_TEST != true ]]; then
       step_run "Testing Mac repository" ${AZK_BUILD_TOOLS_PATH}/mac/test.sh $TEST_ARGS

--- a/src/libexec/package-tools/test.sh
+++ b/src/libexec/package-tools/test.sh
@@ -15,7 +15,7 @@ set -e
 
 BASE_DIR=$( echo $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) | sed s#$(pwd)/##g )
 
-export VERSION=$( bin/azk version | awk '{ print $2 }' )
+export VERSION=$( bin/azk version | sed -e 's/^azk version\ //; s/,.*//' )
 export SO=$1
 
 if [[ $# == 2 ]]; then

--- a/src/libexec/package-tools/ubuntu/generate.sh
+++ b/src/libexec/package-tools/ubuntu/generate.sh
@@ -28,7 +28,7 @@ set -e
 export PATH=`pwd`/bin:$PATH
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-export VERSION=$( azk version | awk '{ print $2 }' )
+export VERSION=$( azk version | sed -e 's/^azk version\ //; s/,.*//' )
 export SECRET_KEY=$1
 export LIBNSS_RESOLVER_VERSION=$2
 export DISTRO=$3 && export REPO=azk-${DISTRO}

--- a/src/manifest/get_project.js
+++ b/src/manifest/get_project.js
@@ -204,10 +204,10 @@ export class GetProject extends UIProxy {
   }
 
   _getGitRemoteInfo(git_url) {
-    return this._gitspawn_LsRemoteAsync(git_url)
-    .then((git_result_obj) => {
+    return this._gitHelper.lsRemote(git_url, this.gitOutput)
+    .then((lsRemote_result) => {
       this.ok('commands.start.get_project.getting_remote_info', {git_url});
-      var parsed_result = this._parseGitLsRemoteResult(git_result_obj.message);
+      var parsed_result = this._parseGitLsRemoteResult(lsRemote_result);
       return parsed_result;
     })
     .catch(this._checkGitError(
@@ -364,10 +364,6 @@ export class GetProject extends UIProxy {
   /**********************
     gitspaw _Async calls *
    **********************/
-  _gitspawn_LsRemoteAsync(git_url) {
-    return spawnAsync('git', ['ls-remote', git_url], this.gitOutput);
-  }
-
   _gitspawn_PullAsync(git_url, git_branch_tag_commit, dest_folder) {
 
     var git_params = [

--- a/src/manifest/get_project.js
+++ b/src/manifest/get_project.js
@@ -2,7 +2,7 @@ import { path, lazy_require, config, log, fsAsync } from 'azk';
 import { async, promiseResolve, promiseReject } from 'azk/utils/promises';
 import { UIProxy } from 'azk/cli/ui';
 import { matchFirstRegex, matchAllRegex, fulltrim } from 'azk/utils/regex_helper';
-import { spawnAsync, printOutput } from 'azk/utils/spawn_helper';
+import { printOutput } from 'azk/utils/spawn_helper';
 import { GitCallError } from 'azk/utils/errors';
 
 var lazy = lazy_require({
@@ -18,7 +18,7 @@ export class GetProject extends UIProxy {
     this.is_new_git = null;
     this._gitHelper = lazy.git_helper;
 
-    this.gitOutput = (data) => printOutput(
+    this._gitOutput = (data) => printOutput(
       this.ok.bind(this),
       args.verbose_level,
       '[git]',
@@ -102,7 +102,8 @@ export class GetProject extends UIProxy {
       var force_azk_start_url_endpoint = config('urls:force:endpoints:start');
       this._sendForceAzkStart(command_parse_result, force_azk_start_url_endpoint);
 
-      yield this._checkGitVersion(command_parse_result.verbose_level);
+      var git_version = yield this._gitHelper.version(this._gitOutput);
+      this._checkGitVersion(git_version);
 
       var remoteInfo = yield this._getGitRemoteInfo(
         command_parse_result.git_url,
@@ -129,14 +130,6 @@ export class GetProject extends UIProxy {
             git_destination_path : command_parse_result.git_destination_path,
           });
         }
-
-        // TODO: show menu options
-        // yield this._pullDestination(
-        //   command_parse_result.git_url,
-        //   command_parse_result.git_branch_tag_commit,
-        //   command_parse_result.git_destination_path,
-        //   command_parse_result.verbose_level);
-
       } else {
         // clone to specific branch
         if (_isBranchOrTag && this.is_new_git) {
@@ -189,22 +182,14 @@ export class GetProject extends UIProxy {
     });
   }
 
-  _checkGitVersion() {
+  _checkGitVersion(git_version) {
     this.ok('commands.start.get_project.getting_git_version');
-
-    return this._gitHelper.version(this.gitOutput)
-    .then((git_version) => {
-      this.is_new_git = lazy.semver.gte(git_version, this.IS_NEW_GIT_VERSION_AFTER);
-      return git_version;
-    })
-    .catch(this._checkGitError(
-      null,
-      null,
-      null));
+    this.is_new_git = lazy.semver.gte(git_version, this.IS_NEW_GIT_VERSION_AFTER);
+    return git_version;
   }
 
   _getGitRemoteInfo(git_url) {
-    return this._gitHelper.lsRemote(git_url, this.gitOutput)
+    return this._gitHelper.lsRemote(git_url, this._gitOutput)
     .then((lsRemote_result) => {
       this.ok('commands.start.get_project.getting_remote_info', {git_url});
       var parsed_result = this._parseGitLsRemoteResult(lsRemote_result);
@@ -304,7 +289,7 @@ export class GetProject extends UIProxy {
     return filtered.length > 0;
   }
 
-  _checkDestinationFolder(git_destination_path/*, verbose_level*/) {
+  _checkDestinationFolder(git_destination_path) {
     this.ok('commands.start.get_project.checking_destination', {
       git_destination_path,
     });
@@ -312,21 +297,21 @@ export class GetProject extends UIProxy {
     return fsAsync.exists(git_destination_path);
   }
 
-  _pullDestination(git_url, git_branch_tag_commit, git_destination_path, verbose_level) {
+  _pullDestination(git_url, git_branch_tag_commit, git_destination_path) {
     this.ok('commands.start.get_project.git_pull', {
       git_url,
       git_branch_tag_commit,
       git_destination_path,
     });
 
-    return this._gitspawn_PullAsync(git_url,
-                                    git_branch_tag_commit,
-                                    git_destination_path,
-                                    verbose_level)
+    return this._gitHelper.pull(git_url,
+                                git_branch_tag_commit,
+                                git_destination_path,
+                                this._gitOutput)
       .catch(this._checkGitError(git_url, git_branch_tag_commit, git_destination_path));
   }
 
-  _cloneToFolder(git_url, git_branch_tag_commit, git_destination_path, verbose_level) {
+  _cloneToFolder(git_url, git_branch_tag_commit, git_destination_path) {
     if (git_branch_tag_commit === 'master') {
       this.ok('commands.start.get_project.cloning_master_to_folder', {
         git_url,
@@ -341,64 +326,23 @@ export class GetProject extends UIProxy {
       });
     }
 
-    return this._gitspawn_CloneAsync(git_url,
-                                     git_branch_tag_commit,
-                                     git_destination_path,
-                                     verbose_level)
+    return this._gitHelper.clone(git_url,
+                                git_branch_tag_commit,
+                                git_destination_path,
+                                this.is_new_git,
+                                this._gitOutput)
       .catch(this._checkGitError(git_url, git_branch_tag_commit, git_destination_path));
   }
 
   _checkoutToCommit(parsed_args) {
     this.ok('commands.start.get_project.checkout_to_commit', parsed_args);
 
-    return this._gitspawn_CheckoutInFolderAsync(parsed_args.git_url,
-                                                parsed_args.git_branch_tag_commit,
-                                                parsed_args.git_destination_path,
-                                                parsed_args.verbose_level)
+    return this._gitHelper.checkout(parsed_args.git_branch_tag_commit,
+                                    parsed_args.git_destination_path,
+                                    this._gitOutput)
     .catch(this._checkGitError(
       parsed_args.git_url,
       parsed_args.git_branch_tag_commit,
       parsed_args.git_destination_path));
-  }
-
-  /**********************
-    gitspaw _Async calls *
-   **********************/
-  _gitspawn_PullAsync(git_url, git_branch_tag_commit, dest_folder) {
-
-    var git_params = [
-      '--git-dir',
-      path.resolve(dest_folder, '.git'),
-      '--work-tree',
-      path.resolve(dest_folder),
-      'pull',
-      git_url,
-      git_branch_tag_commit
-    ];
-
-    return spawnAsync('git', git_params, this.gitOutput);
-  }
-
-  _gitspawn_CloneAsync(git_url, git_branch_tag_commit, dest_folder) {
-
-    var git_params = [
-      'clone',
-      git_url,
-      dest_folder,
-      '--recursive'
-    ];
-
-    if (this.is_new_git) {
-      git_params.push('--single-branch');
-      git_params.push('--branch');
-      git_params.push(git_branch_tag_commit);
-    }
-
-    return spawnAsync('git', git_params, this.gitOutput);
-  }
-
-  _gitspawn_CheckoutInFolderAsync(git_url, git_branch_tag_commit, dest_folder) {
-    return spawnAsync('git', ['-C', dest_folder, 'checkout', git_branch_tag_commit],
-      this.gitOutput);
   }
 }

--- a/src/utils/git_helper.js
+++ b/src/utils/git_helper.js
@@ -7,6 +7,21 @@ var lazy = lazy_require({
 var gitHelper = {
   version: (scanFunction) => {
     return lazy.spawnAsync('git', ['--version'], scanFunction);
+  },
+
+  revParse: (revision, location, scanFunction) => {
+    return lazy.spawnAsync('git', [
+      // --git-dir=.git rev-parse --verify HEAD
+      '--git-dir',
+      location,
+      'rev-parse',
+      '--verify',
+      revision
+    ], scanFunction)
+    .then((result) => {
+      return result.message
+        .substring(0, 7);
+    });
   }
 };
 

--- a/src/utils/git_helper.js
+++ b/src/utils/git_helper.js
@@ -1,5 +1,7 @@
 import { lazy_require } from 'azk';
 import { promiseResolve } from 'azk/utils/promises';
+import { groupFromRegex } from 'azk/utils/regex_helper';
+// matchFirstRegex, matchAllRegex, fulltrim,
 
 var lazy = lazy_require({
   spawnAsync : ['azk/utils/spawn_helper'],
@@ -7,7 +9,11 @@ var lazy = lazy_require({
 
 var gitHelper = {
   version: (scanFunction) => {
-    return lazy.spawnAsync('git', ['--version'], scanFunction);
+    return lazy.spawnAsync('git', ['--version'], scanFunction)
+    .then((result) => {
+      var git_version = groupFromRegex(result.message, /.*?(\d+\.\d+\.\d+)/, 1);
+      return promiseResolve(git_version);
+    });
   },
 
   revParse: (revision, location, scanFunction) => {

--- a/src/utils/git_helper.js
+++ b/src/utils/git_helper.js
@@ -1,101 +1,51 @@
 import { lazy_require, path } from 'azk';
 import { promiseResolve, promiseReject } from 'azk/utils/promises';
 import { groupFromRegex } from 'azk/utils/regex_helper';
-// matchFirstRegex, matchAllRegex, fulltrim,
 
 var lazy = lazy_require({
   spawnAsync : ['azk/utils/spawn_helper'],
 });
 
 var gitHelper = {
-  version: (scanFunction) => {
-    return lazy.spawnAsync('git', ['--version'], scanFunction)
-    .then((result) => {
-      if (result.error_code === 0) {
-        var git_version = groupFromRegex(result.message, /.*?(\d+\.\d+\.\d+)/, 1);
-        return promiseResolve(git_version);
-      } else {
-        return promiseReject(result.message);
-      }
-    });
+  version(scanFunction) {
+    let git_params = ['--version'];
+    let format = (result) => groupFromRegex(result.message, /.*?(\d+\.\d+\.\d+)/, 1);
+    return this._spawn_async(git_params, scanFunction, format);
   },
 
-  revParse: (revision, git_path, scanFunction) => {
-    return lazy.spawnAsync('git', [
-      '--git-dir',
-      git_path,
-      'rev-parse',
-      '--verify',
-      revision
-    ], scanFunction)
-    .then((result) => {
-      if (result.error_code === 0) {
-        const commit_id = result.message.substring(0, 7);
-        return promiseResolve(commit_id);
-      } else {
-        return promiseReject(result.message);
-      }
-    });
-  },
-
-  show: (revision, format, git_path, scanFunction) => {
-    return lazy.spawnAsync('git', [
-      '--git-dir',
-      git_path,
-      'show',
-      '-s',
-      '--format=' + format,
-      revision,
-    ], scanFunction)
-    .then((result) => {
-      if (result.error_code === 0) {
-        return promiseResolve(result.message);
-      } else {
-        return promiseReject(result.message);
-      }
-    });
-  },
-
-  lsRemote: (git_url, scanFunction) => {
-    return lazy.spawnAsync('git', [
-      'ls-remote',
-      git_url,
-    ], scanFunction)
-    .then((result) => {
-      if (result.error_code === 0) {
-        return promiseResolve(result.message);
-      } else {
-        return promiseReject(result.message);
-      }
-    });
-  },
-
-  clone: (git_url, git_branch_tag_commit, dest_folder, is_new_git, scanFunction) => {
-    var git_params = [
-      'clone',
-      git_url,
-      dest_folder,
-      '--recursive'
+  revParse(revision, git_path, scanFunction) {
+    let git_params = [
+      '--git-dir', git_path, 'rev-parse', '--verify', revision
     ];
+    let format = (result) => result.message.substring(0, 7);
+    return this._spawn_async(git_params, scanFunction, format);
+  },
+
+  show(revision, format, git_path, scanFunction) {
+    let git_params = [
+      '--git-dir', git_path, 'show', '-s', '--format=' + format, revision
+    ];
+    return this._spawn_async(git_params, scanFunction);
+  },
+
+  lsRemote(git_url, scanFunction) {
+    let git_params = [ 'ls-remote', git_url ];
+    return this._spawn_async(git_params, scanFunction);
+  },
+
+  clone(git_url, git_branch_tag_commit, dest_folder, is_new_git, scanFunction) {
+    var git_params = [ 'clone', git_url, dest_folder, '--recursive' ];
 
     if (is_new_git) {
-      // git_params.push('--single-branch');
       git_params.push('--branch');
       git_params.push(git_branch_tag_commit);
     }
 
-    return lazy.spawnAsync('git', git_params, scanFunction)
-    .then((result) => {
-      if (result.error_code === 0) {
-        return promiseResolve(result.message);
-      } else {
-        return promiseReject(result.message);
-      }
-    });
+    return this._spawn_async(git_params, scanFunction);
   },
 
-  pull: (git_url, git_branch_tag_commit, dest_folder, scanFunction) => {
-    return lazy.spawnAsync('git', [
+  pull(git_url, git_branch_tag_commit, dest_folder, scanFunction) {
+    let git_params = [
       '--git-dir',
       path.resolve(dest_folder, '.git'),
       '--work-tree',
@@ -103,27 +53,30 @@ var gitHelper = {
       'pull',
       git_url,
       git_branch_tag_commit
-    ], scanFunction)
-    .then((result) => {
-      if (result.error_code === 0) {
-        return promiseResolve(result.message);
-      } else {
-        return promiseReject(result.message);
-      }
-    });
+    ];
+
+    return this._spawn_async(git_params, scanFunction);
   },
 
-  checkout: (git_branch_tag_commit, dest_folder, scanFunction) => {
-    return lazy.spawnAsync('git',
-      ['-C', dest_folder, 'checkout', git_branch_tag_commit],
-      scanFunction)
-    .then((result) => {
-      if (result.error_code === 0) {
-        return promiseResolve(result.message);
-      } else {
-        return promiseReject(result.message);
-      }
-    });
+  checkout(git_branch_tag_commit, dest_folder, scanFunction) {
+    let git_params = ['-C', dest_folder, 'checkout', git_branch_tag_commit];
+    return this._spawn_async(git_params, scanFunction);
+  },
+
+  _spawn_async(git_params, scanFunction, format = null) {
+    if (!format) {
+      format = (result) => result.message;
+    }
+
+    return lazy
+      .spawnAsync('git', git_params, scanFunction)
+      .then((result) => {
+        if (result.error_code === 0) {
+          return promiseResolve(format(result));
+        } else {
+          return promiseReject(result.message);
+        }
+      });
   },
 
 };

--- a/src/utils/git_helper.js
+++ b/src/utils/git_helper.js
@@ -16,11 +16,10 @@ var gitHelper = {
     });
   },
 
-  revParse: (revision, location, scanFunction) => {
+  revParse: (revision, git_path, scanFunction) => {
     return lazy.spawnAsync('git', [
-      // --git-dir=.git rev-parse --verify HEAD
       '--git-dir',
-      location,
+      git_path,
       'rev-parse',
       '--verify',
       revision
@@ -29,7 +28,17 @@ var gitHelper = {
       const commit_id = result.message.substring(0, 7);
       return promiseResolve(commit_id);
     });
-  }
+  },
+
+  lsRemote: (git_url, scanFunction) => {
+    return lazy.spawnAsync('git', [
+      'ls-remote',
+      git_url,
+    ], scanFunction)
+    .then((result) => {
+      return promiseResolve(result.message);
+    });
+  },
 };
 
 export default gitHelper;

--- a/src/utils/git_helper.js
+++ b/src/utils/git_helper.js
@@ -5,17 +5,8 @@ var lazy = lazy_require({
 });
 
 var gitHelper = {
-  version: ({verbose_level, ui}) => {
-    return lazy.spawnAsync({
-      executable   : 'git',
-      params_array : [
-        '--version'
-      ],
-      verbose_level : verbose_level,
-      uiOk          : ui.ok.bind(ui),
-      spawn_prefix  : ''
-    });
-
+  version: (scanFunction) => {
+    return lazy.spawnAsync('git', ['--version'], scanFunction);
   }
 };
 

--- a/src/utils/git_helper.js
+++ b/src/utils/git_helper.js
@@ -1,5 +1,5 @@
-import { lazy_require } from 'azk';
-import { promiseResolve } from 'azk/utils/promises';
+import { lazy_require, path } from 'azk';
+import { promiseResolve, promiseReject } from 'azk/utils/promises';
 import { groupFromRegex } from 'azk/utils/regex_helper';
 // matchFirstRegex, matchAllRegex, fulltrim,
 
@@ -11,8 +11,12 @@ var gitHelper = {
   version: (scanFunction) => {
     return lazy.spawnAsync('git', ['--version'], scanFunction)
     .then((result) => {
-      var git_version = groupFromRegex(result.message, /.*?(\d+\.\d+\.\d+)/, 1);
-      return promiseResolve(git_version);
+      if (result.error_code === 0) {
+        var git_version = groupFromRegex(result.message, /.*?(\d+\.\d+\.\d+)/, 1);
+        return promiseResolve(git_version);
+      } else {
+        return promiseReject(result.message);
+      }
     });
   },
 
@@ -25,8 +29,12 @@ var gitHelper = {
       revision
     ], scanFunction)
     .then((result) => {
-      const commit_id = result.message.substring(0, 7);
-      return promiseResolve(commit_id);
+      if (result.error_code === 0) {
+        const commit_id = result.message.substring(0, 7);
+        return promiseResolve(commit_id);
+      } else {
+        return promiseReject(result.message);
+      }
     });
   },
 
@@ -36,9 +44,70 @@ var gitHelper = {
       git_url,
     ], scanFunction)
     .then((result) => {
-      return promiseResolve(result.message);
+      if (result.error_code === 0) {
+        return promiseResolve(result.message);
+      } else {
+        return promiseReject(result.message);
+      }
     });
   },
+
+  clone: (git_url, git_branch_tag_commit, dest_folder, is_new_git, scanFunction) => {
+    var git_params = [
+      'clone',
+      git_url,
+      dest_folder,
+      '--recursive'
+    ];
+
+    if (is_new_git) {
+      // git_params.push('--single-branch');
+      git_params.push('--branch');
+      git_params.push(git_branch_tag_commit);
+    }
+
+    return lazy.spawnAsync('git', git_params, scanFunction)
+    .then((result) => {
+      if (result.error_code === 0) {
+        return promiseResolve(result.message);
+      } else {
+        return promiseReject(result.message);
+      }
+    });
+  },
+
+  pull: (git_url, git_branch_tag_commit, dest_folder, scanFunction) => {
+    return lazy.spawnAsync('git', [
+      '--git-dir',
+      path.resolve(dest_folder, '.git'),
+      '--work-tree',
+      path.resolve(dest_folder),
+      'pull',
+      git_url,
+      git_branch_tag_commit
+    ], scanFunction)
+    .then((result) => {
+      if (result.error_code === 0) {
+        return promiseResolve(result.message);
+      } else {
+        return promiseReject(result.message);
+      }
+    });
+  },
+
+  checkout: (git_branch_tag_commit, dest_folder, scanFunction) => {
+    return lazy.spawnAsync('git',
+      ['-C', dest_folder, 'checkout', git_branch_tag_commit],
+      scanFunction)
+    .then((result) => {
+      if (result.error_code === 0) {
+        return promiseResolve(result.message);
+      } else {
+        return promiseReject(result.message);
+      }
+    });
+  },
+
 };
 
 export default gitHelper;

--- a/src/utils/git_helper.js
+++ b/src/utils/git_helper.js
@@ -1,0 +1,22 @@
+import { lazy_require } from 'azk';
+
+var lazy = lazy_require({
+  spawnAsync : ['azk/utils/spawn_helper'],
+});
+
+var gitHelper = {
+  version: ({verbose_level, ui}) => {
+    return lazy.spawnAsync({
+      executable   : 'git',
+      params_array : [
+        '--version'
+      ],
+      verbose_level : verbose_level,
+      uiOk          : ui.ok.bind(ui),
+      spawn_prefix  : ''
+    });
+
+  }
+};
+
+export default gitHelper;

--- a/src/utils/git_helper.js
+++ b/src/utils/git_helper.js
@@ -38,6 +38,24 @@ var gitHelper = {
     });
   },
 
+  show: (revision, format, git_path, scanFunction) => {
+    return lazy.spawnAsync('git', [
+      '--git-dir',
+      git_path,
+      'show',
+      '-s',
+      '--format=' + format,
+      revision,
+    ], scanFunction)
+    .then((result) => {
+      if (result.error_code === 0) {
+        return promiseResolve(result.message);
+      } else {
+        return promiseReject(result.message);
+      }
+    });
+  },
+
   lsRemote: (git_url, scanFunction) => {
     return lazy.spawnAsync('git', [
       'ls-remote',

--- a/src/utils/git_helper.js
+++ b/src/utils/git_helper.js
@@ -1,4 +1,5 @@
 import { lazy_require } from 'azk';
+import { promiseResolve } from 'azk/utils/promises';
 
 var lazy = lazy_require({
   spawnAsync : ['azk/utils/spawn_helper'],
@@ -19,8 +20,8 @@ var gitHelper = {
       revision
     ], scanFunction)
     .then((result) => {
-      return result.message
-        .substring(0, 7);
+      const commit_id = result.message.substring(0, 7);
+      return promiseResolve(commit_id);
     });
   }
 };

--- a/src/utils/spawn_helper.js
+++ b/src/utils/spawn_helper.js
@@ -7,6 +7,13 @@ var lazy = lazy_require({
   colors : ['azk/utils/colors'],
 });
 
+/**
+ * Print output
+ * @param  function uiOk            some output function
+ * @param  number   verbose_level   if 0 do not print
+ * @param  prefix   prefix          some prefix
+ * @param  string   data            what to print
+ */
 export function printOutput(uiOk, verbose_level, prefix, data) {
   // exit if verbose is zero
   if (verbose_level === 0 || !data) {
@@ -21,40 +28,29 @@ export function printOutput(uiOk, verbose_level, prefix, data) {
   uiOk(prefixed_output);
 }
 
-export function spawnAsync(opts) {
+/**
+ * Executes a command against shell
+ * @param  string     executable     executable path
+ * @param  array      params_array   array with all parameters
+ * @param  function   scanFunction   [otional] output function
+ * @return Promisse                  { error_code: 0, message: 'COMMAND RESULT1\nCOMMAND RESULT2' }
+ */
+export function spawnAsync(executable, params_array, scanFunction) {
   return defer(function (resolve, reject) {
-    var spawn_cmd = spawn(opts.executable, opts.params_array);
+    var spawn_cmd = spawn(executable, params_array);
     var outputs = [];
 
     // print command
-    var full_command = ('$> ' + opts.executable + ' ' + lazy.colors.bold(opts.params_array.join(' ')));
-    printOutput(
-      opts.uiOk,
-      opts.verbose_level,
-      opts.spawn_prefix,
-      full_command
-    );
+    scanFunction && scanFunction(`$> ${executable} ${lazy.colors.bold(params_array.join(' '))}`);
 
     spawn_cmd.stdout.on('data', function (data) {
       outputs.push(data);
-
-      // print output
-      printOutput(
-        opts.uiOk,
-        opts.verbose_level,
-        opts.spawn_prefix,
-        data);
+      scanFunction && scanFunction(data);
     });
 
     spawn_cmd.stderr.on('data', function (data) {
       outputs.push(data);
-
-      // print output
-      printOutput(
-        opts.uiOk,
-        opts.verbose_level,
-        opts.spawn_prefix,
-        data);
+      scanFunction && scanFunction(data);
     });
 
     spawn_cmd.on('close', function (code) {


### PR DESCRIPTION
this closes #605 

When we display `azk version` we do not have what exactly `git commit version`. This works well for released versions but for development `azk` version we need to know exactly what commit that we are running.

For this we will take the current commit being executed by git.

We also will include tests on `spawn_helper` and perhaps further improve the output of `azk version`

#### TODO:

- [x] Create tests for Spawn Helper class
- [x] Split `printOutput` and `spawnAsync` behavior. `spawnAsync` should only return command executed;
- [x] Refactor all `spawnAsync` calls
- [x] Create GitHelper class that calls Spawn Helper class
- [x] Change `azk version` to return `git commit id` too
- [x] Create a way to get commit id from released binary azk version
- [x] `git show -s --format="%ci" HEAD | tee` get date from current commit


#### TODO Optional

- [ ] Improve `azk version` to show more info [optional]

### testing

```sh
# tests
azk gulp test --grep 'Azk cli, version'
azk gulp test --grep 'should _gitspawn_VersionAsync get real current git version'
azk gulp test --grep 'Spawn Helper'
azk gulp test --grep 'Git Helper'
azk gulp test --grep 'git version:'

# real world
rm -rf /tmp/azkdemo; azk start azukiapp/azkdemo /tmp/azkdemo --git-ref benchmark -vv; (cd /tmp/azkdemo; azk stop)
```