### PR TITLE
[Package] Fixing Homebrew formula generated by 'pack.sh'

### DIFF
--- a/src/libexec/package-tools/mac/generate.sh
+++ b/src/libexec/package-tools/mac/generate.sh
@@ -48,15 +48,36 @@ class ${CLASS_NAME} < Formula
   url "http://${MAC_BUCKET_URL}/mac/azk_${VERSION}.tar.gz"
   version "${VERSION}"
   sha256 "${SHA256}"
+  head "https://github.com/azukiapp/azk.git"
   ${CONFLICTS}
   depends_on :macos => :mountain_lion
   depends_on :arch => :x86_64
 
   def install
-    prefix.install Dir['*']
-    prefix.install Dir['.nvmrc']
-    prefix.install Dir['.dependencies']
-    prefix.install Dir['.package-envs']
+    items_path = '.'
+    if build.head?
+      ENV.deparallelize
+      ENV['HOMEBREW_TEMP'] = buildpath
+      system 'make', '-e', 'package_mac'
+
+      items_path = 'package/brew/*/usr/lib/azk'
+      items = %w{ bin lib node_modules shared package.json npm-shrinkwrap.json CHANGELOG.md LICENSE README.md }
+    else
+      items = ['*']
+    end
+    items += %w{ .dependencies .nvmrc .package-envs }
+
+    items.each do |item|
+      prefix.install Dir["#{items_path}/#{item}"]
+    end
+  end
+
+  def post_install
+    rmtree './package' if build.head?
+  end
+
+  test do
+    system "azk", "version"
   end
 end
 


### PR DESCRIPTION
Since the `--HEAD` argument [was added](https://github.com/azukiapp/homebrew-azk/pull/8) into [`homebrew-azk`](https://github.com/azukiapp/homebrew-azk), it's needed to update the packaging scripts in order to generate a proper formula supporting this parameter.

This PR intends to do this fix.