### PR TITLE
[Sync] Fixing ownership of the symlink itself, not of the target file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Docs] The instructions for use `azk` and `Wordpress` have been improved;
   * [Manifest] Adding `resolve` options to `path`, with default `true` value;
 
+* Bug
+  * [Sync] Fixing ownership of the symlink itself, not of the target file;
+
 ## v0.17.0 - (2016-02-19)
 
 * Enhancements

--- a/src/system/run.js
+++ b/src/system/run.js
@@ -462,7 +462,7 @@ var Run = {
       var mounted_sync_folders = '/sync_folders';
       var current_sync_folder = path.join(mounted_sync_folders, system.manifest.namespace, system.name, host_folder);
 
-      var find_exec = `-exec chown ${uid}:${gid} '{}' \\;`;
+      var find_exec = `-exec chown -h ${uid}:${gid} '{}' \\;`;
       var find_args = `${current_sync_folder} \\( -not -user ${uid} -or -not -group ${gid} \\) ${find_exec}`;
 
       // Script to fix sync folder


### PR DESCRIPTION
This PR intends to fix a bug in the `sync` mount.

When a symlink was intended to be synced, `sync` tried to run a `chown` over it. The bug occurs when the target file didn't exist in the `sync` container context.

Example:

```
mounts: {
  '/azk/#{manifest.dir}' : sync("."),
  '/azk/other/file'      : path("../file"),  // may or may not be mounted
}
```

```
$ ls -l ./link
lrwxrwxrwx 1 user users 27 Mar 31 19:28 link -> ../file

```

In this case, the `sync` occurs for the current dir (`.`), which contains a symlink named `link` that points to the file `../file`. In the `sync` container, the `file` doesn't exist, and the `chown` fails.

Adding the `-h` option, the `chown` command is applied to the symlink itself, instead of be applied to the target file.