### PR TITLE
[Sync] Avoiding touching unrelated files when starting a system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Code] Replacing `chai` by `azk-dev/lib/chai`;
   * [Code] Adding `azk [node|npm|gulp|clingwrap|ncu]` commands in development mode (`AZK_ENV=development`);
   * [Code] Adding global dependencies: `npm-check-updates` and `clingwrap`, for manage npm packages;
+  * [File sharing] Avoiding to fix the synced files permissions for all systems every time a system was started #616;
   * [Docs] All examples of the property `command` were updated as `array` instead of `string`;
 
 * Bug

--- a/src/system/run.js
+++ b/src/system/run.js
@@ -449,11 +449,14 @@ var Run = {
 
   _clean_sync_folder(system, host_folder) {
     return async(this, function* () {
-      var uid_gid;
+      var local_user = config('agent:vm:user');
+      var uid, gid;
       if (config('agent:requires_vm')) {
-        uid_gid = `\$(id -u ${config('agent:vm:user')}):\$(id -g ${config('agent:vm:user')})`;
+        uid = `\$(id -u ${local_user})`;
+        gid = `\$(id -g ${local_user})`;
       } else {
-        uid_gid = `${process.getuid()}:${process.getuid()}`;
+        uid = `${process.getuid()}`;
+        gid = uid;
       }
 
       var mounted_sync_folders = '/sync_folders';
@@ -462,7 +465,7 @@ var Run = {
       // Script to fix sync folder
       var script = [
         `mkdir -p ${current_sync_folder}`,
-        `chown -R ${uid_gid} ${current_sync_folder}`
+        `find ${current_sync_folder} -not -user ${uid} -or -not -group ${gid} -exec chown ${uid}:${gid} '{}' \\;`
       ].join(" && ");
 
       // Docker params

--- a/src/system/run.js
+++ b/src/system/run.js
@@ -462,7 +462,7 @@ var Run = {
       // Script to fix sync folder
       var script = [
         `mkdir -p ${current_sync_folder}`,
-        `chown -R ${uid_gid} ${mounted_sync_folders}`
+        `chown -R ${uid_gid} ${current_sync_folder}`
       ].join(" && ");
 
       // Docker params


### PR DESCRIPTION
This PR closes #615.

Instead of fixing permissions for `sync_folders` root folder (causing every file inside to be touched) every time a system was started, now only that system specific sync folder's permissions are fixed.