### PR TITLE
[Cli] Removing colored output from 'azk version --full' command (VM IP address)

### DIFF
--- a/src/cmds/version.js
+++ b/src/cmds/version.js
@@ -63,8 +63,8 @@ export default class Version extends CliTrackerController {
       };
 
       if (require_vm && agent.agent) {
-        var ip = config('agent:vm:ip');
-        data.use_vm = data.use_vm + ', ip: ' + this.ui.c.yellow(ip);
+        let ip = config('agent:vm:ip');
+        data.use_vm = `${data.use_vm}, IP: ${ip}`;
       }
 
       // Show doctor info


### PR DESCRIPTION
This PR is a minor improvement for #653 , removing colored output from VM IP address.