### PR TITLE
[Package] Updating how `azk version` is extracted from CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,13 +160,13 @@ package_clean:
 	@echo "task: $@"
 	@rm -Rf ${AZK_PACKAGE_PREFIX}/..?* ${AZK_PACKAGE_PREFIX}/.[!.]* ${AZK_PACKAGE_PREFIX}/*
 
-check_version: NEW_AZK_VERSION=$(shell ${PATH_USR_LIB_AZK}/bin/azk version | sed -e 's/^azk version\ //; s/,.*//')
+check_version: NEW_AZK_VERSION=$(shell ${PATH_USR_LIB_AZK}/bin/azk version | sed -e 's/^azk //; s/^version //; s/,.*//' )
 check_version:
 	@echo "task: $@"
 	@if [ ! "${AZK_VERSION}" = "${NEW_AZK_VERSION}" ] ; then \
 		echo 'Error to run: ${PATH_USR_LIB_AZK}/bin/azk version'; \
 		echo 'Expect: azk ${AZK_VERSION}'; \
-		echo 'Output: ${NEW_AZK_VERSION}'; \
+		echo 'Output: azk ${NEW_AZK_VERSION}'; \
 		exit 1; \
 	fi
 

--- a/shared/scripts/install.sh
+++ b/shared/scripts/install.sh
@@ -422,9 +422,8 @@ check_azk_installation() {
 }
 
 azk_is_up_to_date() {
+  AZK_CURRENT_VERSION=$(azk version | sed -e 's/^azk //; s/^version //; s/,.*//')
   AZK_TAGS_URL="https://api.github.com/repos/azukiapp/azk/tags"
-  AZK_VERSIONS=$(curl -sSL ${AZK_TAGS_URL} | grep name)
-  AZK_CURRENT_VERSION=$(azk version | sed -e 's/^azk version\ //; s/,.*//')
   AZK_LATEST_VERSION=$( curl -sSL ${AZK_TAGS_URL} | \
                         grep name | \
                         head -1 | \

--- a/spec/cmds/init_spec.js
+++ b/spec/cmds/init_spec.js
@@ -15,6 +15,16 @@ describe('Azk cli, init controller', function() {
   var doc_opts    = { exit: false };
   var run_options = { ui: ui };
 
+  it("should return manifest filename", function() {
+    doc_opts.argv = ['init', '--filename'];
+    var options = cli.docopt(doc_opts);
+    return cli.run(doc_opts, run_options).then((code) => {
+      h.expect(options).to.have.property('--filename', true);
+      h.expect(code).to.equal(0);
+      h.expect(outputs[0]).to.equal(config('manifest'));
+    });
+  });
+
   describe("run in a project already has a manifest", function() {
     var message = t("commands.init.already_exists", manifest);
 

--- a/spec/integration/common/cmds/docker.bats
+++ b/spec/integration/common/cmds/docker.bats
@@ -28,7 +28,7 @@ image_name="azukiapp/azktcl"
 
   run azk docker -- build -t $image .
   assert_success
-  assert_match "Step 0 : FROM ${image_name}:${image_tag}"
+  assert_match "Step 1 : FROM ${image_name}:${image_tag}"
 
   run azk docker rmi $image
   assert_success

--- a/spec/integration/common/cmds/shell.bats
+++ b/spec/integration/common/cmds/shell.bats
@@ -17,7 +17,7 @@ image_name="azukiapp/azktcl"
 
 @test "$test_label run shell with shell-args" {
   cmd="ls -l /; echo 'foo bar'; uname"
-  run azk --log=debug shell --image "${image_name}:${image_tag}" --shell /bin/bash -- -c "${cmd}"
+  run azk --log=debug shell --image "${image_name}:${image_tag}" --shell /bin/bash -- "${cmd}"
   assert_success
   assert_match "d.*bin"
   assert_match "d.*etc"

--- a/spec/integration/common/cmds/version.bats
+++ b/spec/integration/common/cmds/version.bats
@@ -8,5 +8,5 @@ load ../../test_helper
 
   run azk version
   assert_success
-  assert_output "azk $version"
+  assert_match "azk version $version, build .*, date .*"
 }

--- a/src/cmds/init.js
+++ b/src/cmds/init.js
@@ -1,6 +1,6 @@
 import { CliController } from 'cli-router';
 import { _, config, fsAsync, path, lazy_require, log } from 'azk';
-import { async, promiseResolve } from 'azk/utils/promises';
+import { async } from 'azk/utils/promises';
 
 var lazy = lazy_require({
   Generator     : ['azk/generator'],
@@ -11,7 +11,8 @@ export default class Init extends CliController {
   index(params) {
     return async(this, function* () {
       if (params.filename) {
-        return this.showFilename();
+        this.showFilename();
+        return 0;
       }
 
       var generator = new lazy.Generator(this.ui);
@@ -22,7 +23,7 @@ export default class Init extends CliController {
       var manifest_exists = yield fsAsync.exists(file);
       if (manifest_exists && !params.force) {
         this.ui.fail(this.ui.tKeyPath(this.name, "already_exists"), manifest);
-        return promiseResolve(1);
+        return 1;
       }
 
       var systemsData = yield generator.findSystems(cwd);
@@ -42,7 +43,7 @@ export default class Init extends CliController {
         this.ui.ok(this.ui.tKeyPath(this.name, 'github'));
       }
 
-      return promiseResolve(0);
+      return 0;
     });
   }
 

--- a/src/libexec/package-tools/arch/generate.sh
+++ b/src/libexec/package-tools/arch/generate.sh
@@ -21,7 +21,7 @@ abs_dir() {
 export AZK_ROOT_PATH=`cd \`abs_dir ${BASH_SOURCE:-$0}\`/../../..; pwd`
 export PATH=${AZK_ROOT_PATH}/bin:$PATH
 
-export VERSION=${1:-$( azk version | sed -e 's/^azk version\ //; s/,.*//' )}
+export VERSION=${1:-$( azk version | sed -e 's/^azk //; s/^version //; s/,.*//' )}
 export AUR_REPO_DIR=${2:-"/tmp/aur-azk"}
 
 RELEASE_CHANNEL=$( echo "${VERSION}" | sed s/[^\\-]*// | sed s/^\\-// | sed s/\\..*// )

--- a/src/libexec/package-tools/mac/generate.sh
+++ b/src/libexec/package-tools/mac/generate.sh
@@ -12,7 +12,7 @@ if [[ -z "${MAC_REPO_STAGE_BRANCH}" ]]; then
   exit 2
 fi
 
-export VERSION=$( azk version | sed -e 's/^azk version\ //; s/,.*//' )
+export VERSION=$( azk version | sed -e 's/^azk //; s/^version //; s/,.*//'  )
 
 SHA256=$(shasum -a 256 shasum -a 256 "package/brew/azk_${VERSION}.tar.gz" | awk '{print $1}')
 

--- a/src/libexec/package-tools/mac/test.sh
+++ b/src/libexec/package-tools/mac/test.sh
@@ -2,7 +2,7 @@
 
 set -x
 
-export VERSION=$( azk version | sed -e 's/^azk version\ //; s/,.*//' )
+export VERSION=$( azk version | sed -e 's/^azk //; s/^version //; s/,.*//' )
 
 BASE_DIR=$( pwd )
 SHA256=$(shasum -a 256 shasum -a 256 "package/brew/azk_${VERSION}.tar.gz" | awk '{print $1}')
@@ -82,7 +82,7 @@ fi
 cd $FORMULA_DIR
 git checkout $FORMULA_FILE
 
-BAZK_VERSION=$(bazk version | sed -e 's/^azk version\ //; s/,.*//')
+BAZK_VERSION=$(bazk version | sed -e 's/^azk //; s/^version //; s/,.*//')
 if [[ "${BAZK_VERSION}" == "${VERSION}" ]]; then
   echo "azk ${VERSION} has been successfully installed."
 else

--- a/src/libexec/package-tools/pack.sh
+++ b/src/libexec/package-tools/pack.sh
@@ -288,7 +288,7 @@ if [[ $BUILD_DEB == true ]]; then
       step_run "Cleaning environment" rm -Rf package/deb package/public
     fi
 
-    step_run "Downloading libnss-resolver" \
+    step_run "Downloading libnss-resolver" --exit \
     mkdir -p package/deb \
     && wget -q "${LIBNSS_RESOLVER_REPO}/ubuntu12-libnss-resolver_${LIBNSS_RESOLVER_VERSION}_amd64.deb" -O "package/deb/precise-libnss-resolver_${LIBNSS_RESOLVER_VERSION}_amd64.deb" \
     && wget -q "${LIBNSS_RESOLVER_REPO}/ubuntu14-libnss-resolver_${LIBNSS_RESOLVER_VERSION}_amd64.deb" -O "package/deb/trusty-libnss-resolver_${LIBNSS_RESOLVER_VERSION}_amd64.deb" \
@@ -337,7 +337,7 @@ if [[ $BUILD_RPM == true ]]; then
 
     [[ ${CLEAN_REPO} == true ]] && step_run "Cleaning environment" rm -Rf package/rpm package/fedora20 package/fedora23
 
-    step_run "Downloading libnss-resolver" \
+    step_run "Downloading libnss-resolver" --exit \
     mkdir -p package/rpm \
     && wget "${LIBNSS_RESOLVER_REPO}/fedora20-libnss-resolver-${LIBNSS_RESOLVER_VERSION}-1.x86_64.rpm" -O "package/rpm/fedora20-libnss-resolver-${LIBNSS_RESOLVER_VERSION}-1.x86_64.rpm" \
     && wget "${LIBNSS_RESOLVER_REPO}/fedora23-libnss-resolver-${LIBNSS_RESOLVER_VERSION}-1.x86_64.rpm" -O "package/rpm/fedora23-libnss-resolver-${LIBNSS_RESOLVER_VERSION}-1.x86_64.rpm"

--- a/src/libexec/package-tools/test-container.sh
+++ b/src/libexec/package-tools/test-container.sh
@@ -69,7 +69,7 @@ setup() {
 
 run_test() {
   set -e
-  DETECTED_VERSION=$( azk version | sed -e 's/^azk version\ //; s/,.*//' )
+  DETECTED_VERSION=$( azk version | sed -e 's/^azk //; s/^version //; s/,.*//' )
 
   if [[ "${DETECTED_VERSION}" != "${VERSION}" ]]; then
     echo "Version check failed."

--- a/src/libexec/package-tools/test.sh
+++ b/src/libexec/package-tools/test.sh
@@ -15,7 +15,7 @@ set -e
 
 BASE_DIR=$( echo $( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd ) | sed s#$(pwd)/##g )
 
-export VERSION=$( bin/azk version | sed -e 's/^azk version\ //; s/,.*//' )
+export VERSION=$( bin/azk version | sed -e 's/^azk //; s/^version //; s/,.*//' )
 export SO=$1
 
 if [[ $# == 2 ]]; then

--- a/src/libexec/package-tools/ubuntu/generate.sh
+++ b/src/libexec/package-tools/ubuntu/generate.sh
@@ -28,7 +28,7 @@ set -e
 export PATH=`pwd`/bin:$PATH
 DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 
-export VERSION=$( azk version | sed -e 's/^azk version\ //; s/,.*//' )
+export VERSION=$( azk version | sed -e 's/^azk //; s/^version //; s/,.*//' )
 export SECRET_KEY=$1
 export LIBNSS_RESOLVER_VERSION=$2
 export DISTRO=$3 && export REPO=azk-${DISTRO}


### PR DESCRIPTION
This PR intends to update azk scripts and tests for the changes from #614 

The command used to extract azk version from command line is:

```sh
$ azk version | sed -e 's/^azk //; s/^version //; s/,.*//'
```

This works for both old and new `azk version` output:

```sh
# New version output format
$ echo "azk version 0.17.0, build 2f55d48, date 2016-04-01" | \
  sed -e 's/^azk //; s/^version //; s/,.*//'
#=> 0.17.0

# Old version output format
$ echo "azk 0.17.0" | \
  sed -e 's/^azk //; s/^version //; s/,.*//'
#=> 0.17.0
```