### PR TITLE
[Cli] Improving `azk version --full` output

### DIFF
--- a/spec/cmds/doctor_spec.js
+++ b/spec/cmds/doctor_spec.js
@@ -20,7 +20,7 @@ describe('Azk cli, doctor controller', function() {
       h.expect(code).to.equal(0);
       h.expect(options).to.have.property('doctor', true);
       h.expect(outputs[0]).to.match(RegExp(`Version.*\:.*${h.escapeRegExp(Azk.version)}`));
-      h.expect(outputs[0]).to.match(RegExp(`Agent.*\:.*up`));
+      h.expect(outputs[0]).to.match(RegExp(`Agent.*\:.*Running`));
     });
   });
 
@@ -31,7 +31,7 @@ describe('Azk cli, doctor controller', function() {
       h.expect(code).to.equal(0);
       h.expect(options).to.have.property('doctor', true);
       h.expect(outputs[0]).to.match(RegExp(`Version.*\:.*${h.escapeRegExp(Azk.version)}`));
-      h.expect(outputs[0]).to.match(RegExp(`Agent.*\:.*up`));
+      h.expect(outputs[0]).to.match(RegExp(`Agent.*\:.*Running`));
     });
   });
 });

--- a/src/cli/ui.js
+++ b/src/cli/ui.js
@@ -154,9 +154,15 @@ var UI = {
     if (callback) {
       return lazy.execShLib(command, options, callback);
     } else {
-      var result = (err) => { return (err) ? err.code : 0; };
       var execShLib = promisify(lazy.execShLib, { multiArgs: true });
-      return execShLib(command, options).spread(result).catch(result);
+      return execShLib(command, options)
+        .spread((stdout, stderr) => {
+          if (options === true) {
+            return { stdout, stderr };
+          }
+          return 0;
+        })
+        .catch((err) => err.code);
     }
   },
 

--- a/src/cli/views/version_view.js
+++ b/src/cli/views/version_view.js
@@ -47,11 +47,11 @@ export class VersionView extends View {
 
   format(data) {
     return [
-      `${this.c.cyan("Version")}   : ${this.c.blue(data.version)}`,
-      `${this.c.cyan("OS")}        : ${this.c.blue(data.os)}`,
+      `${this.c.cyan("Version")}   : ${data.version}`,
+      `${this.c.cyan("OS")}        : ${data.os}`,
       `${this.c.cyan("Agent")}     : ${data.agent_running}`,
       `${this.c.cyan("Docker")}    : ${data.docker.Version}`,
-      `${this.c.cyan("Use vm")}    : ${data.use_vm}`,
+      `${this.c.cyan("Uses VM")}   : ${data.use_vm}`,
       `${this.c.cyan("VirtualBox")}: ${_.trim(data.vbox_version)}`,
     ];
   }


### PR DESCRIPTION
This PR closes #508 

When the agent is down, `azk` falls back to retrieve Docker version from CLI using the command:

```
docker --version
```

Plus, the output has been slightly improved.