### PR TITLE
[Cli] Fixing error thrown on 'azk scale' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Bug
+  * [Cli] Fixing error thrown when 'azk scale' command was run, regardless it was successful or not;
+
 ## v0.18.0 - (2016-04-07)
 
 * Enhancements

--- a/src/cli/index.js
+++ b/src/cli/index.js
@@ -66,13 +66,17 @@ export function cli(args, cwd, ui = UI) {
 
   if (isPromise(result)) {
     result
-      .then((code) => {
+      .then((code_or_err) => {
         // Convert a not number in a UnknownError
-        if (!_.isNumber(code)) {
-          log.warn('[cli] command not return error or code, return: %j', code);
-          throw new UnknownError(code);
+        if (!_.isNumber(code_or_err)) {
+          log.warn('[cli] command not return error or code, return: %j', code_or_err);
+          // If is undefined, skip throwing the exception
+          if (_.isUndefined(code_or_err)) {
+            return 0;
+          }
+          throw new UnknownError(code_or_err);
         }
-        return code;
+        return code_or_err;
       })
       .catch((error) => {
         return error_handler(error, { ui });

--- a/src/cmds/scale.js
+++ b/src/cmds/scale.js
@@ -48,6 +48,7 @@ export default class Scale extends CliTrackerController {
         var system = systems[i];
         yield this._scale(system, parseInt(opts.to || 1), opts);
       }
+      return 0;
     });
   }
 


### PR DESCRIPTION
This PR intends to fix an issue occurring after the execution of `azk scale` command (see output below).

```
➜  azkdemo git:(master) ✗ azk scale azkdemo 2
┌───┬─────────┬───────────┬───────────────────────────┬────────────────────────────┬────────────────┐
│   │ System  │ Instances │ Hostname/url              │ Instances-Ports            │ Provisioned    │
├───┼─────────┼───────────┼───────────────────────────┼────────────────────────────┼────────────────┤
│ ↑ │ azkdemo │ 2         │ http://azkdemo.dev.azk.io │ 2-http:32769, 1-http:32768 │ 32 minutes ago │
│   │         │           │                           │                            │                │
└───┴─────────┴───────────┴───────────────────────────┴────────────────────────────┴────────────────┘
azk: Unknown error: "undefined"
azk: Sorry, an error has occurred.
azk: A crash report about this error will be sent to azk team in order to make azk better.
? Bonus: if you're ok with telling us your email address, we'll be able to reply you with 
a solution for this issue.
Important: Your email will be saved for future crash reports (we'll never share your email
).
You can always delete/update your email at any time. See http://docs.azk.io/en/reference/c
li/config.html#azk-config
Enter your email [optional]: 
```