### PR TITLE
Make various hipache parameters user configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Suggestions] Refactoring court to support more suggestion for one evidence;
   * [Suggestions] Adding support wordpress;
   * [Core] Support images of other repositories beyond Docker Hub;
-  * [Core] Support for tweaking Load Balancer settings via environment (`AZK_BALANCER_{WORKERS,WORKER_MAX_SOCKETS,TCP_TIMEOUT,DEAD_BACKEND_TTL}`);
   * [Sync] Adding support special characters in sync paths;
   * [Sync] Updating `chokidar` lib (file watching), for a better performance and bug fixes;
   * [Sync] Refactoring the sync system to sync the file tree from the modified file, not the whole tree;
@@ -27,6 +26,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Sync] Improving fault tolerance for the sync process;
   * [Sync] Removing a synced folder shouldn't break the agent nor the sync process;
   * [Package] Adding `ubuntu 16.04` support;
+  * [Balancer] Support for tweaking Load Balancer settings via environment (`AZK_BALANCER_{WORKERS,WORKER_MAX_SOCKETS,TCP_TIMEOUT,DEAD_BACKEND_TTL}`);
 
 ## v0.18.0 - (2016-04-07)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   * [Suggestions] Refactoring court to support more suggestion for one evidence;
   * [Suggestions] Adding support wordpress;
   * [Core] Support images of other repositories beyond Docker Hub;
+  * [Core] Support for tweaking Load Balancer settings via environment (`AZK_BALANCER_{WORKERS,WORKER_MAX_SOCKETS,TCP_TIMEOUT,DEAD_BACKEND_TTL}`);
   * [Sync] Adding support special characters in sync paths;
   * [Sync] Updating `chokidar` lib (file watching), for a better performance and bug fixes;
   * [Sync] Refactoring the sync system to sync the file tree from the modified file, not the whole tree;

--- a/src/agent/balancer.js
+++ b/src/agent/balancer.js
@@ -337,9 +337,10 @@ var Balancer = {
       user: process.getuid(),
       server: {
         accessLog: log,
-        workers: 3,
-        maxSockets: 100,
-        deadBackendTTL: 30
+        workers:        config('agent:balancer:workers'),
+        maxSockets:     config('agent:balancer:worker_max_sockets'),
+        tcpTimeout:     config('agent:balancer:tcp_timeout'),
+        deadBackendTTL: config('agent:balancer:dead_backend_ttl'),
       },
       http: { port, bind },
       driver: ["memcached://" + memcached_socket]

--- a/src/config.js
+++ b/src/config.js
@@ -130,6 +130,10 @@ var options = mergeConfig({
         ip  : new Dynamic("agent:balancer:ip"),
         host: envs('AZK_BALANCER_HOST'),
         port: envs('AZK_BALANCER_PORT', 80),
+        workers:            envs('AZK_BALANCER_WORKERS', 3),
+        worker_max_sockets: envs('AZK_BALANCER_WORKER_MAX_SOCKETS', 100),
+        tcp_timeout:        envs('AZK_BALANCER_TCP_TIMEOUT', 63), // weird enough default that it can be greped easily
+        dead_backend_ttl:   envs('AZK_BALANCER_DEAD_BACKEND_TTL', 30),
         file_dns: "/etc/resolver/" + envs('AZK_BALANCER_HOST'),
       },
       dns: {


### PR DESCRIPTION
We now enable tweaking of various hipache config options via following
environment varables:

    AZK_BALANCER_WORKERS
    AZK_BALANCER_WORKER_MAX_SOCKETS
    AZK_BALANCER_TCP_TIMEOUT
    AZK_BALANCER_DEAD_BACKEND_TTL

Also increase tcpTimeout to 63 (from 30). 63 is a weird enough number
that it should tip of anyone who needs a bigger timeout to search for it
and thus easily discover how to increase.

To test this, start the agent with any/all of the above options and corresponding hipache settings should be visible in `~/.azk/data/run/hipache.json`. Some, like `workers` can also be seen to take effect by just looking at number of hipache processes running.
