### PR TITLE
Adding module `Versions` to `utils`

### DIFF
--- a/spec/utils/versions_spec.js
+++ b/spec/utils/versions_spec.js
@@ -1,0 +1,55 @@
+import h from 'spec/spec_helper';
+import { Versions } from 'azk/utils';
+
+describe("Azk Utils Versions", function() {
+  describe('parse version,', function () {
+    it("should error not regexp", function() {
+      var func = () => Versions.parse(null);
+      h.expect(func).to.throw(Error, /Cannot call method \'match\' of null/);
+    });
+
+    it("should invalid version from empty string", function() {
+      var result = Versions.parse('');
+      h.expect(result).to.be.null;
+    });
+
+    it("should one version by special chars", function() {
+      h.expect(Versions.parse('~> 1.0'     )).to.eql('1.0.0');
+      h.expect(Versions.parse('~> 1.2.9'   )).to.eql('1.2.9');
+      h.expect(Versions.parse('~> 1.3-beta')).to.eql('1.3.0');
+    });
+
+    it("should multiple versions by context", function() {
+      h.expect(Versions.parse('1.0 1.2'          )).to.eql('1.0.0');
+      h.expect(Versions.parse('1.0.1 or 1.2.3'   )).to.eql('1.0.1');
+      h.expect(Versions.parse('1.0.4 or 1.2-beta')).to.eql('1.0.4');
+    });
+  });
+
+  describe('match version,', function () {
+    // https://regex101.com/r/jQ6eE8/3
+    var regex = /elixir[\s]*\:[\s]*\"(?:[~> ]*)?([0-9.]+)(?:(?:[or ]*)?([0-9.]+))?(?:.*)?\".*/gm;
+
+    it("should error not regexp", function() {
+      var func = () => Versions.match(null, '');
+      h.expect(func).to.throw(Error, /regex .* is not instance of \`RegExp\`/);
+    });
+
+    it("should invalid version from empty string", function() {
+      var result = Versions.match(regex, '');
+      h.expect(result).to.not.be.undefined;
+    });
+
+    it("should one version by context", function() {
+      h.expect(Versions.match(regex, 'elixir: "~> 1.0",'     )).to.eql(['1.0.0']);
+      h.expect(Versions.match(regex, 'elixir: "~> 1.2.9",'   )).to.eql(['1.2.9']);
+      h.expect(Versions.match(regex, 'elixir: "~> 1.3-beta",')).to.eql(['1.3.0']);
+    });
+
+    it("should multiple versions by context", function() {
+      h.expect(Versions.match(regex, 'elixir: "~> 1.0 or 1.2",'       )).to.eql(['1.0.0', '1.2.0']);
+      h.expect(Versions.match(regex, 'elixir: "~> 1.0.1 or 1.2.3",'   )).to.eql(['1.0.1', '1.2.3']);
+      h.expect(Versions.match(regex, 'elixir: "~> 1.0.4 or 1.2-beta",')).to.eql(['1.0.4', '1.2.0']);
+    });
+  });
+});

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -5,10 +5,11 @@ var fs     = require('fs');
 var defer  = require('azk/utils/promises').defer;
 
 var Utils = {
-  get default() { return Utils; },
-  get _      () { return _; },
-  get net    () { return require('azk/utils/net'); },
-  get docker () { return require('azk/utils/docker'); },
+  get default () { return Utils; },
+  get _       () { return _; },
+  get net     () { return require('azk/utils/net'); },
+  get docker  () { return require('azk/utils/docker'); },
+  get Versions() { return require('azk/utils/versions'); },
 
   /**
    * `lazy_require` can postpone loading of external dependencies.

--- a/src/utils/versions.js
+++ b/src/utils/versions.js
@@ -1,0 +1,58 @@
+import { lazy_require } from 'azk';
+var lazy = lazy_require({
+  semver: 'semver',
+});
+
+// var last  = require('lodash/array/last');
+
+/**
+ * Versions: Abstraction above the [semver](https://www.npmjs.com/package/semver).
+ */
+
+var Versions = {
+  /**
+   * compare version by regex
+   * @param  {Regex}    regex     Regular expression to compare with content;
+   * @param  {String}   content   String with version to parse;
+   * @return {Array}              collection of versions;
+   */
+  match(regex, content) {
+    if (!(regex instanceof RegExp)) {
+      throw new Error(`regex ${regex} is not instance of \`RegExp\``);
+    }
+    // fix cached regex
+    regex = new RegExp(regex);
+    var match = regex.exec(content) || [];
+    match = match.slice(1, match.length)
+    var versions = [];
+    match.forEach((version) =>{
+      if (version) {
+        version = this.parse(version);
+        versions.push(version);
+      }
+    });
+    return versions;
+  },
+
+  /**
+   * parse version from string
+   * @param  {String}      context   context contents version
+   * @return {String|Null}           parsed version
+   */
+  parse(context, depth=3) {
+    var match   = context.match(/([0-9.]+)/gm);
+    var version = (match && match[0]);
+    if (version) {
+      // force valid format: eg: 1.0 => 1.0.0 (with depth=3)
+      var splited = version.split('.');
+      for(var i = 0; i < depth; i++) {
+        splited[i] = splited[i] || '0';
+      }
+      version = splited.join('.');
+      version = lazy.semver.clean(version);
+    }
+    return version;
+  }
+};
+
+export default Versions;


### PR DESCRIPTION
the module `Versions` is an abstraction above the [semver](https://www.npmjs.com/package/semver).

#### Usage

```javascript
import { Versions } from 'azk/utils';
Versions.parse('~> 1.0'        ); // => '1.0.0'
Versions.parse('1.0 1.2'       ); // => '1.0.0'
Versions.parse('1.0.1 or 1.2.3'); // => '1.0.1'

// https://regex101.com/r/jQ6eE8/3
var regex = /elixir[\s]*\:[\s]*\"(?:[~> ]*)?([0-9.]+)(?:(?:[or ]*)?([0-9.]+))?(?:.*)?\".*/gm;

Versions.match(regex, 'elixir: "~> 1.2",'           ); // => ['1.0.0', '1.2.0']
Versions.match(regex, 'elixir: "~> 1.0.1 or 1.2.3",'); // => ['1.0.1', '1.2.3']
```

#### Tests

```
azk gulp test --grep "Azk Utils Versions"
```