### PR TITLE
[Docs] Adding Arch Linux as supported distribution

### DIFF
--- a/docs/content/en/installation/linux.md
+++ b/docs/content/en/installation/linux.md
@@ -4,9 +4,9 @@
 
 ## Requirements
 
-* **Distributions (tested)**: Ubuntu 12.04/14.04/15.10 and Fedora 20/21/22
+* **Distributions (tested)**: Ubuntu 12.04/14.04/15.10, Fedora 20/21/22 and Arch Linux
 * **Architecture**: 64-bits
-* [Docker][docker] 1.8.1
+* [Docker][docker] 1.8.1 or later
 * Not running any services on ports `80` and `53`
 
 **Important**: If you are running any service on port `80` and/or `53` you must customize the configuration of `azk` setting the following variables `AZK_BALANCER_PORT` and `AZK_DNS_PORT` respectively, before running `azk agent start`.
@@ -27,6 +27,7 @@ There are two ways to install Docker:
 
   - [Ubuntu][docker_ubuntu_installation]
   - [Fedora][docker_fedora_installation]
+  - [Arch Linux][docker_arch_installation]
 
 ## Granting access to Docker service to your user
 
@@ -38,7 +39,7 @@ To avoid having to use sudo when you use the docker command, create a Unix group
 
 To create the docker group and add your user:
 
-1. Log into Ubuntu as a user with sudo privileges;
+1. Log in as a user with sudo privileges;
 
 2. Create the docker group and add your user
 
@@ -147,6 +148,17 @@ The easiest way to install `azk` is to use the script below. It will identify yo
 
 4. You can [start the azk agent](../getting-started/starting-agent.md) now, but, **make sure that the Docker service is running**;
 
+### Arch Linux
+
+> You'll need `yaourt` or some other tool to get packages from [AUR](https://aur.archlinux.org/). To learn how to install `yaourt`, check [these instructions](https://archlinux.fr/yaourt-en).
+
+1. Install `azk` and its dependencies:
+
+  ```bash
+  $ yaourt -S azk
+  ```
+
+2. You can [start the azk agent](../getting-started/starting-agent.md) now, but, **make sure that the Docker service is running**;
 
 ### Other distributions
 

--- a/docs/content/links.md
+++ b/docs/content/links.md
@@ -7,6 +7,7 @@
 [docker_install]: https://docs.docker.com/installation/#installation
 [docker_ubuntu_installation]: http://docs.docker.com/engine/installation/ubuntulinux/
 [docker_fedora_installation]: http://docs.docker.com/engine/installation/fedora/
+[docker_arch_installation]: http://docs.docker.com/engine/installation/linux/archlinux/
 [docker_daemon_attack_surface]: https://docs.docker.com/engine/articles/security/#docker-daemon-attack-surface
 
 [postgres]: http://www.postgresql.org/

--- a/docs/content/pt-BR/installation/linux.md
+++ b/docs/content/pt-BR/installation/linux.md
@@ -4,9 +4,9 @@
 
 ## Requisitos
 
-* **Distribuições (testadas)**: Ubuntu 12.04/14.04/15.10 e Fedora 20/21/22
+* **Distribuições (testadas)**: Ubuntu 12.04/14.04/15.10, Fedora 20/21/22 e Arch Linux
 * **Arquitetura**: 64-bits
-* [Docker][docker] 1.8.1
+* [Docker][docker] 1.8.1 ou mais recente
 * Não estar rodando nenhum serviço nas portas `80` e `53`
 
 **Importante**: Se você estiver rodando algum serviço nas portas `80` e/ou `53` você deve customizar a configuração do `azk` definindo as seguintes variáveis `AZK_BALANCER_PORT` e `AZK_DNS_PORT` respectivamente, antes de executar o `azk agent start`.
@@ -27,6 +27,7 @@ Existem duas formas de instalação do Docker:
 
   - [Ubuntu][docker_ubuntu_installation]
   - [Fedora][docker_fedora_installation]
+  - [Arch Linux][docker_arch_installation]
 
 ## Dando acesso ao serviço do Docker para o seu usuário
 
@@ -146,6 +147,18 @@ A forma mais fácil de instalar o `azk` é utilizar o script abaixo. Ele vai ide
   ```
 
 4. Você pode [iniciar o agent](../getting-started/starting-agent.md) agora, porém, **tenha certeza de que o serviço do Docker está rodando**;
+
+### Arch Linux
+
+> Você precisará do `yaourt` ou de alguma outra ferramenta para obter pacotes do [AUR](https://aur.archlinux.org/). Para aprender como instalar o `yaourt`, [siga essas instruções](https://archlinux.fr/yaourt-en) como instalar o `yaourt`.
+
+1. Instale o `azk` e suas dependências:
+
+  ```bash
+  $ yaourt -S azk
+  ```
+
+2. Você pode [iniciar o agent](../getting-started/starting-agent.md) agora, porém, **tenha certeza de que o serviço do Docker está rodando**;
 
 ### Outras distribuições
 


### PR DESCRIPTION
Since [`azk` installation script](https://github.com/azukiapp/azk/blob/master/shared/scripts/install.sh) already supports Arch Linux (via `yaourt`), I'm adding instructions on docs for manual installation of azk on that SO.