### PR TITLE
[Cli] Adding more options to `azk info`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Docs] Updating whole docs structure: Azkfile, Gitbook version and plugins;
   * [Cli] `azk version` changes to display the first 7 digits of the commit hash and the date of the corresponding commit version;
   * [Cli] Adding options `--full` and `--logo` the command `azk version`, to show more information (old `azk doctor`);
+  * [Cli] Adding more options to `azk info`, now have a `--filter` and `--json`;
 
 * Deprecations
   * [Cli]  Deprecating `azk doctor` command, now use `azk version --full`;

--- a/docs/content/en/reference/cli/info.md
+++ b/docs/content/en/reference/cli/info.md
@@ -4,14 +4,24 @@
 
 #### Usage:
 
-    azk info [options]
+    azk info [<system>] [options]
+
+#### Examples:
+
+```
+azk info
+azk info web
+azk info web,worker --filter=mounts,env
+```
 
 ####  Options:
 
 ```
-  --no-color                Remove colors from output
+  --json                    Outputs in json format.
+  --filter=<props>          Filter system properties [default: all].
   --quiet, -q               Never prompt.
   --help, -h                Shows help usage.
+  --no-color                Remove colors from output
   --log=<level>, -l         Sets log level (default: error).
   --verbose, -v             Sets the level of detail - multiple supported (-vv == --verbose 2) [default: 0].
 ```

--- a/docs/content/pt-BR/reference/cli/info.md
+++ b/docs/content/pt-BR/reference/cli/info.md
@@ -2,18 +2,26 @@
 
   Exite informações dos sistemas do atual `Azkfile.js`.
 
-#### Uso:
+#### Usage:
+
+    azk info [<system>] [options]
+
+#### Examples:
 
 ```
-  azk info [options]
+azk info
+azk info web
+azk info web,worker --filter=mounts,env
 ```
 
 ####  Opções:
 
 ```
-  --no-color                Remove cores na saída padrão
+  --json                    Gera uma saída no formato json.
+  --filter=<props>          Filtras quais as propriedades [padrão: all].
   --quiet, -q               Nunca perguntar.
   --help, -h                Mostrar ajuda de uso.
+  --no-color                Remove cores na saída padrão
   --log=<level>, -l         Defini o nível de log (padrão: error).
   --verbose, -v             Defini o nível de detalhes da saída - suporta múltiplos (-vv == --verbose 2) [padrão: 0].
 ```

--- a/shared/locales/usage-en-US.txt
+++ b/shared/locales/usage-en-US.txt
@@ -10,7 +10,7 @@ Usage:
   azk deploy rollback [<ref>] [-qh --no-color -l <level>] [-v]...
   azk deploy [-qh --no-color -l <level>] [-v]...
   azk docker [-qh --no-color -l <level>] [-v]... [-- <docker-args>...]
-  azk info [-qh --no-color -l <level>] [-v]...
+  azk info [<system>] [--json --filter=<f>] [-qh --no-color -l <level>] [-v]...
   azk init [<path>] [--filename --force] [-qh --no-color -l <level>] [-v]...
   azk logs [<system> <instances>] [--no-timestamps --follow --lines=<n>] [-qh --no-color -l <level>] [-v]...
   azk open [<system>] [--open-with=<app>] [-qh --no-color -l <level>] [-v]...
@@ -84,15 +84,19 @@ Options:
   --cwd=<dir>, -C           Sets the current working directory.
   --env=<data>, -e          Additional environment variables - multiple supported (`-e HTTP_PORT=5000 -e PORT=5000`).
   --filename                Shows the manifest filename.
+  --filter=<props>          Filter system properties [default: all].
   --force, -F               Force mode on.
   --follow, -f              Follows log output.
+  --git-ref=<git-ref>       Git branch, tag or commit to clone
   --help, -h                Shows help usage.
   --image=<name>, -i        Defines the image in which the command will be executed.
+  --json                    Outputs in json format.
   --log=<level>, -l         Sets log level (default: error).
   --logo                    Shows the azk logo before showing health information.
   --full                    Shows full version information.
   --long                    Show all columns.
   --mount=<paths>, -m       Additional mounting points - multiple supported (`-m ~/Home:/azk/user -m ~/data:/var/data`).
+  --mounts                  Only show mounts options.
   --lines=<n>, -n           Outputs the specified number of lines at the end of logs [default: all].
   --no-daemon               Runs `azk agent` in foreground.
   --no-reload-vm            Do not reload Virtual Machine settings.
@@ -110,7 +114,6 @@ Options:
   --tty, -t                 Forces pseudo-tty allocation.
   --text                    Shows output in plain text mode.
   --verbose, -v             Sets the level of detail - multiple supported (-vv == --verbose 2) [default: 0].
-  --git-ref=<git-ref>       Git branch, tag or commit to clone
   --silent                  Prevents any log message about command execution. It's useful when using the `-c` option and the output is used as input to another command using the pipe `|` operator.
   --version                 Shows azk version.
 


### PR DESCRIPTION
This PR adds the following options to the command `azk info`:

- `[<system>]`: just like in the commands `azk start` and `azk stop`, now it's possible to specify a system or a list of systems to retrieve info from;
- `--json`: the command output is formatted as a JSON;
- `--filter=[properties]`: a list of system properties to be shown (the default behavior is to show all of them);