### PR TITLE
Adding mysql root password

### DIFF
--- a/src/generator/suggestions/mysql-5.6.js
+++ b/src/generator/suggestions/mysql-5.6.js
@@ -32,6 +32,7 @@ export class Suggestion extends DefaultSuggestion {
         MYSQL_USER    : "azk",
         MYSQL_PASSWORD: "azk",
         MYSQL_DATABASE: "#{manifest.dir}_development",
+        MYSQL_ROOT_PASSWORD: "azk",
       },
       export_envs_comment: [
         'check this gist to configure your database',


### PR DESCRIPTION
After `azk init` the mysql service does not started because this env is missing.
