### PR TITLE
[Core] Fixing many bugs in expand envs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Bug
   * [Core] Fixing regex bug in expand envs (not expand numbers: `$1` or `${2}`);
+  * [Core] Adding image envs in expand envs variable process;
 
 ## v0.18.0 - (2016-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Bug
   * [Core] Fixing regex bug in expand envs (not expand numbers: `$1` or `${2}`);
   * [Core] Adding image envs in expand envs variable process;
+  * [Core] Adding support to escape variables in command options (shell and system);
 
 ## v0.18.0 - (2016-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+
+* Bug
+  * [Core] Fixing regex bug in expand envs (not expand numbers: `$1` or `${2}`);
+
 ## v0.18.0 - (2016-04-07)
 
 * Enhancements

--- a/docs/content/pt-BR/reference/azkfilejs/expandable_properties.md
+++ b/docs/content/pt-BR/reference/azkfilejs/expandable_properties.md
@@ -319,3 +319,23 @@ systems({
   },
 });
 ```
+
+Caso seja necessário é possível escapar uma variável para que ela não seja expandida:
+
+```js
+systems({
+  web: {
+    image: { docker: "azukiapp/ruby" },
+    command: ["bundle", "exec", "rails", "-p", "\\$HTTP_PORT"],
+    envs: {
+      HTTP_PORT: "8080",
+    },
+  },
+});
+```
+
+O mesmo se aplica para o comando [shell][../cli/shell.md]:
+
+```sh
+$ azk shell web -c `echo \$PATH`
+```

--- a/spec/utils/shell_spec.js
+++ b/spec/utils/shell_spec.js
@@ -1,0 +1,72 @@
+import h from 'spec/spec_helper';
+import { lazy_require } from 'azk';
+
+var lazy = lazy_require({
+  replaceEnvs : ['azk/utils/shell'],
+});
+
+describe("Azk utils/shell module", function() {
+  describe("call replaceEnvs", function() {
+    it("should expand env in a string", function() {
+      var result;
+
+      result = lazy.replaceEnvs("${PATH}");
+      h.expect(result).to.equal("PATH");
+
+      result = lazy.replaceEnvs("${PATH} AZK_ID");
+      h.expect(result).to.equal("PATH AZK_ID");
+
+      result = lazy.replaceEnvs("${PATH} $AZK_ID");
+      h.expect(result).to.equal("PATH AZK_ID");
+
+      result = lazy.replaceEnvs('foo \\\\${BAR}');
+      h.expect(result).to.equal('foo \\\\BAR');
+    });
+
+    it("should support replace_for", function() {
+      var result = lazy.replaceEnvs("foo: ${BAR}", "${env.$1}");
+      h.expect(result).to.equal("foo: ${env.BAR}");
+    });
+
+    it("should not replace if not have a var", function() {
+      var result = lazy.replaceEnvs("foo bar");
+      h.expect(result).to.equal("foo bar");
+    });
+
+    it("should ignore special", function() {
+      var result;
+
+      result = lazy.replaceEnvs("${1} $AZK_ID");
+      h.expect(result).to.equal("${1} AZK_ID");
+
+      result = lazy.replaceEnvs("${@} $AZK_ID");
+      h.expect(result).to.equal("${@} AZK_ID");
+
+      result = lazy.replaceEnvs("$? $AZK_ID");
+      h.expect(result).to.equal("$? AZK_ID");
+    });
+
+    it("should support escaped vars with slash", function() {
+      var result;
+
+      result = lazy.replaceEnvs('foo \\${BAR}');
+      h.expect(result).to.equal('foo ${BAR}');
+
+      result = lazy.replaceEnvs('foo \\ ${BAR}');
+      h.expect(result).to.equal('foo \\ BAR');
+
+      result = lazy.replaceEnvs('foo \\\\\\${BAR}');
+      h.expect(result).to.equal('foo \\\\${BAR}');
+
+      result = lazy.replaceEnvs('foo \\$BAR ${FOO}');
+      h.expect(result).to.equal('foo $BAR FOO');
+    });
+
+    it("should support escaped in json", function() {
+      var result;
+
+      result = lazy.replaceEnvs(JSON.stringify('foo \\${BAR}'), "$1", true);
+      h.expect(JSON.parse(result)).to.equal('foo ${BAR}');
+    });
+  });
+});

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -14,8 +14,8 @@ var regex_port = new XRegExp(
   "(?<public>[0-9]{1,})(:(?<private>[0-9]{1,})){0,1}(/(?<protocol>tcp|udp)){0,1}", "x"
 );
 
-// https://regex101.com/r/rK1eJ0/2
-var regex_envs = /(?:\${[=|-]?([A-Z|\d|_]+)})|(?:\$[=|-]?([A-Z|\d|_]+))/g;
+// https://regex101.com/r/rK1eJ0/3
+var regex_envs = /(?:\${[=|-]?([A-Z0-9_]*[A-Z_]+[A-Z0-9_]*)})|(?:\$[=|-]?([A-Z0-9_]*[A-Z_]+[A-Z0-9_]*))/g;
 
 export class System {
   constructor(manifest, name, image, options = {}) {

--- a/src/system/index.js
+++ b/src/system/index.js
@@ -377,7 +377,7 @@ export class System {
   }
 
   // Private methods
-  _make_options(daemon, options = {}) {
+  _make_options(daemon, options = {}, image_conf = {}) {
     // Default values
     options = _.defaults(options, {
       workdir: this.options.workdir,
@@ -391,8 +391,14 @@ export class System {
       dns_servers: this.options.dns_servers,
     });
 
+    var img_envs = {};
+    _.forEach(image_conf.Env, (env_data) => {
+      env_data = env_data.split("=");
+      img_envs[env_data[0]] = env_data[1];
+    });
+
     // Map ports to docker configs: ports and envs
-    var envs  = _.merge({}, this.envs, this._envs_from_file(), options.envs);
+    var envs  = _.merge({}, img_envs, this.envs, this._envs_from_file(), options.envs);
     var ports = {};
     var parsed_ports = this._parse_ports(options.ports);
 

--- a/src/utils/shell.js
+++ b/src/utils/shell.js
@@ -1,0 +1,15 @@
+// https://regex101.com/r/rK1eJ0/6
+var regex_envs = /(\\*)(\$(?:(?:[=|-]?([A-Z0-9_]*[A-Z_]+[A-Z0-9_]*)|(?:{[=|-]?([A-Z0-9_]*[A-Z_]+[A-Z0-9_]*)}))))/g;
+
+export function replaceEnvs(str, replace_for = "$1", json = false) {
+  return str.replace(regex_envs, (_match, slashes, v1, v2, v3) => {
+    var slashes_size = slashes.length / (json ? 2 : 1);
+    if (slashes_size % 2 === 0) {
+      return `${slashes}${replace_for.replace("$1", v2 || v3)}`;
+    } else if (slashes_size) {
+      return `${slashes.slice(0, slashes.length - (json ? 2 : 1))}${v1}`;
+    } else {
+      return _match;
+    }
+  });
+}


### PR DESCRIPTION
- Closes #665;
- Fixes support special variables, like `${@}` and `${?}`;
- Adding image envs in expand options;
- Adding support escaped variables with `\`, like `echo \$PATH`; 