### PR TITLE
[Docs] Fixing files ownership after creating them from inside a container on Linux

### DIFF
--- a/docs/content/en/starting-from-scratch/nodejs.md
+++ b/docs/content/en/starting-from-scratch/nodejs.md
@@ -14,6 +14,12 @@ $ azk shell --image azukiapp/node --shell /bin/bash
 # exit
 ```
 
+> Note: If you're on Linux, you have to fix the ownership of the resulting folder. This is because the container run as root user, so that all created files and folder own to the root user. To do this fix, just run:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` .
+```
+
 ### Creating the Azkfile.js
 
 ```sh

--- a/docs/content/en/starting-from-scratch/php-cakephp.md
+++ b/docs/content/en/starting-from-scratch/php-cakephp.md
@@ -4,8 +4,14 @@
 
 ```sh
 $ azk shell --image azukiapp/php-fpm --shell /bin/bash
-# composer create-project cakephp/app my-cake-php --prefer-dist
+# composer create-project cakephp/app <my-app> --prefer-dist
 # exit
+```
+
+> Note: If you're on Linux, you have to fix the ownership of the resulting folder. This is because the container run as root user, so that all created files and folder own to the root user. To do this fix, just run:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` <my-app>
 ```
 
 ### Creating the Azkfile.js

--- a/docs/content/en/starting-from-scratch/php-laravel.md
+++ b/docs/content/en/starting-from-scratch/php-laravel.md
@@ -4,8 +4,14 @@
 
 ```sh
 $ azk shell --image azukiapp/php-fpm --shell /bin/bash
-# composer create-project laravel/laravel my-app --prefer-dist
+# composer create-project laravel/laravel <my-app> --prefer-dist
 # exit
+```
+
+> Note: If you're on Linux, you have to fix the ownership of the resulting folder. This is because the container run as root user, so that all created files and folder own to the root user. To do this fix, just run:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` <my-app>
 ```
 
 ### Creating the Azkfile.js

--- a/docs/content/en/starting-from-scratch/python-django.md
+++ b/docs/content/en/starting-from-scratch/python-django.md
@@ -9,6 +9,12 @@ $ azk shell --image azukiapp/python --shell /bin/bash
 # exit
 ```
 
+> Note: If you're on Linux, you have to fix the ownership of the resulting folder. This is because the container run as root user, so that all created files and folder own to the root user. To do this fix, just run:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` <my-app>
+```
+
 ### Creating the Azkfile.js
 
 ```sh

--- a/docs/content/en/starting-from-scratch/ruby-rails.md
+++ b/docs/content/en/starting-from-scratch/ruby-rails.md
@@ -9,6 +9,12 @@ $ azk shell --image azukiapp/ruby --shell /bin/bash
 # exit
 ```
 
+> Note: If you're on Linux, you have to fix the ownership of the resulting folder. This is because the container run as root user, so that all created files and folder own to the root user. To do this fix, just run:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` <my-app>
+```
+
 ### Creating the Azkfile.js
 
 ```sh

--- a/docs/content/pt-BR/starting-from-scratch/nodejs.md
+++ b/docs/content/pt-BR/starting-from-scratch/nodejs.md
@@ -14,6 +14,12 @@ $ azk shell --image azukiapp/node --shell /bin/bash
 # exit
 ```
 
+> Nota: Se você estiver usando Linux, você terá que transferir a propriedade da pasta gerada para seu usuário. Isso acontece pois o container é executado como usuário root, portanto todos os arquivos e pastas gerados dentro do container pertencem ao usuário root. Para fazer esta correção, basta executar:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` .
+```
+
 ### Gerando o Azkfile.js
 
 ```sh

--- a/docs/content/pt-BR/starting-from-scratch/php-cakephp.md
+++ b/docs/content/pt-BR/starting-from-scratch/php-cakephp.md
@@ -4,8 +4,14 @@
 
 ```sh
 $ azk shell --image azukiapp/php-fpm --shell /bin/bash
-# composer create-project cakephp/app my-app --prefer-dist
+# composer create-project cakephp/app <my-app> --prefer-dist
 # exit
+```
+
+> Nota: Se você estiver usando Linux, você terá que transferir a propriedade da pasta gerada para seu usuário. Isso acontece pois o container é executado como usuário root, portanto todos os arquivos e pastas gerados dentro do container pertencem ao usuário root. Para fazer esta correção, basta executar:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` <my-app>
 ```
 
 ### Gerando o Azkfile.js

--- a/docs/content/pt-BR/starting-from-scratch/php-laravel.md
+++ b/docs/content/pt-BR/starting-from-scratch/php-laravel.md
@@ -4,9 +4,16 @@
 
 ```sh
 $ azk shell --image azukiapp/php-fpm --shell /bin/bash
-# composer create-project laravel/laravel my-app --prefer-dist
+# composer create-project laravel/laravel <my-app> --prefer-dist
 # exit
 ```
+
+> Nota: Se você estiver usando Linux, você terá que transferir a propriedade da pasta gerada para seu usuário. Isso acontece pois o container é executado como usuário root, portanto todos os arquivos e pastas gerados dentro do container pertencem ao usuário root. Para fazer esta correção, basta executar:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` <my-app>
+```
+
 
 ### Gerando o Azkfile.js
 

--- a/docs/content/pt-BR/starting-from-scratch/python-django.md
+++ b/docs/content/pt-BR/starting-from-scratch/python-django.md
@@ -9,6 +9,12 @@ $ azk shell --image azukiapp/python --shell /bin/bash
 # exit
 ```
 
+> Nota: Se você estiver usando Linux, você terá que transferir a propriedade da pasta gerada para seu usuário. Isso acontece pois o container é executado como usuário root, portanto todos os arquivos e pastas gerados dentro do container pertencem ao usuário root. Para fazer esta correção, basta executar:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` <my-app>
+```
+
 ### Gerando o Azkfile.js
 
 ```sh

--- a/docs/content/pt-BR/starting-from-scratch/ruby-rails.md
+++ b/docs/content/pt-BR/starting-from-scratch/ruby-rails.md
@@ -9,6 +9,12 @@ $ azk shell --image azukiapp/ruby --shell /bin/bash
 # exit
 ```
 
+> Nota: Se você estiver usando Linux, você terá que transferir a propriedade da pasta gerada para seu usuário. Isso acontece pois o container é executado como usuário root, portanto todos os arquivos e pastas gerados dentro do container pertencem ao usuário root. Para fazer esta correção, basta executar:
+
+```sh
+$ sudo chown -R `id -un`:`id -gn` <my-app>
+```
+
 ### Gerando o Azkfile.js
 
 ```sh


### PR DESCRIPTION
This PR is a fix for an issue raised by @chiaretto on azk's docs.

After creating a new Rails/PHP project from inside a container on Linux, the ownership of the resulting folder must be fixed (since the resulting files and folders belong to root) and those instructions were missing in the current docs.