### PR TITLE
Fix resizing terminal window width not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## dev
+* Bug
+  * [Cmds] Fix resizing terminal window in `azk shell` didn't send new width to container 
+
+
 ## v0.19.0 - (2016-09-28)
 
 * Bug

--- a/src/docker/run.js
+++ b/src/docker/run.js
@@ -7,7 +7,7 @@ function new_resize(container) {
   return function() {
     var dimensions = {
       h: process.stdout.rows,
-      w: process.stderr.columns
+      w: process.stdout.columns
     };
 
     if (dimensions.h !== 0 && dimensions.w !== 0) {


### PR DESCRIPTION
In `azk shell -t`, when resizing window only the height was being updated.
You can test the fix by running `stty -a` in shell and seeing that column/row counts are updated.
